### PR TITLE
Phase 5C: Implement Hono API routes — issues + checkout + comments

### DIFF
--- a/apps/cli/__tests__/issues.test.ts
+++ b/apps/cli/__tests__/issues.test.ts
@@ -1,0 +1,632 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type CompanyRow = { id: string; issue_prefix: string; issue_counter: number }
+type AgentRow = { id: string; name: string }
+type IssueRow = {
+  id: string
+  identifier: string
+  issue_number: number
+  title: string
+  status: string
+  priority: string
+  assignee_agent_id: string | null
+  company_id: string
+}
+type CommentRow = {
+  id: string
+  issue_id: string
+  content: string
+  parent_id: string | null
+  is_resolved: boolean
+}
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  prefix: string,
+): Promise<CompanyRow> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: `Company ${prefix}`, issue_prefix: prefix }),
+  })
+  const body = (await res.json()) as { data: CompanyRow }
+  return body.data
+}
+
+async function createAgent(
+  db: PGliteProvider,
+  companyId: string,
+  name: string = 'Test Agent',
+): Promise<AgentRow> {
+  // Insert directly — agents route lives on a parallel branch
+  const result = await db.query<AgentRow>(
+    `INSERT INTO agents (company_id, name, adapter_type, adapter_config)
+     VALUES ($1, $2, 'process', '{}')
+     RETURNING id, name`,
+    [companyId, name],
+  )
+  return result.rows[0]
+}
+
+async function createIssue(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<IssueRow> {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Default Issue', ...overrides }),
+  })
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('issues routes — CRUD', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'CRUD')
+    companyId = company.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/issues returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /api/companies/:id/issues creates an issue', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'First Issue', priority: 'high' }),
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.title).toBe('First Issue')
+    expect(body.data.priority).toBe('high')
+    expect(body.data.status).toBe('backlog')
+    expect(body.data.company_id).toBe(companyId)
+    expect(body.data.id).toBeTruthy()
+  })
+
+  it('POST /api/companies/:id/issues returns 400 on missing title', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priority: 'low' }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/issues returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /api/companies/:id/issues/:issueId returns issue detail', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Detail Issue' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.id).toBe(issue.id)
+    expect(body.data.title).toBe('Detail Issue')
+  })
+
+  it('GET /api/companies/:id/issues/:issueId returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000`,
+    )
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Issue not found')
+  })
+
+  it('PATCH /api/companies/:id/issues/:issueId updates issue fields', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Patch Issue' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'todo', priority: 'critical' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('todo')
+    expect(body.data.priority).toBe('critical')
+  })
+
+  it('PATCH /api/companies/:id/issues/:issueId returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('PATCH /api/companies/:id/issues/:issueId returns 400 on validation error', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Validate Issue' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'invalid_status_value' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /api/companies/:id/issues lists multiple issues', async () => {
+    await createIssue(app, companyId, { title: 'List Issue A' })
+    await createIssue(app, companyId, { title: 'List Issue B' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.length).toBeGreaterThan(1)
+  })
+})
+
+describe('issues routes — auto-generated identifier', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'ACME')
+    companyId = company.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('auto-generates identifier from company prefix + counter (ACME-1)', async () => {
+    const issue = await createIssue(app, companyId, { title: 'First' })
+    expect(issue.identifier).toBe('ACME-1')
+    expect(issue.issue_number).toBe(1)
+  })
+
+  it('auto-increments identifier for sequential issues (ACME-2, ACME-3)', async () => {
+    const second = await createIssue(app, companyId, { title: 'Second' })
+    const third = await createIssue(app, companyId, { title: 'Third' })
+    expect(second.identifier).toBe('ACME-2')
+    expect(third.identifier).toBe('ACME-3')
+  })
+
+  it('different companies have independent counters', async () => {
+    const other = await createCompany(app, 'BETA')
+    const betaIssue = await createIssue(app, other.id, { title: 'Beta First' })
+    expect(betaIssue.identifier).toBe('BETA-1')
+  })
+})
+
+describe('issues routes — atomic checkout', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId1: string
+  let agentId2: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'CHKOUT')
+    companyId = company.id
+    // Create real agents to satisfy FK constraint
+    const agent1 = await createAgent(db, companyId, 'Worker Agent 1')
+    const agent2 = await createAgent(db, companyId, 'Worker Agent 2')
+    agentId1 = agent1.id
+    agentId2 = agent2.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('checkout succeeds for an unassigned backlog issue', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Checkout Issue' })
+    expect(issue.status).toBe('backlog')
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId1 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+    expect(body.data.assignee_agent_id).toBe(agentId1)
+  })
+
+  it('checkout returns 409 if issue is already claimed', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Already Claimed' })
+
+    // First claim succeeds
+    const first = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId1 }),
+      },
+    )
+    expect(first.status).toBe(200)
+
+    // Second claim returns 409
+    const second = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId2 }),
+      },
+    )
+    expect(second.status).toBe(409)
+    const body = (await second.json()) as { error: string }
+    expect(body.error).toContain('already claimed')
+  })
+
+  it('checkout returns 409 for issue in done status', async () => {
+    const issue = await createIssue(app, companyId, {
+      title: 'Done Issue',
+      status: 'done',
+    })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId1 }),
+    })
+    expect(res.status).toBe(409)
+  })
+
+  it('checkout succeeds for todo status issue', async () => {
+    const issue = await createIssue(app, companyId, {
+      title: 'Todo Issue',
+      status: 'todo',
+    })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId1 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+  })
+
+  it('checkout returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId1 }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('issues routes — release', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId1: string
+  let agentId2: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'REL')
+    companyId = company.id
+    const agent1 = await createAgent(db, companyId, 'Release Agent 1')
+    const agent2 = await createAgent(db, companyId, 'Release Agent 2')
+    agentId1 = agent1.id
+    agentId2 = agent2.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('release unassigns the issue and sets status to todo', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Release Me' })
+
+    // Checkout first
+    await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId1 }),
+    })
+
+    // Release
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/release`, {
+      method: 'POST',
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('todo')
+    expect(body.data.assignee_agent_id).toBeNull()
+  })
+
+  it('release returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/release`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('released issue can be checked out again', async () => {
+    const issue = await createIssue(app, companyId, { title: 'Recheckout Me' })
+
+    // Checkout
+    await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId1 }),
+    })
+
+    // Release
+    await app.request(`/api/companies/${companyId}/issues/${issue.id}/release`, {
+      method: 'POST',
+    })
+
+    // Recheckout — should succeed
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: agentId2 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.assignee_agent_id).toBe(agentId2)
+  })
+})
+
+describe('issues routes — comments', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let issueId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'CMT')
+    companyId = company.id
+    const issue = await createIssue(app, companyId, { title: 'Issue For Comments' })
+    issueId = issue.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /comments returns empty array for new issue', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /comments creates a comment', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Hello world' }),
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: CommentRow }
+    expect(body.data.content).toBe('Hello world')
+    expect(body.data.issue_id).toBe(issueId)
+    expect(body.data.parent_id).toBeNull()
+    expect(body.data.is_resolved).toBe(false)
+  })
+
+  it('POST /comments returns 400 on missing content', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ author_agent_id: null }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /comments returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'bad-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /comments lists comments ordered by created_at', async () => {
+    // Create a second comment
+    await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Second comment' }),
+    })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CommentRow[] }
+    expect(body.data.length).toBeGreaterThanOrEqual(2)
+    // Ordered ASC by created_at — first created should be first
+    expect(body.data[0].content).toBe('Hello world')
+  })
+
+  it('POST /comments supports threading via parent_id', async () => {
+    // Create parent comment
+    const parentRes = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Parent comment' }),
+      },
+    )
+    const parentBody = (await parentRes.json()) as { data: CommentRow }
+    const parentCommentId = parentBody.data.id
+
+    // Create threaded reply
+    const replyRes = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Reply comment', parent_id: parentCommentId }),
+      },
+    )
+    expect(replyRes.status).toBe(201)
+    const replyBody = (await replyRes.json()) as { data: CommentRow }
+    expect(replyBody.data.parent_id).toBe(parentCommentId)
+  })
+
+  it('POST /comments returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Ghost comment' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /comments returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/comments`,
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('issues routes — filtering', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let filtAgentId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'FILT')
+    companyId = company.id
+    const filtAgent = await createAgent(db, companyId, 'Filter Test Agent')
+    filtAgentId = filtAgent.id
+
+    // Seed issues with various statuses/priorities
+    await createIssue(app, companyId, { title: 'Backlog Low', status: 'backlog', priority: 'low' })
+    await createIssue(app, companyId, { title: 'Todo High', status: 'todo', priority: 'high' })
+    await createIssue(app, companyId, { title: 'Todo Medium', status: 'todo', priority: 'medium' })
+    await createIssue(app, companyId, {
+      title: 'Done Critical',
+      status: 'done',
+      priority: 'critical',
+    })
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('filters by status', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues?status=todo`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.every((i) => i.status === 'todo')).toBe(true)
+    expect(body.data).toHaveLength(2)
+  })
+
+  it('filters by priority', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues?priority=high`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.every((i) => i.priority === 'high')).toBe(true)
+    expect(body.data).toHaveLength(1)
+  })
+
+  it('filters by status and priority combined', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues?status=todo&priority=medium`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].title).toBe('Todo Medium')
+  })
+
+  it('returns empty array when no issues match filter', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues?status=in_review`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('filters by assignee', async () => {
+    // Create and checkout an issue so it has a real assignee
+    const issue = await createIssue(app, companyId, { title: 'Assigned Issue' })
+    await app.request(`/api/companies/${companyId}/issues/${issue.id}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: filtAgentId }),
+    })
+
+    const res = await app.request(
+      `/api/companies/${companyId}/issues?assignee=${filtAgentId}`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.length).toBeGreaterThanOrEqual(1)
+    expect(body.data.every((i) => i.assignee_agent_id === filtAgentId)).toBe(true)
+  })
+})

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -1,0 +1,308 @@
+/**
+ * Issue CRUD + checkout + comments routes — /api/companies/:id/issues
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Issue, IssueComment } from '@shackleai/shared'
+import { CreateIssueInput, UpdateIssueInput, CreateIssueCommentInput } from '@shackleai/shared'
+import { IssueStatus } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/issues — list with filters (status, priority, assignee)
+  app.get('/:id/issues', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const { status, priority, assignee } = c.req.query()
+
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let paramIndex = 2
+
+    if (status) {
+      conditions.push(`status = $${paramIndex++}`)
+      params.push(status)
+    }
+
+    if (priority) {
+      conditions.push(`priority = $${paramIndex++}`)
+      params.push(priority)
+    }
+
+    if (assignee) {
+      conditions.push(`assignee_agent_id = $${paramIndex++}`)
+      params.push(assignee)
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await db.query<Issue>(
+      `SELECT * FROM issues WHERE ${where} ORDER BY created_at DESC`,
+      params,
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues — create issue with atomic identifier generation
+  app.post('/:id/issues', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateIssueInput.safeParse({ company_id: companyId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { title, description, parent_id, goal_id, project_id, status, priority, assignee_agent_id } =
+      parsed.data
+
+    // Atomically increment company issue_counter and get prefix + new counter value
+    const counterResult = await db.query<{ issue_prefix: string; issue_counter: number }>(
+      `UPDATE companies SET issue_counter = issue_counter + 1 WHERE id = $1
+       RETURNING issue_prefix, issue_counter`,
+      [companyId],
+    )
+
+    if (counterResult.rows.length === 0) {
+      return c.json({ error: 'Company not found' }, 404)
+    }
+
+    const { issue_prefix, issue_counter } = counterResult.rows[0]
+    const identifier = `${issue_prefix}-${issue_counter}`
+
+    const result = await db.query<Issue>(
+      `INSERT INTO issues
+         (company_id, identifier, issue_number, title, description, parent_id,
+          goal_id, project_id, status, priority, assignee_agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING *`,
+      [
+        companyId,
+        identifier,
+        issue_counter,
+        title,
+        description ?? null,
+        parent_id ?? null,
+        goal_id ?? null,
+        project_id ?? null,
+        status,
+        priority,
+        assignee_agent_id ?? null,
+      ],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/issues/:issueId — issue detail
+  app.get('/:id/issues/:issueId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    const result = await db.query<Issue>(
+      `SELECT * FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // PATCH /api/companies/:id/issues/:issueId — update status, priority, description, etc.
+  app.patch('/:id/issues/:issueId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue exists and belongs to company
+    const existing = await db.query<Issue>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = UpdateIssueInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const updates = parsed.data
+    const fields = Object.keys(updates) as (keyof typeof updates)[]
+
+    if (fields.length === 0) {
+      const result = await db.query<Issue>(
+        `SELECT * FROM issues WHERE id = $1 AND company_id = $2`,
+        [issueId, companyId],
+      )
+      return c.json({ data: result.rows[0] })
+    }
+
+    const setClauses = fields.map((f, i) => `${f} = $${i + 3}`).join(', ')
+    const values = fields.map((f) => updates[f])
+
+    const result = await db.query<Issue>(
+      `UPDATE issues SET ${setClauses}, updated_at = NOW()
+       WHERE id = $1 AND company_id = $2
+       RETURNING *`,
+      [issueId, companyId, ...values],
+    )
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/checkout — atomic claim
+  // Returns 409 if already claimed by another agent
+  app.post('/:id/issues/:issueId/checkout', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue exists and belongs to company first
+    const existing = await db.query<Issue>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      body = {}
+    }
+
+    const agentId =
+      body && typeof body === 'object' && 'agent_id' in body && typeof body.agent_id === 'string'
+        ? body.agent_id
+        : null
+
+    // Atomic checkout: only succeeds if unassigned and in backlog/todo
+    const result = await db.query<Issue>(
+      `UPDATE issues
+       SET assignee_agent_id = $1, status = 'in_progress', started_at = NOW(), updated_at = NOW()
+       WHERE id = $2 AND company_id = $3
+         AND assignee_agent_id IS NULL
+         AND status IN ('backlog', 'todo')
+       RETURNING *`,
+      [agentId, issueId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      // Issue exists but is already claimed or not in a checkable state
+      return c.json({ error: 'Issue already claimed or not available for checkout' }, 409)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/release — unassign + set status back to todo
+  app.post('/:id/issues/:issueId/release', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    const result = await db.query<Issue>(
+      `UPDATE issues
+       SET assignee_agent_id = NULL, status = $1, updated_at = NOW()
+       WHERE id = $2 AND company_id = $3
+       RETURNING *`,
+      [IssueStatus.Todo, issueId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/comments — add comment
+  app.post('/:id/issues/:issueId/comments', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue belongs to company
+    const existing = await db.query<Issue>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateIssueCommentInput.safeParse({ issue_id: issueId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { content, author_agent_id, parent_id, is_resolved } = parsed.data
+
+    const result = await db.query<IssueComment>(
+      `INSERT INTO issue_comments (issue_id, author_agent_id, content, parent_id, is_resolved)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [issueId, author_agent_id ?? null, content, parent_id ?? null, is_resolved],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/issues/:issueId/comments — list comments ordered by created_at
+  app.get('/:id/issues/:issueId/comments', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue belongs to company
+    const existing = await db.query<Issue>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const result = await db.query<IssueComment>(
+      `SELECT * FROM issue_comments WHERE issue_id = $1 ORDER BY created_at ASC`,
+      [issueId],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  return app
+}


### PR DESCRIPTION
## Summary

- Adds `issuesRouter` with full CRUD for issues scoped by company (`/api/companies/:id/issues`)
- Implements atomic checkout via single `UPDATE ... WHERE assignee_agent_id IS NULL AND status IN ('backlog','todo') RETURNING *` — returns 409 if already claimed
- Auto-generates issue identifiers from company `issue_prefix` + atomically incremented `issue_counter` (e.g. `ACME-1`)
- Adds release endpoint to unassign and reset status to `todo`
- Adds comment endpoints with threading support via `parent_id`
- Supports filtering by `?status=`, `?priority=`, `?assignee=` query params
- Registers `issuesRouter` in `createApp`
- 34 new Vitest tests covering CRUD, identifier generation, atomic checkout races, release/recheckout, comments, and filters

## Test plan

- [x] `pnpm build` passes (TypeScript strict)
- [x] `pnpm lint` passes (zero ESLint warnings)
- [x] `pnpm --filter @shackleai/orchestrator test` — 55 tests pass (34 new issue tests)
- [x] Atomic checkout: first claim succeeds, second returns 409
- [x] Identifier generation: sequential per-company counter (ACME-1, ACME-2 …)
- [x] Independent counters across companies
- [x] Filter by status, priority, assignee
- [x] Comment threading via parent_id
- [x] 404 for non-existent issues

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)