### PR TITLE
Phase 8: Set up GitHub Actions CI/CD and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a reproducible bug in the ShackleAI Orchestrator
+title: "bug: "
+labels: "type:bug"
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Run `...`
+2. See error `...`
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include the full error message and stack trace if available.
+
+## Environment
+
+- OS: [e.g. macOS 14, Ubuntu 22.04, Windows 11]
+- Node.js version: [e.g. 20.11.0]
+- pnpm version: [e.g. 10.32.1]
+- `@shackleai/orchestrator` version: [e.g. 0.1.0]
+
+## Additional Context
+
+Add any other context, logs, or screenshots about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for the ShackleAI Orchestrator
+title: "feat: "
+labels: "type:feature"
+---
+
+## Problem Statement
+
+A clear and concise description of the problem this feature would solve.
+For example: "I'm always frustrated when..."
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you have considered.
+
+## Additional Context
+
+Add any other context, mockups, or examples about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+-
+-
+-
+
+## Test Plan
+
+- [ ] `pnpm lint` passes with zero warnings
+- [ ] `pnpm typecheck` passes with no errors
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm test` passes
+- [ ] Tested manually (describe steps below)
+
+**Manual test steps:**
+
+1.
+2.
+
+## Related Issues
+
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: CI (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20, 22]
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm turbo typecheck
+
+      - name: Lint
+        run: pnpm turbo lint
+
+      - name: Test
+        run: pnpm turbo test
+
+      - name: Build
+        run: pnpm turbo build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish packages to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm turbo build
+
+      - name: Publish @shackleai/shared
+        run: pnpm publish --filter @shackleai/shared --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @shackleai/db
+        run: pnpm publish --filter @shackleai/db --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @shackleai/core
+        run: pnpm publish --filter @shackleai/core --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @shackleai/orchestrator
+        run: pnpm publish --filter @shackleai/orchestrator --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              generate_release_notes: true,
+              draft: false,
+              prerelease: tag.includes('-'),
+            });


### PR DESCRIPTION
## Summary

- Add `ci.yml` — runs typecheck, lint, test, and build on PRs to main across Node 20 and 22 matrix
- Add `publish.yml` — publishes `@shackleai/shared`, `@shackleai/db`, `@shackleai/core`, and `@shackleai/orchestrator` to npm in dependency order on tag push (`v*`)
- Add `release.yml` — creates a GitHub Release with auto-generated notes on tag push
- Add issue templates for bug reports and feature requests with frontmatter labels
- Add pull request template with summary, test plan checklist, and issue reference section

## Test Plan

- [ ] Push a PR to main and verify CI workflow triggers on Node 20 and 22
- [ ] Push a `v*` tag and verify publish workflow runs packages in correct order (shared → db → core → orchestrator)
- [ ] Push a `v*` tag and verify a GitHub Release is created with auto-generated notes
- [ ] Verify issue templates appear in the GitHub "New Issue" picker
- [ ] Verify PR template loads when opening a new pull request

## Notes

- pnpm version pinned to `10.32.1` (from `packageManager` field in root `package.json`)
- `dashboard` app is excluded from publish — it is private and has no npm publish config
- `--no-git-checks` flag used in publish steps to work correctly in CI detached HEAD state
- `--access public` flag ensures scoped packages are published publicly on first publish

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)