### PR TITLE
Phase 5E: CLI commands — agent, task, run, doctor, upgrade

### DIFF
--- a/apps/cli/__tests__/agent-cmd.test.ts
+++ b/apps/cli/__tests__/agent-cmd.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { AdapterType, AgentStatus } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  name = 'CLI Test Corp',
+) {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'CLI Agent',
+      adapter_type: AdapterType.Claude,
+      ...overrides,
+    }),
+  })
+  return res
+}
+
+// ---------------------------------------------------------------------------
+// Tests — agent CLI command API calls
+// ---------------------------------------------------------------------------
+
+describe('agent CLI command — API integration', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('list agents returns empty array initially', async () => {
+    const res = await app.request(`/api/companies/${companyId}/agents`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('create agent via API and list it', async () => {
+    const createRes = await createAgent(app, companyId, {
+      name: 'TestBot',
+      role: 'worker',
+      adapter_type: AdapterType.Process,
+    })
+    expect(createRes.status).toBe(201)
+
+    const listRes = await app.request(`/api/companies/${companyId}/agents`)
+    const body = (await listRes.json()) as {
+      data: { name: string; role: string; adapter_type: string }[]
+    }
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].name).toBe('TestBot')
+    expect(body.data[0].role).toBe('worker')
+    expect(body.data[0].adapter_type).toBe(AdapterType.Process)
+  })
+
+  it('pause agent sets status to paused', async () => {
+    const createRes = await createAgent(app, companyId, { name: 'PauseBot' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const agentId = created.data.id
+
+    const res = await app.request(
+      `/api/companies/${companyId}/agents/${agentId}/pause`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { status: string } }
+    expect(body.data.status).toBe(AgentStatus.Paused)
+  })
+
+  it('resume agent sets status to idle', async () => {
+    const createRes = await createAgent(app, companyId, { name: 'ResumeBot' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const agentId = created.data.id
+
+    // Pause first
+    await app.request(
+      `/api/companies/${companyId}/agents/${agentId}/pause`,
+      { method: 'POST' },
+    )
+
+    // Resume
+    const res = await app.request(
+      `/api/companies/${companyId}/agents/${agentId}/resume`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { status: string } }
+    expect(body.data.status).toBe(AgentStatus.Idle)
+  })
+
+  it('terminate agent sets status to terminated', async () => {
+    const createRes = await createAgent(app, companyId, { name: 'TermBot' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const agentId = created.data.id
+
+    const res = await app.request(
+      `/api/companies/${companyId}/agents/${agentId}/terminate`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { status: string } }
+    expect(body.data.status).toBe(AgentStatus.Terminated)
+  })
+
+  it('wakeup agent triggers heartbeat', async () => {
+    const createRes = await createAgent(app, companyId, { name: 'WakeBot' })
+    const created = (await createRes.json()) as { data: { id: string } }
+    const agentId = created.data.id
+
+    const res = await app.request(
+      `/api/companies/${companyId}/agents/${agentId}/wakeup`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { triggered: boolean; agent: { last_heartbeat_at: string } }
+    }
+    expect(body.data.triggered).toBe(true)
+    expect(body.data.agent.last_heartbeat_at).toBeTruthy()
+  })
+
+  it('lifecycle actions return 404 for non-existent agent', async () => {
+    const ghost = '00000000-0000-0000-0000-000000000000'
+    for (const action of ['pause', 'resume', 'terminate', 'wakeup']) {
+      const res = await app.request(
+        `/api/companies/${companyId}/agents/${ghost}/${action}`,
+        { method: 'POST' },
+      )
+      expect(res.status).toBe(404)
+    }
+  })
+})

--- a/apps/cli/__tests__/task-cmd.test.ts
+++ b/apps/cli/__tests__/task-cmd.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { AdapterType } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type IssueRow = {
+  id: string
+  identifier: string
+  title: string
+  status: string
+  priority: string
+  assignee_agent_id: string | null
+}
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  prefix: string,
+) {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: `Company ${prefix}`, issue_prefix: prefix }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgentDirectly(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  name: string,
+) {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      adapter_type: AdapterType.Process,
+    }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createTask(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Default Task', ...overrides }),
+  })
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Tests — task CLI command API calls
+// ---------------------------------------------------------------------------
+
+describe('task CLI command — API integration', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app, 'TASK')
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('list tasks returns empty array initially', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('create task via API and list it', async () => {
+    const createRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Implement CLI',
+        description: 'Build the CLI commands',
+        priority: 'high',
+      }),
+    })
+    expect(createRes.status).toBe(201)
+
+    const listRes = await app.request(`/api/companies/${companyId}/issues`)
+    const body = (await listRes.json()) as { data: IssueRow[] }
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].title).toBe('Implement CLI')
+    expect(body.data[0].identifier).toBe('TASK-1')
+    expect(body.data[0].priority).toBe('high')
+  })
+
+  it('assign task to agent via checkout endpoint', async () => {
+    const task = await createTask(app, companyId, { title: 'Assignable Task' })
+    const agentId = await createAgentDirectly(app, companyId, 'Worker')
+
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+    expect(body.data.assignee_agent_id).toBe(agentId)
+  })
+
+  it('complete task via PATCH status=done', async () => {
+    const task = await createTask(app, companyId, { title: 'Completable Task' })
+
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('complete returns 404 for non-existent task', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('assign returns 409 if task already claimed', async () => {
+    const task = await createTask(app, companyId, { title: 'Double Claim' })
+    const agent1 = await createAgentDirectly(app, companyId, 'Agent1')
+    const agent2 = await createAgentDirectly(app, companyId, 'Agent2')
+
+    // First checkout
+    const first = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agent1 }),
+      },
+    )
+    expect(first.status).toBe(200)
+
+    // Second checkout should 409
+    const second = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agent2 }),
+      },
+    )
+    expect(second.status).toBe(409)
+  })
+})

--- a/apps/cli/src/api-client.ts
+++ b/apps/cli/src/api-client.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared API client for CLI commands that call the local orchestrator server.
+ */
+
+import { readConfig } from './config.js'
+
+const DEFAULT_PORT = 4800
+
+export async function apiClient(
+  path: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const config = await readConfig()
+  if (!config) {
+    console.error('Not initialized. Run `shackleai init` first.')
+    process.exit(1)
+  }
+
+  const baseUrl = `http://localhost:${DEFAULT_PORT}`
+  const url = path.startsWith('/') ? `${baseUrl}${path}` : `${baseUrl}/${path}`
+
+  const res = await fetch(url, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+  })
+
+  return res
+}
+
+export async function getCompanyId(): Promise<string> {
+  const config = await readConfig()
+  if (!config) {
+    console.error('Not initialized. Run `shackleai init` first.')
+    process.exit(1)
+  }
+  return config.companyId
+}

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,0 +1,214 @@
+/**
+ * `shackleai agent` — Manage agents (list, create, pause, resume, terminate)
+ */
+
+import type { Command } from 'commander'
+import * as p from '@clack/prompts'
+import { AdapterType, AgentRole } from '@shackleai/shared'
+import type { Agent } from '@shackleai/shared'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+function formatAgentTable(agents: Agent[]): void {
+  if (agents.length === 0) {
+    console.log('No agents found.')
+    return
+  }
+
+  const rows = agents.map((a) => ({
+    ID: a.id.slice(0, 8),
+    Name: a.name,
+    Role: a.role,
+    Status: a.status,
+    Adapter: a.adapter_type,
+    'Last Heartbeat': a.last_heartbeat_at
+      ? new Date(a.last_heartbeat_at).toLocaleString()
+      : '-',
+  }))
+
+  console.table(rows)
+}
+
+async function listAgents(): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/agents`)
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Agent[]>
+  formatAgentTable(body.data)
+}
+
+async function createAgentInteractive(): Promise<void> {
+  p.intro('Create a new agent')
+
+  const name = await p.text({
+    message: 'Agent name',
+    placeholder: 'coder-bot',
+    validate: (v) => {
+      if (!v.trim()) return 'Agent name is required'
+      return undefined
+    },
+  })
+
+  if (p.isCancel(name)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const roleOptions = Object.entries(AgentRole).map(([key, value]) => ({
+    value,
+    label: key,
+  }))
+
+  const role = await p.select({
+    message: 'Agent role',
+    options: roleOptions,
+  })
+
+  if (p.isCancel(role)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const adapterOptions = Object.entries(AdapterType).map(([key, value]) => ({
+    value,
+    label: key,
+  }))
+
+  const adapterType = await p.select({
+    message: 'Adapter type',
+    options: adapterOptions,
+  })
+
+  if (p.isCancel(adapterType)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const companyId = await getCompanyId()
+  const spin = p.spinner()
+  spin.start('Creating agent...')
+
+  const res = await apiClient(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    body: JSON.stringify({
+      name: name.trim(),
+      role,
+      adapter_type: adapterType,
+    }),
+  })
+
+  if (!res.ok) {
+    spin.stop('Failed to create agent')
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Agent>
+  spin.stop(`Agent created: ${body.data.name} (${body.data.id})`)
+}
+
+async function pauseAgent(id: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    `/api/companies/${companyId}/agents/${id}/pause`,
+    { method: 'POST' },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Agent>
+  console.log(`Agent ${body.data.name} paused.`)
+}
+
+async function resumeAgent(id: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    `/api/companies/${companyId}/agents/${id}/resume`,
+    { method: 'POST' },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Agent>
+  console.log(`Agent ${body.data.name} resumed.`)
+}
+
+async function terminateAgent(id: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    `/api/companies/${companyId}/agents/${id}/terminate`,
+    { method: 'POST' },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Agent>
+  console.log(`Agent ${body.data.name} terminated.`)
+}
+
+export function registerAgentCommand(program: Command): void {
+  const agent = program
+    .command('agent')
+    .description('Manage agents')
+
+  agent
+    .command('list')
+    .description('List all agents')
+    .action(async () => {
+      await listAgents()
+    })
+
+  agent
+    .command('create')
+    .description('Create a new agent (interactive)')
+    .action(async () => {
+      await createAgentInteractive()
+    })
+
+  agent
+    .command('pause')
+    .argument('<id>', 'Agent ID')
+    .description('Pause an agent')
+    .action(async (id: string) => {
+      await pauseAgent(id)
+    })
+
+  agent
+    .command('resume')
+    .argument('<id>', 'Agent ID')
+    .description('Resume a paused agent')
+    .action(async (id: string) => {
+      await resumeAgent(id)
+    })
+
+  agent
+    .command('terminate')
+    .argument('<id>', 'Agent ID')
+    .description('Terminate an agent')
+    .action(async (id: string) => {
+      await terminateAgent(id)
+    })
+}

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,0 +1,90 @@
+/**
+ * `shackleai doctor` — Health checks and system diagnostics
+ */
+
+import type { Command } from 'commander'
+import { readConfig, getConfigPath } from '../config.js'
+
+const VERSION = '0.1.0'
+
+async function runDoctor(): Promise<void> {
+  console.log(`ShackleAI Orchestrator v${VERSION} — Doctor\n`)
+
+  let allOk = true
+
+  // 1. Check config
+  const configPath = getConfigPath()
+  console.log(`Config path: ${configPath}`)
+
+  const config = await readConfig()
+  if (!config) {
+    console.log('[FAIL] Config not found. Run `shackleai init` first.')
+    allOk = false
+  } else {
+    console.log('[OK]   Config loaded')
+    console.log(`       Company: ${config.companyName} (${config.companyId})`)
+    console.log(`       Mode:    ${config.mode}`)
+  }
+
+  // 2. Check DB connection via API health endpoint
+  if (config) {
+    try {
+      const healthRes = await fetch('http://localhost:4800/api/health')
+      if (healthRes.ok) {
+        const health = (await healthRes.json()) as {
+          status: string
+          version: string
+        }
+        console.log(`[OK]   Server reachable (v${health.version})`)
+
+        // 3. Fetch dashboard metrics for counts
+        try {
+          const dashRes = await fetch(
+            `http://localhost:4800/api/companies/${config.companyId}/dashboard`,
+          )
+          if (dashRes.ok) {
+            const dash = (await dashRes.json()) as {
+              data: {
+                agentCount: number
+                taskCount: number
+                openTasks: number
+                completedTasks: number
+              }
+            }
+            console.log(`[OK]   Database connected`)
+            console.log(`       Agents: ${dash.data.agentCount}`)
+            console.log(`       Tasks:  ${dash.data.taskCount} (${dash.data.openTasks} open, ${dash.data.completedTasks} completed)`)
+          } else {
+            console.log('[WARN] Could not fetch dashboard metrics')
+          }
+        } catch {
+          console.log('[WARN] Could not fetch dashboard metrics')
+        }
+      } else {
+        console.log('[FAIL] Server not responding correctly')
+        allOk = false
+      }
+    } catch {
+      console.log(
+        '[FAIL] Server not reachable at http://localhost:4800. Is it running? (`shackleai start`)',
+      )
+      allOk = false
+    }
+  }
+
+  console.log('')
+  if (allOk) {
+    console.log('All checks passed.')
+  } else {
+    console.log('Some checks failed. See above for details.')
+  }
+}
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Run health checks and diagnostics')
+    .action(async () => {
+      await runDoctor()
+    })
+}

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,0 +1,52 @@
+/**
+ * `shackleai run <agentId>` — Trigger on-demand agent wakeup/heartbeat
+ */
+
+import type { Command } from 'commander'
+import type { Agent } from '@shackleai/shared'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface WakeupResponse {
+  data: {
+    agent: Agent
+    triggered: boolean
+  }
+  error?: string
+}
+
+async function runAgent(agentId: string): Promise<void> {
+  const companyId = await getCompanyId()
+
+  console.log(`Triggering wakeup for agent ${agentId}...`)
+
+  const res = await apiClient(
+    `/api/companies/${companyId}/agents/${agentId}/wakeup`,
+    { method: 'POST' },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as { error?: string }
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as WakeupResponse
+  const { agent, triggered } = body.data
+
+  console.log(`Triggered: ${triggered}`)
+  console.log(`Agent:     ${agent.name} (${agent.id})`)
+  console.log(`Status:    ${agent.status}`)
+  console.log(
+    `Heartbeat: ${agent.last_heartbeat_at ? new Date(agent.last_heartbeat_at).toLocaleString() : '-'}`,
+  )
+}
+
+export function registerRunCommand(program: Command): void {
+  program
+    .command('run')
+    .argument('<agentId>', 'Agent ID to trigger')
+    .description('Trigger an on-demand agent wakeup')
+    .action(async (agentId: string) => {
+      await runAgent(agentId)
+    })
+}

--- a/apps/cli/src/commands/task.ts
+++ b/apps/cli/src/commands/task.ts
@@ -1,0 +1,193 @@
+/**
+ * `shackleai task` — Manage tasks/issues (list, create, assign, complete)
+ */
+
+import type { Command } from 'commander'
+import * as p from '@clack/prompts'
+import { IssuePriority } from '@shackleai/shared'
+import type { Issue } from '@shackleai/shared'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+function formatTaskTable(tasks: Issue[]): void {
+  if (tasks.length === 0) {
+    console.log('No tasks found.')
+    return
+  }
+
+  const rows = tasks.map((t) => ({
+    ID: t.id.slice(0, 8),
+    Identifier: t.identifier,
+    Title: t.title.length > 40 ? t.title.slice(0, 37) + '...' : t.title,
+    Status: t.status,
+    Priority: t.priority,
+    Assignee: t.assignee_agent_id ? t.assignee_agent_id.slice(0, 8) : '-',
+  }))
+
+  console.table(rows)
+}
+
+async function listTasks(): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/issues`)
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Issue[]>
+  formatTaskTable(body.data)
+}
+
+async function createTaskInteractive(): Promise<void> {
+  p.intro('Create a new task')
+
+  const title = await p.text({
+    message: 'Task title',
+    placeholder: 'Implement feature X',
+    validate: (v) => {
+      if (!v.trim()) return 'Title is required'
+      return undefined
+    },
+  })
+
+  if (p.isCancel(title)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const description = await p.text({
+    message: 'Description (optional)',
+    placeholder: 'Detailed description of the task',
+  })
+
+  if (p.isCancel(description)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const priorityOptions = Object.entries(IssuePriority).map(
+    ([key, value]) => ({
+      value,
+      label: key,
+    }),
+  )
+
+  const priority = await p.select({
+    message: 'Priority',
+    options: priorityOptions,
+  })
+
+  if (p.isCancel(priority)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const companyId = await getCompanyId()
+  const spin = p.spinner()
+  spin.start('Creating task...')
+
+  const res = await apiClient(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: title.trim(),
+      description: description?.trim() || null,
+      priority,
+    }),
+  })
+
+  if (!res.ok) {
+    spin.stop('Failed to create task')
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Issue>
+  spin.stop(`Task created: ${body.data.identifier} — ${body.data.title}`)
+}
+
+async function assignTask(taskId: string, agentId: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    `/api/companies/${companyId}/issues/${taskId}/checkout`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ agent_id: agentId }),
+    },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Issue>
+  console.log(
+    `Task ${body.data.identifier} assigned to agent ${agentId.slice(0, 8)}. Status: ${body.data.status}`,
+  )
+}
+
+async function completeTask(taskId: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    `/api/companies/${companyId}/issues/${taskId}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'done' }),
+    },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Issue>
+  console.log(`Task ${body.data.identifier} marked as done.`)
+}
+
+export function registerTaskCommand(program: Command): void {
+  const task = program
+    .command('task')
+    .description('Manage tasks')
+
+  task
+    .command('list')
+    .description('List all tasks')
+    .action(async () => {
+      await listTasks()
+    })
+
+  task
+    .command('create')
+    .description('Create a new task (interactive)')
+    .action(async () => {
+      await createTaskInteractive()
+    })
+
+  task
+    .command('assign')
+    .argument('<taskId>', 'Task ID')
+    .argument('<agentId>', 'Agent ID to assign')
+    .description('Assign a task to an agent')
+    .action(async (taskId: string, agentId: string) => {
+      await assignTask(taskId, agentId)
+    })
+
+  task
+    .command('complete')
+    .argument('<taskId>', 'Task ID')
+    .description('Mark a task as done')
+    .action(async (taskId: string) => {
+      await completeTask(taskId)
+    })
+}

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,0 +1,96 @@
+/**
+ * `shackleai upgrade` — License key activation and status
+ */
+
+import type { Command } from 'commander'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface LicenseInfo {
+  tier: string
+  valid_until: string | null
+  last_validated_at: string | null
+}
+
+interface LicenseActivateResponse {
+  data: LicenseInfo
+  error?: string
+}
+
+async function activateKey(key: string): Promise<void> {
+  const companyId = await getCompanyId()
+
+  console.log('Activating license key...')
+
+  const res = await apiClient(
+    `/api/companies/${companyId}/license`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ key }),
+    },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as {
+      error?: string
+    }
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    console.error(
+      'License activation failed. The API endpoint may not be available yet.',
+    )
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as LicenseActivateResponse
+  console.log(`License activated.`)
+  console.log(`  Tier:  ${body.data.tier}`)
+  console.log(
+    `  Valid: ${body.data.valid_until ? new Date(body.data.valid_until).toLocaleDateString() : 'indefinite'}`,
+  )
+}
+
+async function showStatus(): Promise<void> {
+  const companyId = await getCompanyId()
+
+  const res = await apiClient(`/api/companies/${companyId}/license`)
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      console.log('No license key activated. Using free tier.')
+      console.log('Run `shackleai upgrade --key <key>` to activate a license.')
+      return
+    }
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as {
+      error?: string
+    }
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as LicenseActivateResponse
+  console.log('License status:')
+  console.log(`  Tier:      ${body.data.tier}`)
+  console.log(
+    `  Valid:     ${body.data.valid_until ? new Date(body.data.valid_until).toLocaleDateString() : 'indefinite'}`,
+  )
+  console.log(
+    `  Validated: ${body.data.last_validated_at ? new Date(body.data.last_validated_at).toLocaleString() : 'never'}`,
+  )
+}
+
+export function registerUpgradeCommand(program: Command): void {
+  program
+    .command('upgrade')
+    .description('Manage license key')
+    .option('--key <key>', 'Activate a license key')
+    .option('--status', 'Show current license status')
+    .action(async (opts: { key?: string; status?: boolean }) => {
+      if (opts.key) {
+        await activateKey(opts.key)
+      } else if (opts.status) {
+        await showStatus()
+      } else {
+        // Default: show status
+        await showStatus()
+      }
+    })
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,11 @@
 import { Command } from 'commander'
 import { initCommand } from './commands/init.js'
 import { startCommand } from './commands/start.js'
+import { registerAgentCommand } from './commands/agent.js'
+import { registerTaskCommand } from './commands/task.js'
+import { registerRunCommand } from './commands/run.js'
+import { registerDoctorCommand } from './commands/doctor.js'
+import { registerUpgradeCommand } from './commands/upgrade.js'
 
 export const VERSION = '0.1.0'
 
@@ -31,5 +36,11 @@ program
   .action(async (opts: { port: string }) => {
     await startCommand({ port: parseInt(opts.port, 10) })
   })
+
+registerAgentCommand(program)
+registerTaskCommand(program)
+registerRunCommand(program)
+registerDoctorCommand(program)
+registerUpgradeCommand(program)
 
 program.parse()


### PR DESCRIPTION
## Summary

- Implements 5 new CLI commands: `agent`, `task`, `run`, `doctor`, `upgrade`
- Creates shared `api-client.ts` utility for all HTTP calls to the local orchestrator server
- `agent` command: list, create (interactive with @clack/prompts), pause, resume, terminate
- `task` command: list, create (interactive), assign (checkout), complete (mark done)
- `run` command: trigger on-demand agent wakeup via `/wakeup` endpoint
- `doctor` command: checks config, server health, DB metrics (agent/task counts)
- `upgrade` command: license key activation (`--key`) and status (`--status`)
- All commands registered in `index.ts` using Commander subcommand pattern
- Integration tests for agent and task commands using PGlite + `createApp`

Closes #17

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (132/132 tests, 14 test files in CLI package)
- [ ] Manual: `shackleai agent list` returns agents table
- [ ] Manual: `shackleai task create` walks through interactive prompts
- [ ] Manual: `shackleai doctor` shows config + server health
- [ ] Manual: `shackleai run <id>` triggers wakeup

🤖 Generated with [Claude Code](https://claude.com/claude-code)