### PR TITLE
Phase 8: Prepare all packages for npm publish

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,8 +1,27 @@
 {
   "name": "@shackleai/orchestrator",
-  "version": "0.0.0",
-  "description": "CLI for ShackleAI agent orchestrator",
+  "version": "0.1.0",
+  "description": "The open-source AI agent orchestrator — run, manage, and coordinate Claude Code agents from the command line",
+  "keywords": [
+    "ai",
+    "agent",
+    "orchestrator",
+    "shackleai",
+    "cli",
+    "claude",
+    "mcp",
+    "model-context-protocol",
+    "automation",
+    "devtools"
+  ],
+  "author": "ShackleAI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shackleai/orchestrator",
+    "directory": "apps/cli"
+  },
+  "homepage": "https://github.com/shackleai/orchestrator",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,9 +30,16 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc --build",
@@ -21,7 +47,6 @@
     "lint": "eslint src/",
     "test": "vitest run --passWithNoTests"
   },
-  "files": ["dist"],
   "dependencies": {
     "@clack/prompts": "^0.10.0",
     "@hono/node-server": "^1.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,16 +1,41 @@
 {
   "name": "@shackleai/core",
-  "version": "0.0.0",
-  "description": "Core orchestration engine for ShackleAI",
+  "version": "0.1.0",
+  "description": "Core orchestration engine for ShackleAI — agent lifecycle, task scheduling, governance, and MCP integration",
+  "keywords": [
+    "ai",
+    "agent",
+    "orchestrator",
+    "shackleai",
+    "core",
+    "mcp",
+    "model-context-protocol",
+    "task-scheduling",
+    "governance"
+  ],
+  "author": "ShackleAI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shackleai/orchestrator",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/shackleai/orchestrator",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc --build",
@@ -18,9 +43,6 @@
     "lint": "eslint src/",
     "test": "vitest run"
   },
-  "files": [
-    "dist"
-  ],
   "dependencies": {
     "@shackleai/db": "workspace:*",
     "@shackleai/shared": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,16 +1,39 @@
 {
   "name": "@shackleai/db",
-  "version": "0.0.0",
-  "description": "Database layer for ShackleAI orchestrator",
+  "version": "0.1.0",
+  "description": "Database layer for the ShackleAI agent orchestrator — SQLite and PostgreSQL providers",
+  "keywords": [
+    "ai",
+    "agent",
+    "orchestrator",
+    "shackleai",
+    "database",
+    "sqlite",
+    "postgres"
+  ],
+  "author": "ShackleAI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shackleai/orchestrator",
+    "directory": "packages/db"
+  },
+  "homepage": "https://github.com/shackleai/orchestrator",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc --build",
@@ -18,7 +41,6 @@
     "lint": "eslint src/",
     "test": "vitest run"
   },
-  "files": ["dist"],
   "dependencies": {
     "@electric-sql/pglite": "^0.2.17",
     "pg": "^8.16.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,16 +1,39 @@
 {
   "name": "@shackleai/shared",
-  "version": "0.0.0",
-  "description": "Shared types, utilities, and constants for ShackleAI",
+  "version": "0.1.0",
+  "description": "Shared types, utilities, and constants for the ShackleAI agent orchestrator",
+  "keywords": [
+    "ai",
+    "agent",
+    "orchestrator",
+    "shackleai",
+    "shared",
+    "types",
+    "utilities"
+  ],
+  "author": "ShackleAI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shackleai/orchestrator",
+    "directory": "packages/shared"
+  },
+  "homepage": "https://github.com/shackleai/orchestrator",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc --build",
@@ -18,9 +41,6 @@
     "lint": "eslint src/",
     "test": "vitest run --passWithNoTests"
   },
-  "files": [
-    "dist"
-  ],
   "dependencies": {
     "zod": "^3.24.0"
   }


### PR DESCRIPTION
## Summary

- Bumps version from `0.0.0` to `0.1.0` across all 4 public packages (`@shackleai/shared`, `@shackleai/db`, `@shackleai/core`, `@shackleai/orchestrator`)
- Adds all required npm publish metadata: `keywords`, `author`, `repository`, `homepage`, `publishConfig: { access: "public" }`
- Updates `exports` map on all packages to include `"default"` condition alongside `import` and `types`
- Preserves `"private": true` on `shackleai-dashboard`

## Verification

- `pnpm build` — 5/5 packages build successfully, all versions reported as `0.1.0`
- `pnpm pack --dry-run` run in each public package — output contains only `dist/` files and `package.json`, no `src/`, `tests/`, or `node_modules/`
- Dependency chain confirmed: `@shackleai/orchestrator` -> `@shackleai/core` -> `@shackleai/db` -> `@shackleai/shared`
- `tsconfig.json` files inherit `declaration: true`, `declarationMap: true`, `composite: true` from root — no changes required

## Test plan

- [ ] CI lint passes
- [ ] CI build passes (all 5 packages)
- [ ] CI typecheck passes
- [ ] Dry-run pack for each public package shows only `dist/` + `package.json`
- [ ] Dashboard package still has `"private": true`

Closes #23

---
Generated with [Claude Code](https://claude.com/claude-code)