### PR TITLE
Phase 5D: Remaining API routes — policies, costs, heartbeats, activity, goals, projects

### DIFF
--- a/apps/cli/__tests__/activity.test.ts
+++ b/apps/cli/__tests__/activity.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+// Insert an activity log entry directly via db — activity_log is an audit log,
+// entries are written by the system (triggers, hooks), not via this API.
+async function insertActivityLog(
+  db: PGliteProvider,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const result = await db.query<{ id: string }>(
+    `INSERT INTO activity_log
+       (company_id, entity_type, entity_id, actor_type, actor_id, action)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      companyId,
+      overrides.entity_type ?? 'agent',
+      overrides.entity_id ?? null,
+      overrides.actor_type ?? 'system',
+      overrides.actor_id ?? null,
+      overrides.action ?? 'created',
+    ],
+  )
+  return result.rows[0].id
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('activity routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/activity returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/activity`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('GET /api/companies/:id/activity returns 404 for non-existent company', async () => {
+    const res = await app.request(
+      `/api/companies/00000000-0000-0000-0000-000000000000/activity`,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/companies/:id/activity lists activity log entries', async () => {
+    const newCompanyId = await createCompany(app, 'Activity List Corp')
+
+    await insertActivityLog(db, newCompanyId, { entity_type: 'agent', action: 'created' })
+    await insertActivityLog(db, newCompanyId, { entity_type: 'issue', action: 'closed' })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/activity`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(2)
+  })
+
+  it('GET /api/companies/:id/activity filters by entity_type', async () => {
+    const newCompanyId = await createCompany(app, 'ActFilter Corp')
+
+    await insertActivityLog(db, newCompanyId, { entity_type: 'agent', action: 'created' })
+    await insertActivityLog(db, newCompanyId, { entity_type: 'issue', action: 'created' })
+    await insertActivityLog(db, newCompanyId, { entity_type: 'issue', action: 'closed' })
+
+    const res = await app.request(
+      `/api/companies/${newCompanyId}/activity?entity_type=issue`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { entity_type: string }[]
+    }
+    expect(body.data).toHaveLength(2)
+    expect(body.data.every((e) => e.entity_type === 'issue')).toBe(true)
+  })
+
+  it('GET /api/companies/:id/activity returns correct shape', async () => {
+    const newCompanyId = await createCompany(app, 'ActShape Corp')
+    await insertActivityLog(db, newCompanyId, {
+      entity_type: 'policy',
+      actor_type: 'agent',
+      action: 'updated',
+    })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/activity`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: {
+        id: string
+        company_id: string
+        entity_type: string
+        actor_type: string
+        action: string
+        created_at: string
+      }[]
+    }
+    const entry = body.data[0]
+    expect(entry.id).toBeTruthy()
+    expect(entry.company_id).toBe(newCompanyId)
+    expect(entry.entity_type).toBe('policy')
+    expect(entry.actor_type).toBe('agent')
+    expect(entry.action).toBe('updated')
+  })
+})

--- a/apps/cli/__tests__/costs.test.ts
+++ b/apps/cli/__tests__/costs.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { AdapterType } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  name = 'Cost Agent',
+) {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, adapter_type: AdapterType.Claude }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createCostEvent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return app.request(`/api/companies/${companyId}/costs/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      input_tokens: 100,
+      output_tokens: 50,
+      cost_cents: 10,
+      ...overrides,
+    }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('costs routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+    agentId = await createAgent(app, companyId)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/costs returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /api/companies/:id/costs/events creates cost event', async () => {
+    const res = await createCostEvent(app, companyId, {
+      agent_id: agentId,
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      input_tokens: 200,
+      output_tokens: 80,
+      cost_cents: 25,
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: {
+        id: string
+        company_id: string
+        agent_id: string
+        input_tokens: number
+        output_tokens: number
+        cost_cents: number
+        provider: string
+        model: string
+      }
+    }
+    expect(body.data.id).toBeTruthy()
+    expect(body.data.company_id).toBe(companyId)
+    expect(body.data.agent_id).toBe(agentId)
+    expect(body.data.input_tokens).toBe(200)
+    expect(body.data.output_tokens).toBe(80)
+    expect(body.data.cost_cents).toBe(25)
+    expect(body.data.provider).toBe('anthropic')
+  })
+
+  it('POST /api/companies/:id/costs/events returns 400 on missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input_tokens: 100 }), // missing output_tokens, cost_cents
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/costs/events returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/companies/:id/costs/events returns 404 for non-existent company', async () => {
+    const res = await createCostEvent(app, '00000000-0000-0000-0000-000000000000')
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/companies/:id/costs lists cost events', async () => {
+    const newCompanyId = await createCompany(app, 'Costs List Corp')
+    await createCostEvent(app, newCompanyId, { input_tokens: 100, output_tokens: 50, cost_cents: 5 })
+    await createCostEvent(app, newCompanyId, { input_tokens: 200, output_tokens: 100, cost_cents: 10 })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/costs`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(2)
+  })
+
+  it('GET /api/companies/:id/costs/by-agent aggregates costs per agent', async () => {
+    const newCompanyId = await createCompany(app, 'By Agent Corp')
+    const agent1Id = await createAgent(app, newCompanyId, 'Agent One')
+    const agent2Id = await createAgent(app, newCompanyId, 'Agent Two')
+
+    await createCostEvent(app, newCompanyId, {
+      agent_id: agent1Id,
+      input_tokens: 100,
+      output_tokens: 50,
+      cost_cents: 10,
+    })
+    await createCostEvent(app, newCompanyId, {
+      agent_id: agent1Id,
+      input_tokens: 200,
+      output_tokens: 100,
+      cost_cents: 20,
+    })
+    await createCostEvent(app, newCompanyId, {
+      agent_id: agent2Id,
+      input_tokens: 300,
+      output_tokens: 150,
+      cost_cents: 30,
+    })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/costs/by-agent`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { agent_id: string; total_cost_cents: number; event_count: number }[]
+    }
+    expect(body.data).toHaveLength(2)
+
+    const agent1Row = body.data.find((r) => r.agent_id === agent1Id)
+    expect(agent1Row).toBeDefined()
+    expect(agent1Row?.total_cost_cents).toBe(30)
+    expect(agent1Row?.event_count).toBe(2)
+  })
+})

--- a/apps/cli/__tests__/goals.test.ts
+++ b/apps/cli/__tests__/goals.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { GoalLevel, GoalStatus } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createGoal(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return app.request(`/api/companies/${companyId}/goals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: 'Achieve World Domination',
+      ...overrides,
+    }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('goals routes — CRUD', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/goals returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/goals`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /api/companies/:id/goals creates goal', async () => {
+    const res = await createGoal(app, companyId, {
+      title: 'Ship v1.0',
+      level: GoalLevel.Strategic,
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: {
+        id: string
+        company_id: string
+        title: string
+        level: string
+        status: string
+      }
+    }
+    expect(body.data.id).toBeTruthy()
+    expect(body.data.company_id).toBe(companyId)
+    expect(body.data.title).toBe('Ship v1.0')
+    expect(body.data.level).toBe(GoalLevel.Strategic)
+    expect(body.data.status).toBe(GoalStatus.Active)
+  })
+
+  it('POST /api/companies/:id/goals returns 400 on missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/goals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level: GoalLevel.Task }), // missing title
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/goals returns 400 on empty title', async () => {
+    const res = await createGoal(app, companyId, { title: '' })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/goals returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/goals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/companies/:id/goals returns 404 for non-existent company', async () => {
+    const res = await createGoal(app, '00000000-0000-0000-0000-000000000000')
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/companies/:id/goals lists multiple goals', async () => {
+    const newCompanyId = await createCompany(app, 'Multi Goal Corp')
+    await createGoal(app, newCompanyId, { title: 'Goal A', level: GoalLevel.Strategic })
+    await createGoal(app, newCompanyId, { title: 'Goal B', level: GoalLevel.Initiative })
+    await createGoal(app, newCompanyId, { title: 'Goal C', level: GoalLevel.Task })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/goals`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(3)
+  })
+
+  it('POST /api/companies/:id/goals supports optional fields', async () => {
+    const res = await createGoal(app, companyId, {
+      title: 'Goal With Description',
+      description: 'A detailed description',
+      level: GoalLevel.Project,
+      status: GoalStatus.Active,
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: { description: string | null; level: string }
+    }
+    expect(body.data.description).toBe('A detailed description')
+    expect(body.data.level).toBe(GoalLevel.Project)
+  })
+})

--- a/apps/cli/__tests__/heartbeats.test.ts
+++ b/apps/cli/__tests__/heartbeats.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { AdapterType, TriggerType, HeartbeatRunStatus } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(app: ReturnType<typeof createApp>, companyId: string) {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Heartbeat Agent', adapter_type: AdapterType.Claude }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+// Insert a heartbeat run directly via db for testing GET routes
+// (No POST endpoint on this router — heartbeats are created by the core engine)
+async function insertHeartbeatRun(
+  db: PGliteProvider,
+  companyId: string,
+  agentId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const result = await db.query<{ id: string }>(
+    `INSERT INTO heartbeat_runs (company_id, agent_id, trigger_type, status)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [
+      companyId,
+      agentId,
+      overrides.trigger_type ?? TriggerType.Manual,
+      overrides.status ?? HeartbeatRunStatus.Queued,
+    ],
+  )
+  return result.rows[0].id
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('heartbeats routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+    agentId = await createAgent(app, companyId)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/heartbeats returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/heartbeats`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('GET /api/companies/:id/heartbeats lists heartbeat runs ordered by created_at DESC', async () => {
+    const newCompanyId = await createCompany(app, 'HBList Corp')
+    const newAgentId = await createAgent(app, newCompanyId)
+
+    const run1Id = await insertHeartbeatRun(db, newCompanyId, newAgentId, {
+      trigger_type: TriggerType.Cron,
+    })
+    const run2Id = await insertHeartbeatRun(db, newCompanyId, newAgentId, {
+      trigger_type: TriggerType.Manual,
+      status: HeartbeatRunStatus.Success,
+    })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/heartbeats`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { id: string }[] }
+    expect(body.data).toHaveLength(2)
+    // Most recent first
+    const ids = body.data.map((r) => r.id)
+    expect(ids).toContain(run1Id)
+    expect(ids).toContain(run2Id)
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId returns heartbeat detail', async () => {
+    const newCompanyId = await createCompany(app, 'HBDetail Corp')
+    const newAgentId = await createAgent(app, newCompanyId)
+    const runId = await insertHeartbeatRun(db, newCompanyId, newAgentId, {
+      trigger_type: TriggerType.Api,
+      status: HeartbeatRunStatus.Running,
+    })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/heartbeats/${runId}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: {
+        id: string
+        company_id: string
+        agent_id: string
+        trigger_type: string
+        status: string
+        stdout_excerpt: string | null
+      }
+    }
+    expect(body.data.id).toBe(runId)
+    expect(body.data.company_id).toBe(newCompanyId)
+    expect(body.data.agent_id).toBe(newAgentId)
+    expect(body.data.trigger_type).toBe(TriggerType.Api)
+    expect(body.data.status).toBe(HeartbeatRunStatus.Running)
+    expect('stdout_excerpt' in body.data).toBe(true)
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId returns 404 for non-existent run', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/heartbeats/00000000-0000-0000-0000-000000000000`,
+    )
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Heartbeat run not found')
+  })
+
+  it('GET /api/companies/:id/heartbeats returns 404 for non-existent company', async () => {
+    const res = await app.request(
+      `/api/companies/00000000-0000-0000-0000-000000000000/heartbeats`,
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/cli/__tests__/policies.test.ts
+++ b/apps/cli/__tests__/policies.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { PolicyAction } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createPolicy(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return app.request(`/api/companies/${companyId}/policies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Default Policy',
+      tool_pattern: 'github.*',
+      ...overrides,
+    }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('policies routes — CRUD', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/policies returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /api/companies/:id/policies creates policy', async () => {
+    const res = await createPolicy(app, companyId)
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: { id: string; name: string; tool_pattern: string; action: string; priority: number }
+    }
+    expect(body.data.id).toBeTruthy()
+    expect(body.data.name).toBe('Default Policy')
+    expect(body.data.tool_pattern).toBe('github.*')
+    expect(body.data.action).toBe(PolicyAction.Allow)
+    expect(body.data.priority).toBe(0)
+  })
+
+  it('POST /api/companies/:id/policies returns 400 on missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Incomplete' }), // missing tool_pattern
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/policies returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/companies/:id/policies returns 404 for non-existent company', async () => {
+    const res = await createPolicy(app, '00000000-0000-0000-0000-000000000000')
+    expect(res.status).toBe(404)
+  })
+
+  it('PATCH /api/companies/:id/policies/:policyId updates policy fields', async () => {
+    const createRes = await createPolicy(app, companyId, { name: 'Patchable Policy' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const policyId = created.data.id
+
+    const res = await app.request(`/api/companies/${companyId}/policies/${policyId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated Policy', action: PolicyAction.Deny }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { name: string; action: string } }
+    expect(body.data.name).toBe('Updated Policy')
+    expect(body.data.action).toBe(PolicyAction.Deny)
+  })
+
+  it('PATCH /api/companies/:id/policies/:policyId returns 404 for non-existent policy', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/00000000-0000-0000-0000-000000000000`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Ghost' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('DELETE /api/companies/:id/policies/:policyId deletes policy', async () => {
+    const createRes = await createPolicy(app, companyId, { name: 'To Delete' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const policyId = created.data.id
+
+    const deleteRes = await app.request(`/api/companies/${companyId}/policies/${policyId}`, {
+      method: 'DELETE',
+    })
+    expect(deleteRes.status).toBe(200)
+    const body = (await deleteRes.json()) as { data: { deleted: boolean; id: string } }
+    expect(body.data.deleted).toBe(true)
+    expect(body.data.id).toBe(policyId)
+
+    // Confirm it is gone
+    const getRes = await app.request(`/api/companies/${companyId}/policies`)
+    const getBody = (await getRes.json()) as { data: { id: string }[] }
+    expect(getBody.data.find((p) => p.id === policyId)).toBeUndefined()
+  })
+
+  it('DELETE /api/companies/:id/policies/:policyId returns 404 for non-existent policy', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/00000000-0000-0000-0000-000000000000`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/companies/:id/policies lists multiple policies', async () => {
+    const newCompanyId = await createCompany(app, 'Multi Policy Corp')
+    await createPolicy(app, newCompanyId, { name: 'Policy A' })
+    await createPolicy(app, newCompanyId, { name: 'Policy B' })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(2)
+  })
+})

--- a/apps/cli/__tests__/projects.test.ts
+++ b/apps/cli/__tests__/projects.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { ProjectStatus } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createProject(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return app.request(`/api/companies/${companyId}/projects`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Default Project',
+      ...overrides,
+    }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('projects routes — CRUD', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/projects returns empty array on fresh company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/projects`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('POST /api/companies/:id/projects creates project', async () => {
+    const res = await createProject(app, companyId, {
+      name: 'Platform v2',
+      description: 'Rebuild the platform',
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: {
+        id: string
+        company_id: string
+        name: string
+        description: string | null
+        status: string
+      }
+    }
+    expect(body.data.id).toBeTruthy()
+    expect(body.data.company_id).toBe(companyId)
+    expect(body.data.name).toBe('Platform v2')
+    expect(body.data.description).toBe('Rebuild the platform')
+    expect(body.data.status).toBe(ProjectStatus.Active)
+  })
+
+  it('POST /api/companies/:id/projects returns 400 on missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'No name' }), // missing name
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/projects returns 400 on empty name', async () => {
+    const res = await createProject(app, companyId, { name: '' })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST /api/companies/:id/projects returns 400 on invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/companies/:id/projects returns 404 for non-existent company', async () => {
+    const res = await createProject(app, '00000000-0000-0000-0000-000000000000')
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/companies/:id/projects lists multiple projects', async () => {
+    const newCompanyId = await createCompany(app, 'Multi Project Corp')
+    await createProject(app, newCompanyId, { name: 'Project Alpha' })
+    await createProject(app, newCompanyId, { name: 'Project Beta' })
+
+    const res = await app.request(`/api/companies/${newCompanyId}/projects`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(2)
+  })
+
+  it('POST /api/companies/:id/projects supports optional fields', async () => {
+    const res = await createProject(app, companyId, {
+      name: 'Dated Project',
+      target_date: '2026-12-31',
+      status: ProjectStatus.Active,
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as {
+      data: { target_date: string | null; status: string }
+    }
+    expect(body.data.target_date).toContain('2026-12-31')
+    expect(body.data.status).toBe(ProjectStatus.Active)
+  })
+})

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -8,6 +8,12 @@ import { companiesRouter } from './routes/companies.js'
 import { dashboardRouter } from './routes/dashboard.js'
 import { agentsRouter } from './routes/agents.js'
 import { issuesRouter } from './routes/issues.js'
+import { policiesRouter } from './routes/policies.js'
+import { costsRouter } from './routes/costs.js'
+import { heartbeatsRouter } from './routes/heartbeats.js'
+import { activityRouter } from './routes/activity.js'
+import { goalsRouter } from './routes/goals.js'
+import { projectsRouter } from './routes/projects.js'
 
 const VERSION = '0.1.0'
 
@@ -22,6 +28,12 @@ export function createApp(db: DatabaseProvider): Hono {
   app.route('/api/companies', dashboardRouter(db))
   app.route('/api/companies', agentsRouter(db))
   app.route('/api/companies', issuesRouter(db))
+  app.route('/api/companies', policiesRouter(db))
+  app.route('/api/companies', costsRouter(db))
+  app.route('/api/companies', heartbeatsRouter(db))
+  app.route('/api/companies', activityRouter(db))
+  app.route('/api/companies', goalsRouter(db))
+  app.route('/api/companies', projectsRouter(db))
 
   return app
 }

--- a/apps/cli/src/server/routes/activity.ts
+++ b/apps/cli/src/server/routes/activity.ts
@@ -1,0 +1,57 @@
+/**
+ * Activity log routes — /api/companies/:id/activity
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { ActivityLogEntry } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function activityRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/activity — audit log with query filters
+  // Supports: entity_type, from (date), to (date)
+  app.get('/:id/activity', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const { entity_type, from, to } = c.req.query()
+
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let paramIndex = 2
+
+    if (entity_type) {
+      conditions.push(`entity_type = $${paramIndex++}`)
+      params.push(entity_type)
+    }
+
+    if (from) {
+      conditions.push(`created_at >= $${paramIndex++}`)
+      params.push(from)
+    }
+
+    if (to) {
+      conditions.push(`created_at <= $${paramIndex++}`)
+      params.push(to)
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await db.query<ActivityLogEntry>(
+      `SELECT * FROM activity_log WHERE ${where} ORDER BY created_at DESC`,
+      params,
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/costs.ts
+++ b/apps/cli/src/server/routes/costs.ts
@@ -1,0 +1,120 @@
+/**
+ * Cost event routes — /api/companies/:id/costs
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { CostEvent } from '@shackleai/shared'
+import { CreateCostEventInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+type CostByAgent = {
+  agent_id: string | null
+  total_cost_cents: number
+  total_input_tokens: number
+  total_output_tokens: number
+  event_count: number
+}
+
+export function costsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/costs — list cost events with optional date range
+  app.get('/:id/costs', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const { from, to } = c.req.query()
+
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let paramIndex = 2
+
+    if (from) {
+      conditions.push(`occurred_at >= $${paramIndex++}`)
+      params.push(from)
+    }
+
+    if (to) {
+      conditions.push(`occurred_at <= $${paramIndex++}`)
+      params.push(to)
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await db.query<CostEvent>(
+      `SELECT * FROM cost_events WHERE ${where} ORDER BY occurred_at DESC`,
+      params,
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // GET /api/companies/:id/costs/by-agent — aggregate costs grouped by agent_id
+  app.get('/:id/costs/by-agent', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    const result = await db.query<CostByAgent>(
+      `SELECT
+         agent_id,
+         SUM(cost_cents)::int AS total_cost_cents,
+         SUM(input_tokens)::int AS total_input_tokens,
+         SUM(output_tokens)::int AS total_output_tokens,
+         COUNT(*)::int AS event_count
+       FROM cost_events
+       WHERE company_id = $1
+       GROUP BY agent_id
+       ORDER BY total_cost_cents DESC`,
+      [companyId],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/costs/events — create cost event
+  app.post('/:id/costs/events', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateCostEventInput.safeParse({ company_id: companyId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { agent_id, issue_id, provider, model, input_tokens, output_tokens, cost_cents } =
+      parsed.data
+
+    const result = await db.query<CostEvent>(
+      `INSERT INTO cost_events
+         (company_id, agent_id, issue_id, provider, model, input_tokens, output_tokens, cost_cents)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        companyId,
+        agent_id ?? null,
+        issue_id ?? null,
+        provider ?? null,
+        model ?? null,
+        input_tokens,
+        output_tokens,
+        cost_cents,
+      ],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/goals.ts
+++ b/apps/cli/src/server/routes/goals.ts
@@ -1,0 +1,71 @@
+/**
+ * Goal CRUD routes — /api/companies/:id/goals
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Goal } from '@shackleai/shared'
+import { CreateGoalInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function goalsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/goals — list goals
+  app.get('/:id/goals', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const result = await db.query<Goal>(
+      `SELECT * FROM goals WHERE company_id = $1 ORDER BY created_at DESC`,
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/goals — create goal
+  app.post('/:id/goals', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateGoalInput.safeParse({ company_id: companyId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { title, description, parent_id, level, status, owner_agent_id } = parsed.data
+
+    const result = await db.query<Goal>(
+      `INSERT INTO goals
+         (company_id, title, description, parent_id, level, status, owner_agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        companyId,
+        title,
+        description ?? null,
+        parent_id ?? null,
+        level,
+        status,
+        owner_agent_id ?? null,
+      ],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/heartbeats.ts
+++ b/apps/cli/src/server/routes/heartbeats.ts
@@ -1,0 +1,50 @@
+/**
+ * Heartbeat run routes — /api/companies/:id/heartbeats
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { HeartbeatRun } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function heartbeatsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/heartbeats — list heartbeat runs ordered by created_at DESC
+  app.get('/:id/heartbeats', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const result = await db.query<HeartbeatRun>(
+      `SELECT * FROM heartbeat_runs WHERE company_id = $1 ORDER BY created_at DESC`,
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // GET /api/companies/:id/heartbeats/:runId — detail of a single heartbeat run
+  app.get('/:id/heartbeats/:runId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const runId = c.req.param('runId')
+
+    const result = await db.query<HeartbeatRun>(
+      `SELECT * FROM heartbeat_runs WHERE id = $1 AND company_id = $2`,
+      [runId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Heartbeat run not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/policies.ts
+++ b/apps/cli/src/server/routes/policies.ts
@@ -1,0 +1,138 @@
+/**
+ * Policy CRUD routes — /api/companies/:id/policies
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Policy } from '@shackleai/shared'
+import { CreatePolicyInput, UpdatePolicyInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function policiesRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/policies — list policies for company
+  app.get('/:id/policies', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const result = await db.query<Policy>(
+      `SELECT * FROM policies WHERE company_id = $1 ORDER BY priority DESC, created_at DESC`,
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/policies — create policy
+  app.post('/:id/policies', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreatePolicyInput.safeParse({ company_id: companyId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { agent_id, name, tool_pattern, action, priority, max_calls_per_hour } = parsed.data
+
+    const result = await db.query<Policy>(
+      `INSERT INTO policies
+         (company_id, agent_id, name, tool_pattern, action, priority, max_calls_per_hour)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        companyId,
+        agent_id ?? null,
+        name,
+        tool_pattern,
+        action,
+        priority,
+        max_calls_per_hour ?? null,
+      ],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // PATCH /api/companies/:id/policies/:policyId — update policy
+  app.patch('/:id/policies/:policyId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const policyId = c.req.param('policyId')
+
+    // Verify policy exists and belongs to company
+    const existing = await db.query<Policy>(
+      `SELECT id FROM policies WHERE id = $1 AND company_id = $2`,
+      [policyId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Policy not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = UpdatePolicyInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const updates = parsed.data
+    const fields = Object.keys(updates) as (keyof typeof updates)[]
+
+    if (fields.length === 0) {
+      const result = await db.query<Policy>(
+        `SELECT * FROM policies WHERE id = $1 AND company_id = $2`,
+        [policyId, companyId],
+      )
+      return c.json({ data: result.rows[0] })
+    }
+
+    const setClauses = fields.map((f, i) => `${f} = $${i + 3}`).join(', ')
+    const values = fields.map((f) => updates[f])
+
+    const result = await db.query<Policy>(
+      `UPDATE policies SET ${setClauses}
+       WHERE id = $1 AND company_id = $2
+       RETURNING *`,
+      [policyId, companyId, ...values],
+    )
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // DELETE /api/companies/:id/policies/:policyId — delete policy
+  app.delete('/:id/policies/:policyId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const policyId = c.req.param('policyId')
+
+    const result = await db.query<Policy>(
+      `DELETE FROM policies WHERE id = $1 AND company_id = $2 RETURNING id`,
+      [policyId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Policy not found' }, 404)
+    }
+
+    return c.json({ data: { deleted: true, id: result.rows[0].id } })
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/projects.ts
+++ b/apps/cli/src/server/routes/projects.ts
@@ -1,0 +1,71 @@
+/**
+ * Project CRUD routes — /api/companies/:id/projects
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Project } from '@shackleai/shared'
+import { CreateProjectInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function projectsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/projects — list projects
+  app.get('/:id/projects', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const result = await db.query<Project>(
+      `SELECT * FROM projects WHERE company_id = $1 ORDER BY created_at DESC`,
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/projects — create project
+  app.post('/:id/projects', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateProjectInput.safeParse({ company_id: companyId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { name, description, goal_id, lead_agent_id, status, target_date } = parsed.data
+
+    const result = await db.query<Project>(
+      `INSERT INTO projects
+         (company_id, name, description, goal_id, lead_agent_id, status, target_date)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        companyId,
+        name,
+        description ?? null,
+        goal_id ?? null,
+        lead_agent_id ?? null,
+        status,
+        target_date ?? null,
+      ],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  return app
+}


### PR DESCRIPTION
## Summary

- Adds 6 new Hono route factories in `apps/cli/src/server/routes/`: `policies`, `costs`, `heartbeats`, `activity`, `goals`, `projects`
- Registers all 6 routers in `apps/cli/src/server/index.ts` under `/api/companies`
- Adds 6 matching Vitest test files in `apps/cli/__tests__/` covering CRUD, validation (400), auth (404 company scope), and domain-specific logic (cost aggregation by agent, heartbeat detail with stdout_excerpt, activity entity_type filter)

## Endpoints added

| Route | Methods |
|-------|---------|
| `/api/companies/:id/policies` | GET, POST |
| `/api/companies/:id/policies/:policyId` | PATCH, DELETE |
| `/api/companies/:id/costs` | GET (date range filter) |
| `/api/companies/:id/costs/by-agent` | GET (aggregate SUM) |
| `/api/companies/:id/costs/events` | POST |
| `/api/companies/:id/heartbeats` | GET |
| `/api/companies/:id/heartbeats/:runId` | GET |
| `/api/companies/:id/activity` | GET (entity_type, from, to filters) |
| `/api/companies/:id/goals` | GET, POST |
| `/api/companies/:id/projects` | GET, POST |

## Test plan

- [x] `pnpm build` — passes (all 5 packages)
- [x] `pnpm lint` — passes (zero warnings)
- [x] `pnpm typecheck` — passes (strict mode)
- [x] `pnpm test` (cli package) — 132/132 tests pass across 14 test files

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)