### PR TITLE
Phase 5F: E2E integration tests — full orchestrator flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "test": "turbo test",
+    "test:e2e": "vitest run --config tests/vitest.config.ts",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yaml}\"",

--- a/tests/e2e/budget.test.ts
+++ b/tests/e2e/budget.test.ts
@@ -1,0 +1,268 @@
+/**
+ * E2E: Budget tracking
+ *
+ * Tests cost event ingestion and aggregation:
+ *   company with budget → agent with budget → cost events → verify aggregation
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../../apps/cli/src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CostEventRow = {
+  id: string
+  company_id: string
+  agent_id: string | null
+  input_tokens: number
+  output_tokens: number
+  cost_cents: number
+  provider: string | null
+  model: string | null
+}
+
+type CostByAgent = {
+  agent_id: string | null
+  total_cost_cents: number
+  total_input_tokens: number
+  total_output_tokens: number
+  event_count: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  name: string,
+  budgetCents = 0,
+): Promise<string> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      issue_prefix: name.toUpperCase().slice(0, 4),
+      budget_monthly_cents: budgetCents,
+    }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  name: string,
+  budgetCents = 0,
+): Promise<string> {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      adapter_type: 'process',
+      budget_monthly_cents: budgetCents,
+    }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function postCostEvent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown>,
+): Promise<CostEventRow> {
+  const res = await app.request(`/api/companies/${companyId}/costs/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      input_tokens: 100,
+      output_tokens: 50,
+      cost_cents: 10,
+      ...overrides,
+    }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: CostEventRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('E2E: budget tracking', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agent1Id: string
+  let agent2Id: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+
+    // Company with a $10 monthly budget (1000 cents)
+    companyId = await createCompany(app, 'Budget Corp', 1000)
+
+    // Agent1 with a $5 monthly budget (500 cents)
+    agent1Id = await createAgent(app, companyId, 'Budget Agent 1', 500)
+
+    // Agent2 with no budget cap
+    agent2Id = await createAgent(app, companyId, 'Budget Agent 2', 0)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('company is created with budget_monthly_cents: 1000', async () => {
+    const res = await app.request(`/api/companies/${companyId}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { budget_monthly_cents: number } }
+    expect(body.data.budget_monthly_cents).toBe(1000)
+  })
+
+  it('agent1 is created with budget_monthly_cents: 500', async () => {
+    const res = await app.request(`/api/companies/${companyId}/agents/${agent1Id}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { budget_monthly_cents: number } }
+    expect(body.data.budget_monthly_cents).toBe(500)
+  })
+
+  it('GET /api/companies/:id/costs returns empty array before any events', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CostEventRow[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('GET /api/companies/:id/costs/by-agent returns empty array before any events', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/by-agent`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CostByAgent[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('posts cost event for agent1 via POST /api/companies/:id/costs/events', async () => {
+    const event = await postCostEvent(app, companyId, {
+      agent_id: agent1Id,
+      input_tokens: 500,
+      output_tokens: 200,
+      cost_cents: 75,
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+    })
+
+    expect(event.id).toBeTruthy()
+    expect(event.company_id).toBe(companyId)
+    expect(event.agent_id).toBe(agent1Id)
+    expect(event.cost_cents).toBe(75)
+    expect(event.input_tokens).toBe(500)
+    expect(event.output_tokens).toBe(200)
+    expect(event.provider).toBe('anthropic')
+    expect(event.model).toBe('claude-3-5-sonnet')
+  })
+
+  it('posts a second cost event for agent1', async () => {
+    await postCostEvent(app, companyId, {
+      agent_id: agent1Id,
+      input_tokens: 300,
+      output_tokens: 100,
+      cost_cents: 40,
+    })
+  })
+
+  it('posts cost event for agent2', async () => {
+    await postCostEvent(app, companyId, {
+      agent_id: agent2Id,
+      input_tokens: 1000,
+      output_tokens: 500,
+      cost_cents: 120,
+    })
+  })
+
+  it('GET /api/companies/:id/costs returns all 3 cost events', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CostEventRow[] }
+    expect(body.data).toHaveLength(3)
+    // Ordered by occurred_at DESC
+    expect(body.data.every((e) => e.company_id === companyId)).toBe(true)
+  })
+
+  it('GET /api/companies/:id/costs/by-agent shows correct aggregation per agent', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/by-agent`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CostByAgent[] }
+
+    // 2 agents with costs
+    expect(body.data).toHaveLength(2)
+
+    // Ordered by total_cost_cents DESC
+    const topAgent = body.data[0]
+    expect(topAgent.agent_id).toBe(agent2Id)
+    expect(topAgent.total_cost_cents).toBe(120)
+    expect(topAgent.event_count).toBe(1)
+
+    const secondAgent = body.data[1]
+    expect(secondAgent.agent_id).toBe(agent1Id)
+    // 75 + 40 = 115
+    expect(secondAgent.total_cost_cents).toBe(115)
+    expect(secondAgent.total_input_tokens).toBe(800) // 500 + 300
+    expect(secondAgent.total_output_tokens).toBe(300) // 200 + 100
+    expect(secondAgent.event_count).toBe(2)
+  })
+
+  it('dashboard totalSpendCents reflects sum of all cost events', async () => {
+    const res = await app.request(`/api/companies/${companyId}/dashboard`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { totalSpendCents: number }
+    }
+    // 75 + 40 + 120 = 235
+    expect(body.data.totalSpendCents).toBe(235)
+  })
+
+  it('returns 400 on POST /costs/events with missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // Missing input_tokens, output_tokens, cost_cents
+      body: JSON.stringify({ agent_id: agent1Id }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('returns 400 on POST /costs/events with invalid JSON', async () => {
+    const res = await app.request(`/api/companies/${companyId}/costs/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /costs supports date range filtering via from/to query params', async () => {
+    // All events occurred at "now" so from far future should return empty
+    const res = await app.request(
+      `/api/companies/${companyId}/costs?from=2099-01-01T00:00:00Z`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CostEventRow[] }
+    expect(body.data).toHaveLength(0)
+  })
+})

--- a/tests/e2e/concurrent-checkout.test.ts
+++ b/tests/e2e/concurrent-checkout.test.ts
@@ -1,0 +1,228 @@
+/**
+ * E2E: Concurrent checkout — conflict resolution
+ *
+ * Verifies the atomic checkout guarantee:
+ *   - First agent to claim a task wins (200)
+ *   - Second agent gets 409 Conflict
+ *   - Task is assigned to the winning agent only
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../../apps/cli/src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AgentRow = { id: string; name: string }
+type IssueRow = {
+  id: string
+  status: string
+  assignee_agent_id: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  name = 'Conflict Corp',
+): Promise<string> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  name: string,
+): Promise<AgentRow> {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, adapter_type: 'process' }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: AgentRow }
+  return body.data
+}
+
+async function createIssue(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  title = 'Contested Task',
+): Promise<IssueRow> {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+async function checkoutIssue(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  issueId: string,
+  agentId: string,
+): Promise<Response> {
+  return app.request(`/api/companies/${companyId}/issues/${issueId}/checkout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent_id: agentId }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('E2E: concurrent checkout — conflict resolution', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agent1: AgentRow
+  let agent2: AgentRow
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+
+    companyId = await createCompany(app, 'Conflict Corp')
+    agent1 = await createAgent(app, companyId, 'Contender One')
+    agent2 = await createAgent(app, companyId, 'Contender Two')
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('agent1 successfully checks out an unassigned backlog task (200)', async () => {
+    const issue = await createIssue(app, companyId, 'Contested Task 1')
+    expect(issue.status).toBe('backlog')
+    expect(issue.assignee_agent_id).toBeNull()
+
+    const res = await checkoutIssue(app, companyId, issue.id, agent1.id)
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+    expect(body.data.assignee_agent_id).toBe(agent1.id)
+  })
+
+  it('agent2 gets 409 Conflict when checking out a task already claimed by agent1', async () => {
+    // Create a fresh task
+    const issue = await createIssue(app, companyId, 'Single Slot Task')
+
+    // agent1 claims it
+    const first = await checkoutIssue(app, companyId, issue.id, agent1.id)
+    expect(first.status).toBe(200)
+
+    // agent2 tries to claim the same task — must fail
+    const second = await checkoutIssue(app, companyId, issue.id, agent2.id)
+    expect(second.status).toBe(409)
+
+    const body = (await second.json()) as { error: string }
+    expect(body.error).toContain('already claimed')
+  })
+
+  it('task remains assigned to agent1, not agent2, after the conflict', async () => {
+    const issue = await createIssue(app, companyId, 'Ownership Task')
+
+    // agent1 claims it
+    await checkoutIssue(app, companyId, issue.id, agent1.id)
+
+    // agent2 fails to claim
+    await checkoutIssue(app, companyId, issue.id, agent2.id)
+
+    // Verify ownership via GET issue detail
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.assignee_agent_id).toBe(agent1.id)
+    expect(body.data.status).toBe('in_progress')
+  })
+
+  it('simulated concurrent checkout — both fire simultaneously, exactly one succeeds', async () => {
+    const issue = await createIssue(app, companyId, 'Race Condition Task')
+
+    // Fire both requests without awaiting each other first
+    const [res1, res2] = await Promise.all([
+      checkoutIssue(app, companyId, issue.id, agent1.id),
+      checkoutIssue(app, companyId, issue.id, agent2.id),
+    ])
+
+    const statuses = [res1.status, res2.status].sort()
+    // Exactly one 200 and one 409
+    expect(statuses).toEqual([200, 409])
+  })
+
+  it('agent2 can claim a different task while agent1 holds another', async () => {
+    const issueA = await createIssue(app, companyId, 'Task for Agent 1')
+    const issueB = await createIssue(app, companyId, 'Task for Agent 2')
+
+    const resA = await checkoutIssue(app, companyId, issueA.id, agent1.id)
+    const resB = await checkoutIssue(app, companyId, issueB.id, agent2.id)
+
+    expect(resA.status).toBe(200)
+    expect(resB.status).toBe(200)
+
+    const bodyA = (await resA.json()) as { data: IssueRow }
+    const bodyB = (await resB.json()) as { data: IssueRow }
+
+    expect(bodyA.data.assignee_agent_id).toBe(agent1.id)
+    expect(bodyB.data.assignee_agent_id).toBe(agent2.id)
+  })
+
+  it('same agent cannot check out the same task twice (409 on re-checkout)', async () => {
+    const issue = await createIssue(app, companyId, 'Double Checkout Task')
+
+    const first = await checkoutIssue(app, companyId, issue.id, agent1.id)
+    expect(first.status).toBe(200)
+
+    // Same agent tries again — task is in_progress, not backlog/todo → 409
+    const second = await checkoutIssue(app, companyId, issue.id, agent1.id)
+    expect(second.status).toBe(409)
+  })
+
+  it('released task can be claimed by a different agent', async () => {
+    const issue = await createIssue(app, companyId, 'Release and Reclaim Task')
+
+    // agent1 claims it
+    await checkoutIssue(app, companyId, issue.id, agent1.id)
+
+    // agent1 releases it
+    const releaseRes = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/release`,
+      { method: 'POST' },
+    )
+    expect(releaseRes.status).toBe(200)
+
+    // agent2 now claims it successfully
+    const res = await checkoutIssue(app, companyId, issue.id, agent2.id)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.assignee_agent_id).toBe(agent2.id)
+  })
+
+  it('returns 404 when checking out a non-existent task', async () => {
+    const res = await checkoutIssue(
+      app,
+      companyId,
+      '00000000-0000-0000-0000-000000000000',
+      agent1.id,
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/tests/e2e/full-flow.test.ts
+++ b/tests/e2e/full-flow.test.ts
@@ -1,0 +1,257 @@
+/**
+ * E2E: Full orchestrator flow
+ *
+ * Tests the complete happy path:
+ *   company → agents → tasks → checkout → complete → dashboard metrics
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../../apps/cli/src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AgentRow = { id: string; name: string; status: string }
+type IssueRow = {
+  id: string
+  identifier: string
+  title: string
+  status: string
+  assignee_agent_id: string | null
+}
+type DashboardMetrics = {
+  agentCount: number
+  taskCount: number
+  openTasks: number
+  completedTasks: number
+  totalSpendCents: number
+  recentActivity: unknown[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  name = 'Test Corp',
+): Promise<string> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<AgentRow> {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Test Agent', adapter_type: 'process', ...overrides }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: AgentRow }
+  return body.data
+}
+
+async function createIssue(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<IssueRow> {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Test Task', ...overrides }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('E2E: full orchestrator flow', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agent1: AgentRow
+  let agent2: AgentRow
+  let task1: IssueRow
+  let task2: IssueRow
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('step 1 — creates a company via POST /api/companies', async () => {
+    companyId = await createCompany(app, 'Flow Corp')
+    expect(companyId).toBeTruthy()
+  })
+
+  it('step 2 — creates agent1 via POST /api/companies/:id/agents', async () => {
+    agent1 = await createAgent(app, companyId, { name: 'Agent Alpha' })
+    expect(agent1.id).toBeTruthy()
+    expect(agent1.name).toBe('Agent Alpha')
+    expect(agent1.status).toBe('idle')
+  })
+
+  it('step 2 — creates agent2 via POST /api/companies/:id/agents', async () => {
+    agent2 = await createAgent(app, companyId, { name: 'Agent Beta' })
+    expect(agent2.id).toBeTruthy()
+    expect(agent2.name).toBe('Agent Beta')
+  })
+
+  it('step 2 — both agents appear in GET /api/companies/:id/agents', async () => {
+    const res = await app.request(`/api/companies/${companyId}/agents`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: AgentRow[] }
+    expect(body.data.length).toBe(2)
+    const names = body.data.map((a) => a.name)
+    expect(names).toContain('Agent Alpha')
+    expect(names).toContain('Agent Beta')
+  })
+
+  it('step 3 — creates task1 via POST /api/companies/:id/issues', async () => {
+    task1 = await createIssue(app, companyId, { title: 'Implement feature A' })
+    expect(task1.id).toBeTruthy()
+    expect(task1.title).toBe('Implement feature A')
+    expect(task1.status).toBe('backlog')
+    expect(task1.assignee_agent_id).toBeNull()
+  })
+
+  it('step 3 — creates task2 via POST /api/companies/:id/issues', async () => {
+    task2 = await createIssue(app, companyId, { title: 'Write tests for feature A' })
+    expect(task2.id).toBeTruthy()
+    expect(task2.status).toBe('backlog')
+  })
+
+  it('step 4 — agent1 checks out task1 via POST /api/companies/:id/issues/:taskId/checkout', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task1.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agent1.id }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+    expect(body.data.assignee_agent_id).toBe(agent1.id)
+  })
+
+  it('step 4 — agent2 checks out task2 via POST /api/companies/:id/issues/:taskId/checkout', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task2.id}/checkout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agent2.id }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+    expect(body.data.assignee_agent_id).toBe(agent2.id)
+  })
+
+  it('step 5 — inserts heartbeat runs directly into db', async () => {
+    await db.query(
+      `INSERT INTO heartbeat_runs (company_id, agent_id, trigger_type, status)
+       VALUES ($1, $2, 'manual', 'completed'), ($3, $4, 'manual', 'completed')`,
+      [companyId, agent1.id, companyId, agent2.id],
+    )
+
+    const res = await app.request(`/api/companies/${companyId}/heartbeats`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('step 6 — dashboard metrics show 2 agents and 2 open tasks', async () => {
+    const res = await app.request(`/api/companies/${companyId}/dashboard`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: DashboardMetrics }
+
+    expect(body.data.agentCount).toBe(2)
+    expect(body.data.taskCount).toBe(2)
+    // Both tasks are in_progress which is NOT done/cancelled → openTasks = 2
+    expect(body.data.openTasks).toBe(2)
+    expect(body.data.completedTasks).toBe(0)
+    expect(body.data.totalSpendCents).toBe(0)
+  })
+
+  it('step 7 — completes task1 via PATCH /api/companies/:id/issues/:taskId', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task1.id}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('step 7 — completes task2 via PATCH /api/companies/:id/issues/:taskId', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task2.id}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('step 8 — dashboard metrics show 2 completed tasks after completion', async () => {
+    const res = await app.request(`/api/companies/${companyId}/dashboard`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: DashboardMetrics }
+
+    expect(body.data.completedTasks).toBe(2)
+    // done status is excluded from openTasks count
+    expect(body.data.openTasks).toBe(0)
+  })
+
+  it('step 9 — activity log is accessible via GET /api/companies/:id/activity', async () => {
+    const res = await app.request(`/api/companies/${companyId}/activity`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+  })
+
+  it('step 10 — heartbeat detail is accessible via GET /api/companies/:id/heartbeats/:runId', async () => {
+    const listRes = await app.request(`/api/companies/${companyId}/heartbeats`)
+    const listBody = (await listRes.json()) as { data: Array<{ id: string }> }
+    const runId = listBody.data[0].id
+
+    const res = await app.request(`/api/companies/${companyId}/heartbeats/${runId}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { id: string } }
+    expect(body.data.id).toBe(runId)
+  })
+})

--- a/tests/e2e/governance.test.ts
+++ b/tests/e2e/governance.test.ts
@@ -1,0 +1,218 @@
+/**
+ * E2E: Governance — policy enforcement
+ *
+ * Tests policy CRUD and priority ordering:
+ *   company → deny policy → allow policy → verify order
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../../apps/cli/src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PolicyRow = {
+  id: string
+  company_id: string
+  name: string
+  tool_pattern: string
+  action: string
+  priority: number
+  agent_id: string | null
+  max_calls_per_hour: number | null
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Gov Corp'): Promise<string> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createPolicy(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown>,
+): Promise<PolicyRow> {
+  const res = await app.request(`/api/companies/${companyId}/policies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(overrides),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: PolicyRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('E2E: governance — policy enforcement', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let denyPolicyId: string
+  let allowPolicyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app, 'Gov Corp')
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('creates a deny-all policy via POST /api/companies/:id/policies', async () => {
+    const policy = await createPolicy(app, companyId, {
+      name: 'deny-all',
+      tool_pattern: '*',
+      action: 'deny',
+      priority: 10,
+    })
+
+    expect(policy.name).toBe('deny-all')
+    expect(policy.tool_pattern).toBe('*')
+    expect(policy.action).toBe('deny')
+    expect(policy.priority).toBe(10)
+    expect(policy.company_id).toBe(companyId)
+    expect(policy.agent_id).toBeNull()
+
+    denyPolicyId = policy.id
+  })
+
+  it('verifies deny policy appears in GET /api/companies/:id/policies', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PolicyRow[] }
+    expect(body.data.length).toBe(1)
+    expect(body.data[0].id).toBe(denyPolicyId)
+    expect(body.data[0].action).toBe('deny')
+  })
+
+  it('creates an allow policy with higher priority via POST /api/companies/:id/policies', async () => {
+    const policy = await createPolicy(app, companyId, {
+      name: 'allow-web-search',
+      tool_pattern: 'web_search',
+      action: 'allow',
+      priority: 100,
+    })
+
+    expect(policy.name).toBe('allow-web-search')
+    expect(policy.tool_pattern).toBe('web_search')
+    expect(policy.action).toBe('allow')
+    expect(policy.priority).toBe(100)
+
+    allowPolicyId = policy.id
+  })
+
+  it('verifies both policies exist via GET /api/companies/:id/policies', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PolicyRow[] }
+    expect(body.data.length).toBe(2)
+  })
+
+  it('policies are ordered by priority DESC (allow=100 first, deny=10 second)', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PolicyRow[] }
+
+    // Ordered by priority DESC — higher priority first
+    expect(body.data[0].priority).toBeGreaterThan(body.data[1].priority)
+    expect(body.data[0].action).toBe('allow')
+    expect(body.data[1].action).toBe('deny')
+  })
+
+  it('updates the deny policy priority via PATCH /api/companies/:id/policies/:policyId', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/${denyPolicyId}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ priority: 5 }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PolicyRow }
+    expect(body.data.priority).toBe(5)
+  })
+
+  it('returns 404 for PATCH on non-existent policy', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/00000000-0000-0000-0000-000000000000`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ priority: 1 }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('deletes the allow policy via DELETE /api/companies/:id/policies/:policyId', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/${allowPolicyId}`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { deleted: boolean; id: string } }
+    expect(body.data.deleted).toBe(true)
+    expect(body.data.id).toBe(allowPolicyId)
+  })
+
+  it('only deny policy remains after deletion', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PolicyRow[] }
+    expect(body.data.length).toBe(1)
+    expect(body.data[0].id).toBe(denyPolicyId)
+  })
+
+  it('returns 404 for DELETE on non-existent policy', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/policies/00000000-0000-0000-0000-000000000000`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 on POST with missing required fields', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // Missing name, tool_pattern, action
+      body: JSON.stringify({ priority: 5 }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('returns 400 on POST with invalid action value', async () => {
+    const res = await app.request(`/api/companies/${companyId}/policies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'bad-action',
+        tool_pattern: '*',
+        action: 'block', // not a valid PolicyAction
+        priority: 1,
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@shackleai/db': resolve(root, 'packages/db/dist/index.js'),
+      '@shackleai/shared': resolve(root, 'packages/shared/dist/index.js'),
+      '@shackleai/core': resolve(root, 'packages/core/dist/index.js'),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 30000,
+  },
+})


### PR DESCRIPTION
## Summary

- Adds 4 E2E integration test suites at `tests/e2e/` covering the complete orchestrator lifecycle
- Adds `tests/vitest.config.ts` with workspace package alias resolution so the root-level test runner can import `@shackleai/db`, `@shackleai/shared`, and `@shackleai/core` from their built `dist/` outputs
- Adds `test:e2e` script to root `package.json` for running the suite directly: `pnpm test:e2e`

### Test coverage added (48 tests across 4 files)

**`tests/e2e/full-flow.test.ts`** (15 tests) — complete orchestrator happy path
- Company creation → 2 agents → 2 tasks → checkout by each agent → heartbeat insertion → dashboard metrics → task completion → final metrics verification → activity log access → heartbeat detail access

**`tests/e2e/governance.test.ts`** (12 tests) — policy CRUD and enforcement
- Create deny-all policy → verify → create allow policy with higher priority → verify both exist → verify ordering by `priority DESC` → PATCH priority → DELETE → validation error cases

**`tests/e2e/budget.test.ts`** (13 tests) — cost tracking and aggregation
- Company with budget (`1000 cents`) → agents with budgets → 3 cost events across 2 agents → verify `GET /costs` list → verify `GET /costs/by-agent` aggregation (totals, token sums, event counts) → dashboard `totalSpendCents` → date range filter → validation error cases

**`tests/e2e/concurrent-checkout.test.ts`** (8 tests) — conflict resolution
- Sequential checkout returns 200 then 409 → ownership verified on conflict → `Promise.all` concurrent checkout: exactly one 200 + one 409 → agents can hold different tasks simultaneously → same-agent re-checkout blocked → release-and-reclaim flow → 404 on unknown task

## Test plan

- [x] `pnpm build` — 5 tasks successful
- [x] `pnpm lint` — 8 tasks successful, zero warnings
- [x] `pnpm typecheck` — 8 tasks successful
- [x] `pnpm test:e2e` — 48/48 tests pass across 4 suites

Closes #18

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)