### PR TITLE
Add OpenClaw + CrewAI adapter types

### DIFF
--- a/packages/core/src/governance/engine.ts
+++ b/packages/core/src/governance/engine.ts
@@ -44,7 +44,6 @@ export class GovernanceEngine {
     companyId: string,
     agentId: string,
     toolName: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _params?: Record<string, unknown>,
   ): Promise<PolicyCheckResult> {
     // Fetch all policies for this company that apply to this agent

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -37,6 +37,8 @@ export const AdapterType = {
   Http: 'http',
   Claude: 'claude',
   Mcp: 'mcp',
+  OpenClaw: 'openclaw',
+  CrewAI: 'crewai',
 } as const
 export type AdapterType = (typeof AdapterType)[keyof typeof AdapterType]
 


### PR DESCRIPTION
## Summary
- Add `openclaw` and `crewai` to `AdapterType` constants in `@shackleai/shared`
- Remove stale eslint-disable directive in governance engine

Prerequisite for #40 and #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)