### PR TITLE
Implement observatory — event logging + activity trail

### DIFF
--- a/packages/core/__tests__/observatory.test.ts
+++ b/packages/core/__tests__/observatory.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import type { DatabaseProvider } from '@shackleai/db'
+import { Observatory } from '../src/observatory.js'
+
+let db: PGliteProvider
+let observatory: Observatory
+
+// Helper: seed a company so FK constraints pass
+const COMPANY_ID = '00000000-0000-4000-a000-000000000001'
+
+async function seedCompany(provider: DatabaseProvider): Promise<void> {
+  await provider.query(
+    `INSERT INTO companies (id, name, status, issue_prefix, issue_counter, budget_monthly_cents, spent_monthly_cents)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [COMPANY_ID, 'Test Co', 'active', 'TST', 0, 10000, 0],
+  )
+}
+
+// Helper: wait for fire-and-forget inserts to flush
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 100))
+}
+
+beforeAll(async () => {
+  db = new PGliteProvider() // in-memory
+  await runMigrations(db)
+  await seedCompany(db)
+  observatory = new Observatory(db)
+})
+
+afterAll(async () => {
+  await db.close()
+})
+
+describe('Observatory', () => {
+  describe('logEvent', () => {
+    it('inserts a record into activity_log', async () => {
+      observatory.logEvent({
+        company_id: COMPANY_ID,
+        entity_type: 'agent',
+        entity_id: '00000000-0000-4000-a000-000000000010',
+        actor_type: 'system',
+        actor_id: 'scheduler',
+        action: 'agent.started',
+        changes: { status: 'running' },
+      })
+
+      await flush()
+
+      const result = await db.query<{ action: string }>(
+        'SELECT action FROM activity_log WHERE action = $1',
+        ['agent.started'],
+      )
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.action).toBe('agent.started')
+    })
+
+    it('never throws even with invalid data', async () => {
+      // Passing a bad company_id that violates FK constraint
+      expect(() => {
+        observatory.logEvent({
+          company_id: '00000000-0000-4000-a000-999999999999',
+          entity_type: 'agent',
+          actor_type: 'system',
+          action: 'should.fail.silently',
+        })
+      }).not.toThrow()
+
+      // Wait for the async error to be caught silently
+      await flush()
+    })
+
+    it('never throws when db provider itself throws', async () => {
+      const brokenDb: DatabaseProvider = {
+        query: () => Promise.reject(new Error('db is down')),
+        exec: () => Promise.reject(new Error('db is down')),
+        close: () => Promise.resolve(),
+      }
+
+      const brokenObservatory = new Observatory(brokenDb)
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      expect(() => {
+        brokenObservatory.logEvent({
+          company_id: COMPANY_ID,
+          entity_type: 'test',
+          actor_type: 'system',
+          action: 'broken.event',
+        })
+      }).not.toThrow()
+
+      await flush()
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[Observatory] logEvent failed:',
+        expect.any(Error),
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('logActivity', () => {
+    it('inserts immutable activity records', async () => {
+      observatory.logActivity({
+        company_id: COMPANY_ID,
+        entity_type: 'issue',
+        entity_id: null,
+        actor_type: 'user',
+        actor_id: 'user-42',
+        action: 'issue.created',
+        changes: { title: 'New issue' },
+      })
+
+      await flush()
+
+      const result = await db.query<{ action: string; actor_id: string }>(
+        'SELECT action, actor_id FROM activity_log WHERE action = $1',
+        ['issue.created'],
+      )
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.actor_id).toBe('user-42')
+    })
+  })
+
+  describe('getEvents', () => {
+    it('returns events filtered by entity type', async () => {
+      // Insert a few events with different entity types
+      observatory.logEvent({
+        company_id: COMPANY_ID,
+        entity_type: 'project',
+        actor_type: 'system',
+        action: 'project.created',
+      })
+      observatory.logEvent({
+        company_id: COMPANY_ID,
+        entity_type: 'project',
+        actor_type: 'system',
+        action: 'project.updated',
+      })
+      observatory.logEvent({
+        company_id: COMPANY_ID,
+        entity_type: 'goal',
+        actor_type: 'system',
+        action: 'goal.created',
+      })
+
+      await flush()
+
+      const events = await observatory.getEvents(COMPANY_ID, {
+        entityType: 'project',
+      })
+      expect(events.length).toBeGreaterThanOrEqual(2)
+      expect(events.every((e) => e.entity_type === 'project')).toBe(true)
+    })
+
+    it('returns events filtered by date range', async () => {
+      const now = new Date()
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+      const oneHourLater = new Date(now.getTime() + 60 * 60 * 1000)
+
+      const events = await observatory.getEvents(COMPANY_ID, {
+        startDate: oneHourAgo,
+        endDate: oneHourLater,
+      })
+
+      // Should include all events we inserted (they were just created)
+      expect(events.length).toBeGreaterThan(0)
+    })
+
+    it('returns empty array for unknown company', async () => {
+      const events = await observatory.getEvents(
+        '00000000-0000-4000-a000-000000000099',
+      )
+      expect(events).toEqual([])
+    })
+
+    it('respects limit parameter', async () => {
+      const events = await observatory.getEvents(COMPANY_ID, { limit: 2 })
+      expect(events.length).toBeLessThanOrEqual(2)
+    })
+  })
+
+  describe('getActivity', () => {
+    it('returns activity filtered by actor type', async () => {
+      const activity = await observatory.getActivity(COMPANY_ID, {
+        actorType: 'user',
+      })
+      expect(activity.length).toBeGreaterThanOrEqual(1)
+      expect(activity.every((a) => a.actor_type === 'user')).toBe(true)
+    })
+
+    it('returns activity filtered by action', async () => {
+      const activity = await observatory.getActivity(COMPANY_ID, {
+        action: 'agent.started',
+      })
+      expect(activity.length).toBeGreaterThanOrEqual(1)
+      expect(activity.every((a) => a.action === 'agent.started')).toBe(true)
+    })
+
+    it('returns activity filtered by actor_id', async () => {
+      const activity = await observatory.getActivity(COMPANY_ID, {
+        actorId: 'user-42',
+      })
+      expect(activity.length).toBeGreaterThanOrEqual(1)
+      expect(activity.every((a) => a.actor_id === 'user-42')).toBe(true)
+    })
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,11 @@
     "build": "tsc --build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
-  "files": ["dist"]
+  "files": ["dist"],
+  "dependencies": {
+    "@shackleai/db": "workspace:*",
+    "@shackleai/shared": "workspace:*"
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,10 @@
  * @shackleai/core — Core orchestration engine
  */
 export const VERSION = '0.0.0'
+
+export { Observatory } from './observatory.js'
+export type {
+  LogEventInput,
+  EventFilters,
+  ActivityFilters,
+} from './observatory.js'

--- a/packages/core/src/observatory.ts
+++ b/packages/core/src/observatory.ts
@@ -1,0 +1,207 @@
+/**
+ * Observatory — fire-and-forget event logging and immutable activity trail.
+ *
+ * Design principles:
+ * - logEvent / logActivity NEVER throw — errors are silently caught (console.error at most).
+ * - logEvent / logActivity NEVER block the caller — they return void, not a Promise.
+ * - getEvents / getActivity return queried data with optional filters.
+ * - All queries are parameterized — no string concatenation.
+ * - All queries are scoped to company_id (multi-tenant).
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+import type { ActivityLogEntry } from '@shackleai/shared'
+
+export interface LogEventInput {
+  company_id: string
+  entity_type: string
+  entity_id?: string
+  actor_type: string
+  actor_id?: string
+  action: string
+  changes?: Record<string, unknown>
+}
+
+export interface EventFilters {
+  entityType?: string
+  entityId?: string
+  startDate?: Date
+  endDate?: Date
+  limit?: number
+}
+
+export interface ActivityFilters {
+  actorType?: string
+  actorId?: string
+  action?: string
+  startDate?: Date
+  endDate?: Date
+  limit?: number
+}
+
+export class Observatory {
+  private db: DatabaseProvider
+
+  constructor(db: DatabaseProvider) {
+    this.db = db
+  }
+
+  /**
+   * Log an event to activity_log. Fire-and-forget — never throws, never blocks.
+   */
+  logEvent(event: LogEventInput): void {
+    this.insertEvent(event).catch((err: unknown) => {
+      console.error('[Observatory] logEvent failed:', err)
+    })
+  }
+
+  /**
+   * Log an activity entry. Fire-and-forget — never throws, never blocks.
+   * Immutable: activity_log has no UPDATE/DELETE operations.
+   */
+  logActivity(entry: Omit<ActivityLogEntry, 'id' | 'created_at'>): void {
+    this.insertActivity(entry).catch((err: unknown) => {
+      console.error('[Observatory] logActivity failed:', err)
+    })
+  }
+
+  /**
+   * Query events from activity_log with optional filters, scoped to a company.
+   */
+  async getEvents(
+    companyId: string,
+    filters?: EventFilters,
+  ): Promise<ActivityLogEntry[]> {
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let idx = 2
+
+    if (filters?.entityType) {
+      conditions.push(`entity_type = $${idx}`)
+      params.push(filters.entityType)
+      idx++
+    }
+
+    if (filters?.entityId) {
+      conditions.push(`entity_id = $${idx}`)
+      params.push(filters.entityId)
+      idx++
+    }
+
+    if (filters?.startDate) {
+      conditions.push(`created_at >= $${idx}`)
+      params.push(filters.startDate.toISOString())
+      idx++
+    }
+
+    if (filters?.endDate) {
+      conditions.push(`created_at <= $${idx}`)
+      params.push(filters.endDate.toISOString())
+      idx++
+    }
+
+    const limit = filters?.limit ?? 100
+    const sql = `
+      SELECT id, company_id, entity_type, entity_id, actor_type, actor_id, action, changes, created_at
+      FROM activity_log
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY created_at DESC
+      LIMIT $${idx}
+    `
+    params.push(limit)
+
+    const result = await this.db.query<ActivityLogEntry>(sql, params)
+    return result.rows
+  }
+
+  /**
+   * Query activity from activity_log with actor-oriented filters, scoped to a company.
+   */
+  async getActivity(
+    companyId: string,
+    filters?: ActivityFilters,
+  ): Promise<ActivityLogEntry[]> {
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let idx = 2
+
+    if (filters?.actorType) {
+      conditions.push(`actor_type = $${idx}`)
+      params.push(filters.actorType)
+      idx++
+    }
+
+    if (filters?.actorId) {
+      conditions.push(`actor_id = $${idx}`)
+      params.push(filters.actorId)
+      idx++
+    }
+
+    if (filters?.action) {
+      conditions.push(`action = $${idx}`)
+      params.push(filters.action)
+      idx++
+    }
+
+    if (filters?.startDate) {
+      conditions.push(`created_at >= $${idx}`)
+      params.push(filters.startDate.toISOString())
+      idx++
+    }
+
+    if (filters?.endDate) {
+      conditions.push(`created_at <= $${idx}`)
+      params.push(filters.endDate.toISOString())
+      idx++
+    }
+
+    const limit = filters?.limit ?? 100
+    const sql = `
+      SELECT id, company_id, entity_type, entity_id, actor_type, actor_id, action, changes, created_at
+      FROM activity_log
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY created_at DESC
+      LIMIT $${idx}
+    `
+    params.push(limit)
+
+    const result = await this.db.query<ActivityLogEntry>(sql, params)
+    return result.rows
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────
+
+  private async insertEvent(event: LogEventInput): Promise<void> {
+    await this.db.query(
+      `INSERT INTO activity_log (company_id, entity_type, entity_id, actor_type, actor_id, action, changes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        event.company_id,
+        event.entity_type,
+        event.entity_id ?? null,
+        event.actor_type,
+        event.actor_id ?? null,
+        event.action,
+        event.changes ? JSON.stringify(event.changes) : null,
+      ],
+    )
+  }
+
+  private async insertActivity(
+    entry: Omit<ActivityLogEntry, 'id' | 'created_at'>,
+  ): Promise<void> {
+    await this.db.query(
+      `INSERT INTO activity_log (company_id, entity_type, entity_id, actor_type, actor_id, action, changes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        entry.company_id,
+        entry.entity_type,
+        entry.entity_id ?? null,
+        entry.actor_type,
+        entry.actor_id ?? null,
+        entry.action,
+        entry.changes ? JSON.stringify(entry.changes) : null,
+      ],
+    )
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,9 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../db" },
+    { "path": "../shared" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,14 @@ importers:
 
   apps/dashboard: {}
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      '@shackleai/db':
+        specifier: workspace:*
+        version: link:../db
+      '@shackleai/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/db:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `Observatory` class to `@shackleai/core` with fire-and-forget audit logging
- `logEvent()` and `logActivity()` insert into `activity_log` — never throw, never block the caller
- `getEvents()` and `getActivity()` query with parameterized SQL, multi-tenant scoping, and optional filters (entity type, actor, date range, limit)
- Adds `@shackleai/db` and `@shackleai/shared` as workspace dependencies to core package
- Adds TypeScript project references to core tsconfig for cross-package resolution

## Test plan
- [x] logEvent inserts a record into activity_log
- [x] logEvent never throws with invalid data (FK violation)
- [x] logEvent never throws when db provider itself errors
- [x] logActivity inserts immutable records
- [x] getEvents filters by entity type
- [x] getEvents filters by date range
- [x] getEvents returns empty array for unknown company
- [x] getEvents respects limit parameter
- [x] getActivity filters by actor type
- [x] getActivity filters by action
- [x] getActivity filters by actor_id
- All 11 tests pass against in-memory PGlite with full migration suite

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)