### PR TITLE
Phase 3D: Implement OpenClaw adapter

### DIFF
--- a/packages/core/__tests__/adapter-registry.test.ts
+++ b/packages/core/__tests__/adapter-registry.test.ts
@@ -65,7 +65,7 @@ describe('AdapterRegistry', () => {
     registry.register(mockAdapter)
 
     const all = registry.list()
-    expect(all).toHaveLength(2) // process + http
-    expect(all.map((a) => a.type).sort()).toEqual(['http', 'process'])
+    expect(all).toHaveLength(3) // process + openclaw + http
+    expect(all.map((a) => a.type).sort()).toEqual(['http', 'openclaw', 'process'])
   })
 })

--- a/packages/core/__tests__/openclaw-adapter.test.ts
+++ b/packages/core/__tests__/openclaw-adapter.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest'
+import { OpenClawAdapter } from '../src/adapters/openclaw.js'
+import type { AdapterContext } from '../src/adapters/adapter.js'
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+/** Create a temporary Python-like entrypoint that is actually a node script. */
+function createTempScript(name: string, content: string): string {
+  const dir = join(tmpdir(), 'shackleai-openclaw-tests')
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, name)
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+/**
+ * The OpenClawAdapter spawns `pythonPath entrypoint --task ... --session ...`.
+ * For testing, we override pythonPath to `node` and write JS scripts as
+ * entrypoints. The adapter does not care whether Python or Node runs the file.
+ */
+function makeCtx(overrides: Partial<AdapterContext> = {}): AdapterContext {
+  return {
+    agentId: 'agent-001',
+    companyId: 'company-001',
+    heartbeatRunId: 'run-001',
+    adapterConfig: {
+      pythonPath: 'node',
+      entrypoint: '', // must be set per test
+    },
+    env: {},
+    ...overrides,
+  }
+}
+
+describe('OpenClawAdapter', () => {
+  const adapter = new OpenClawAdapter()
+
+  it('has correct type and label', () => {
+    expect(adapter.type).toBe('openclaw')
+    expect(adapter.label).toBe('OpenClaw Agent')
+  })
+
+  it('returns error when entrypoint is missing from adapterConfig', async () => {
+    const ctx = makeCtx({ adapterConfig: { pythonPath: 'node' } })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('adapterConfig.entrypoint is required')
+  })
+
+  it('returns error when entrypoint file does not exist', async () => {
+    const ctx = makeCtx({
+      adapterConfig: {
+        pythonPath: 'node',
+        entrypoint: '/nonexistent/path/agent.py',
+      },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('Entrypoint not found')
+  })
+
+  it('spawns subprocess and captures stdout', async () => {
+    const script = createTempScript(
+      'simple-agent.js',
+      `process.stdout.write('hello from openclaw');`,
+    )
+
+    const ctx = makeCtx({
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('hello from openclaw')
+
+    unlinkSync(script)
+  })
+
+  it('injects SHACKLEAI_* env vars', async () => {
+    const script = createTempScript(
+      'env-agent.js',
+      `const e = process.env;
+process.stdout.write([
+  e.SHACKLEAI_RUN_ID,
+  e.SHACKLEAI_AGENT_ID,
+  e.SHACKLEAI_TASK_ID,
+  e.SHACKLEAI_API_URL,
+].join(','));`,
+    )
+
+    const ctx = makeCtx({
+      agentId: 'agent-env',
+      heartbeatRunId: 'run-env',
+      task: 'task-env',
+      env: { SHACKLEAI_API_URL: 'https://api.shackleai.com' },
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe(
+      'run-env,agent-env,task-env,https://api.shackleai.com',
+    )
+
+    unlinkSync(script)
+  })
+
+  it('passes task payload as --task JSON argument', async () => {
+    const script = createTempScript(
+      'task-agent.js',
+      `const idx = process.argv.indexOf('--task');
+const payload = JSON.parse(process.argv[idx + 1]);
+process.stdout.write(payload.agentId + ':' + payload.task);`,
+    )
+
+    const ctx = makeCtx({
+      agentId: 'agent-task',
+      task: 'analyze data',
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('agent-task:analyze data')
+
+    unlinkSync(script)
+  })
+
+  it('parses __shackleai_result__ block for token usage', async () => {
+    const resultJson = JSON.stringify({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        costCents: 0.5,
+        model: 'gpt-4',
+        provider: 'openai',
+      },
+    })
+    const script = createTempScript(
+      'usage-agent.js',
+      `process.stdout.write('some output\\n__shackleai_result__${resultJson}__shackleai_result__\\nmore output');`,
+    )
+
+    const ctx = makeCtx({
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.usage).toBeDefined()
+    expect(result.usage!.inputTokens).toBe(100)
+    expect(result.usage!.outputTokens).toBe(50)
+    expect(result.usage!.costCents).toBe(0.5)
+    expect(result.usage!.model).toBe('gpt-4')
+    expect(result.usage!.provider).toBe('openai')
+
+    unlinkSync(script)
+  })
+
+  it('parses session state from __shackleai_result__ block', async () => {
+    const resultJson = JSON.stringify({
+      session_id_after: 'session-xyz-123',
+    })
+    const script = createTempScript(
+      'session-agent.js',
+      `process.stdout.write('__shackleai_result__${resultJson}__shackleai_result__');`,
+    )
+
+    const ctx = makeCtx({
+      sessionState: 'session-previous',
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.sessionState).toBe('session-xyz-123')
+
+    unlinkSync(script)
+  })
+
+  it('passes session state through to subprocess', async () => {
+    const script = createTempScript(
+      'session-check.js',
+      `const idx = process.argv.indexOf('--session');
+process.stdout.write('session:' + process.argv[idx + 1]);`,
+    )
+
+    const ctx = makeCtx({
+      sessionState: 'prev-session-abc',
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('session:prev-session-abc')
+
+    unlinkSync(script)
+  })
+
+  it('enforces timeout and kills the process', async () => {
+    const script = createTempScript(
+      'slow-agent.js',
+      `setTimeout(() => {}, 60000);`,
+    )
+
+    const ctx = makeCtx({
+      adapterConfig: {
+        pythonPath: 'node',
+        entrypoint: script,
+        timeout: 1, // 1 second
+      },
+    })
+
+    const start = Date.now()
+    const result = await adapter.execute(ctx)
+    const elapsed = Date.now() - start
+
+    expect(result.exitCode).toBe(124)
+    expect(result.stderr).toContain('timeout')
+    // Should complete in roughly 1-12 seconds (timeout + 10s kill grace)
+    expect(elapsed).toBeLessThan(20_000)
+
+    unlinkSync(script)
+  }, 25_000)
+
+  it('truncates stdout at 10 MB limit', async () => {
+    // Generate >10MB of output. Write in a loop to exceed the limit.
+    const script = createTempScript(
+      'big-agent.js',
+      `const chunk = 'x'.repeat(1024 * 1024); // 1MB
+for (let i = 0; i < 12; i++) { process.stdout.write(chunk); }`,
+    )
+
+    const ctx = makeCtx({
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('[WARNING] stdout truncated')
+    // Actual stdout should be roughly 10MB, not 12MB
+    expect(result.stdout.length).toBeLessThanOrEqual(10 * 1024 * 1024 + 200)
+
+    unlinkSync(script)
+  }, 15_000)
+
+  it('returns non-zero exit code on failure', async () => {
+    const script = createTempScript(
+      'fail-agent.js',
+      `process.exit(42);`,
+    )
+
+    const ctx = makeCtx({
+      adapterConfig: { pythonPath: 'node', entrypoint: script },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(42)
+
+    unlinkSync(script)
+  })
+
+  it('returns exit code 127 when pythonPath command does not exist', async () => {
+    const script = createTempScript('dummy.js', '')
+
+    const ctx = makeCtx({
+      adapterConfig: {
+        pythonPath: 'shackleai_nonexistent_python_xyz',
+        entrypoint: script,
+      },
+    })
+    const result = await adapter.execute(ctx)
+
+    expect(result.exitCode).toBe(127)
+    expect(result.stderr).toContain('Failed to spawn OpenClaw process')
+
+    unlinkSync(script)
+  })
+
+  it('testEnvironment detects available runtime', async () => {
+    // testEnvironment checks for python3/python — we can't guarantee Python
+    // is installed, so we just verify it returns a valid shape
+    const result = await adapter.testEnvironment()
+    expect(typeof result.ok).toBe('boolean')
+    if (!result.ok) {
+      expect(typeof result.error).toBe('string')
+    }
+  })
+})

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -4,10 +4,12 @@
 
 export type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
 export { ProcessAdapter } from './process.js'
+export { OpenClawAdapter } from './openclaw.js'
 export { getLastSessionState, saveSessionState } from './session.js'
 
 import type { AdapterModule } from './adapter.js'
 import { ProcessAdapter } from './process.js'
+import { OpenClawAdapter } from './openclaw.js'
 
 /**
  * AdapterRegistry — maps adapter_type strings to AdapterModule instances.
@@ -20,6 +22,7 @@ export class AdapterRegistry {
 
   constructor() {
     this.register(new ProcessAdapter())
+    this.register(new OpenClawAdapter())
   }
 
   /** Register an adapter module. Overwrites any existing adapter with the same type. */

--- a/packages/core/src/adapters/openclaw.ts
+++ b/packages/core/src/adapters/openclaw.ts
@@ -1,0 +1,263 @@
+/**
+ * OpenClawAdapter — spawns a Python OpenClaw agent as a subprocess.
+ *
+ * Constructs a CLI invocation of a Python entrypoint with a JSON task payload,
+ * injects SHACKLEAI_* env vars, enforces a configurable timeout with graceful
+ * SIGTERM -> SIGKILL escalation, and parses structured output for token usage
+ * and session state.
+ *
+ * Cross-platform: on Windows, `python3` is typically just `python`.
+ */
+
+import { spawn } from 'node:child_process'
+import { access, constants } from 'node:fs/promises'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+
+/** Default timeout in milliseconds (300 seconds). */
+const DEFAULT_TIMEOUT_MS = 300_000
+
+/** Grace period between SIGTERM and SIGKILL in milliseconds. */
+const KILL_GRACE_MS = 10_000
+
+/** Maximum stdout buffer size in bytes (10 MB). */
+const MAX_STDOUT_BYTES = 10 * 1024 * 1024
+
+/** Marker for structured result JSON in stdout. */
+const RESULT_MARKER = '__shackleai_result__'
+
+interface ShackleAIResult {
+  session_id_after?: string | null
+  usage?: {
+    inputTokens: number
+    outputTokens: number
+    costCents: number
+    model: string
+    provider: string
+  }
+}
+
+/**
+ * Parse the `__shackleai_result__` JSON block from stdout.
+ * Expected format in stdout:
+ *   __shackleai_result__{"session_id_after":"...","usage":{...}}__shackleai_result__
+ */
+function parseResultBlock(stdout: string): ShackleAIResult | null {
+  const startIdx = stdout.indexOf(RESULT_MARKER)
+  if (startIdx === -1) return null
+
+  const jsonStart = startIdx + RESULT_MARKER.length
+  const endIdx = stdout.indexOf(RESULT_MARKER, jsonStart)
+  if (endIdx === -1) return null
+
+  const jsonStr = stdout.slice(jsonStart, endIdx).trim()
+  try {
+    return JSON.parse(jsonStr) as ShackleAIResult
+  } catch {
+    return null
+  }
+}
+
+export class OpenClawAdapter implements AdapterModule {
+  readonly type = 'openclaw'
+  readonly label = 'OpenClaw Agent'
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const entrypoint = ctx.adapterConfig.entrypoint as string | undefined
+    if (!entrypoint) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'adapterConfig.entrypoint is required for openclaw adapter',
+      }
+    }
+
+    // Validate entrypoint file exists before spawning
+    try {
+      await access(entrypoint, constants.R_OK)
+    } catch {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `Entrypoint not found or not readable: ${entrypoint}`,
+      }
+    }
+
+    const pythonPath = (ctx.adapterConfig.pythonPath as string) ?? 'python3'
+    const timeoutMs =
+      typeof ctx.adapterConfig.timeout === 'number'
+        ? ctx.adapterConfig.timeout * 1000
+        : DEFAULT_TIMEOUT_MS
+
+    // Build the JSON task payload
+    const taskPayload = JSON.stringify({
+      task: ctx.task ?? '',
+      agentId: ctx.agentId,
+      companyId: ctx.companyId,
+      heartbeatRunId: ctx.heartbeatRunId,
+      sessionState: ctx.sessionState ?? null,
+    })
+
+    const sessionId = ctx.sessionState ?? ctx.heartbeatRunId
+
+    const args = [entrypoint, '--task', taskPayload, '--session', sessionId]
+
+    // Build environment: inject SHACKLEAI_* vars
+    // Note: adapterConfig.envFile is supported for documentation purposes but
+    // env file parsing is not implemented — users should set env vars directly.
+    const env: Record<string, string> = {
+      ...process.env,
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+      SHACKLEAI_API_URL: (ctx.env.SHACKLEAI_API_URL as string) ?? '',
+    }
+
+    if (ctx.task) {
+      env.SHACKLEAI_TASK_ID = ctx.task
+    }
+
+    if (ctx.sessionState) {
+      env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    }
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let stdoutBytes = 0
+      let stdoutTruncated = false
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn(pythonPath, args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        if (stdoutTruncated) return
+        stdoutBytes += chunk.length
+        if (stdoutBytes > MAX_STDOUT_BYTES) {
+          stdoutTruncated = true
+          // Keep what we have, but stop accumulating
+          const overflow = stdoutBytes - MAX_STDOUT_BYTES
+          const trimmed = chunk.subarray(0, chunk.length - overflow)
+          if (trimmed.length > 0) {
+            stdoutChunks.push(trimmed)
+          }
+        } else {
+          stdoutChunks.push(chunk)
+        }
+      })
+
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        child.kill('SIGTERM')
+
+        killTimer = setTimeout(() => {
+          child.kill('SIGKILL')
+        }, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+
+        let stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+
+        if (stdoutTruncated) {
+          stdout += `\n[WARNING] stdout truncated at ${MAX_STDOUT_BYTES} bytes (10 MB limit)`
+        }
+
+        // Parse structured result block for usage and session state
+        const result = parseResultBlock(stdout)
+        const sessionState = result?.session_id_after ?? null
+        const usage = result?.usage ?? undefined
+
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed
+            ? `Process killed after ${timeoutMs}ms timeout\n${stderr}`
+            : stderr,
+          sessionState,
+          usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+
+        resolve({
+          exitCode: 127,
+          stdout: '',
+          stderr: `Failed to spawn OpenClaw process: ${err.message}`,
+        })
+      })
+    })
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    const pythonPath = process.platform === 'win32' ? 'python' : 'python3'
+
+    // Step 1: Check if Python is available
+    const pythonCheck = await this.spawnCheck(pythonPath, ['--version'])
+    if (!pythonCheck.ok) {
+      return {
+        ok: false,
+        error: `Python not found (tried '${pythonPath}'): ${pythonCheck.error}`,
+      }
+    }
+
+    // Step 2: Check if OpenClaw is installed
+    const openclawCheck = await this.spawnCheck(pythonPath, [
+      '-c',
+      'import openclaw; print(openclaw.__version__)',
+    ])
+    if (!openclawCheck.ok) {
+      return {
+        ok: false,
+        error: `OpenClaw not installed: ${openclawCheck.error}`,
+      }
+    }
+
+    return { ok: true }
+  }
+
+  private spawnCheck(
+    command: string,
+    args: string[],
+  ): Promise<{ ok: boolean; error?: string }> {
+    return new Promise((resolve) => {
+      const child = spawn(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      const stderrChunks: Buffer[] = []
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        resolve({ ok: false, error: 'Timed out checking environment' })
+      }, 10_000)
+
+      child.on('close', (code) => {
+        clearTimeout(timer)
+        if (code === 0) {
+          resolve({ ok: true })
+        } else {
+          const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim()
+          resolve({ ok: false, error: stderr || `Exit code ${code}` })
+        }
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timer)
+        resolve({ ok: false, error: err.message })
+      })
+    })
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,7 @@ export type {
   ActivityFilters,
 } from './observatory.js'
 
-export { AdapterRegistry, ProcessAdapter } from './adapters/index.js'
+export { AdapterRegistry, ProcessAdapter, OpenClawAdapter } from './adapters/index.js'
 export { getLastSessionState, saveSessionState } from './adapters/index.js'
 export type {
   AdapterContext,


### PR DESCRIPTION
## Summary
- **OpenClawAdapter**: spawns Python OpenClaw agents as subprocesses with `pythonPath entrypoint --task '{payload}' --session {sessionId}`
- Session state persistence across heartbeats via `__shackleai_result__` structured output parsing
- Token usage parsing (inputTokens, outputTokens, costCents, model, provider)
- Timeout enforcement with graceful SIGTERM -> 10s grace -> SIGKILL escalation
- 10MB stdout buffer limit with truncation warning
- `testEnvironment()` detects Python + OpenClaw installation
- Cross-platform support (Windows `python` vs Unix `python3`)
- Entrypoint validation via `fs.access` before spawning
- SHACKLEAI_* env var injection (RUN_ID, AGENT_ID, TASK_ID, API_URL)
- Registered in AdapterRegistry constructor alongside ProcessAdapter

## Test plan
- [x] Spawns subprocess with task payload and captures stdout
- [x] Timeout kills runaway agents (exit code 124)
- [x] SHACKLEAI_* env vars injected correctly
- [x] Token usage parsed from `__shackleai_result__` output block
- [x] Session state round-trip (before/after) works
- [x] testEnvironment() detects runtime availability
- [x] Large stdout truncated at 10MB with warning
- [x] Missing entrypoint returns clear error
- [x] Missing entrypoint config returns clear error
- [x] Non-zero exit codes propagated
- [x] Invalid pythonPath returns exit code 127
- [x] Task payload passed as --task JSON argument
- [x] Session ID passed as --session argument
- [x] AdapterRegistry updated (14 new tests, all passing)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)