### PR TITLE
Phase 8: Write hero README and all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,220 @@
+# ShackleAI Orchestrator
+
+**The Operating System for AI Agents** — an open-source orchestrator that gives your AI workforce a company org chart, a task tracker, a policy engine, and a cost ledger.
+
+```
+npx @shackleai/orchestrator init
+```
+
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@shackleai/orchestrator)](https://www.npmjs.com/package/@shackleai/orchestrator)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18.12-brightgreen)](https://nodejs.org)
+
+---
+
+## What is it?
+
+ShackleAI Orchestrator gives structure to multi-agent systems. Instead of wiring agents together with ad-hoc scripts, you declare them like employees: they have roles, report to one another, pick up tasks from a shared backlog, check in via heartbeats, and operate under governance policies that control what tools they can call.
+
+Everything is stored locally in an embedded database — no cloud account required.
+
+---
+
+## Quickstart
+
+**Prerequisites:** Node.js 18.12+
+
+```bash
+# Initialize a new orchestrator (interactive wizard)
+npx @shackleai/orchestrator init
+
+# Start the local API server (default port 4800)
+npx @shackleai/orchestrator start
+
+# Run diagnostics
+npx @shackleai/orchestrator doctor
+```
+
+The `init` wizard asks three questions: deployment mode (local embedded database or external PostgreSQL), company name, and whether to create a first agent. It writes a config file to `~/.shackleai/config.json` and runs all database migrations automatically.
+
+---
+
+## Features
+
+| Feature | What it does |
+|---|---|
+| **Companies** | Organizational units — each has its own agent pool, task backlog, and monthly budget |
+| **Agents** | AI workers with roles (`ceo`, `manager`, `worker`), org-chart hierarchy, and heartbeat tracking |
+| **Tasks** | GitHub-style issue tracker — auto-numbered identifiers (e.g. `ACME-42`), priorities, status lifecycle |
+| **Heartbeats** | Scheduled (cron) and on-demand agent wakeups with full run history and stdout capture |
+| **Governance** | Default-deny policy engine — glob-pattern tool access control with priority resolution |
+| **Budgets** | Monthly token cost budgets per agent and per company — soft alert at 80%, hard stop at 100% |
+| **Adapters** | Six execution backends: Process, HTTP webhook, Claude Code CLI, MCP, OpenClaw, CrewAI |
+| **REST API** | Full Hono-based HTTP API served locally — queryable by agents and dashboards |
+| **Activity Log** | Immutable audit trail of every entity change |
+
+---
+
+## Architecture
+
+```
+npx @shackleai/orchestrator init
+         |
+         v
+  ~/.shackleai/config.json
+         |
+         v
+npx @shackleai/orchestrator start
+         |
+         v
++--------------------------------+
+|   Hono HTTP API (port 4800)    |
+|  /api/companies/:id/agents     |
+|  /api/companies/:id/issues     |
+|  /api/companies/:id/policies   |
+|  /api/companies/:id/costs      |
+|  /api/companies/:id/heartbeats |
++--------------------------------+
+         |
+         v
++------------------------+   +------------------+
+|   GovernanceEngine     |   |   CostTracker    |
+|   (default-deny,       |   |   (per-agent     |
+|    glob patterns)      |   |    budget ledger)|
++------------------------+   +------------------+
+         |
+         v
++--------------------------------------------+
+|              Scheduler                     |
+|  cron schedules + on-demand wakeups        |
+|  coalescing: skips if agent already runs   |
++--------------------------------------------+
+         |
+         v
++--------------------------------------------------+
+|               Adapter Layer                      |
+| Process | HTTP | Claude | MCP | OpenClaw | CrewAI|
++--------------------------------------------------+
+         |
+         v
++-----------------------------------+
+|   @shackleai/db                   |
+|   PGlite (local) or PostgreSQL    |
+|   12 migrations, fully typed      |
++-----------------------------------+
+```
+
+**Monorepo packages:**
+
+| Package | npm | Purpose |
+|---|---|---|
+| `apps/cli` | `@shackleai/orchestrator` | CLI entrypoint — `npx` |
+| `packages/core` | `@shackleai/core` | Adapters, governance, scheduler, cost tracker |
+| `packages/db` | `@shackleai/db` | Database layer, migrations, PGlite + PostgreSQL |
+| `packages/shared` | `@shackleai/shared` | TypeScript types, constants, Zod validators |
+
+---
+
+## Comparison
+
+| Capability | DIY Scripts | LangChain | CrewAI | AutoGen | ShackleAI Orchestrator |
+|---|---|---|---|---|---|
+| Multi-agent task routing | Manual | Via chains | Yes | Yes | Yes |
+| Org-chart hierarchy | No | No | Roles only | No | Yes (CEO / Manager / Worker) |
+| Governance (tool access control) | No | No | No | No | Yes — default-deny |
+| Monthly cost budgets | No | No | No | No | Yes — per agent + company |
+| Heartbeat scheduling (cron) | Manual | No | No | No | Yes |
+| Local-first (no cloud account) | Yes | Partial | No | No | Yes |
+| REST API for agents to query | No | No | No | No | Yes |
+| Audit log | No | No | No | No | Yes |
+| Open source (MIT) | N/A | Yes | Yes | Yes | Yes |
+
+---
+
+## Deployment modes
+
+**Local** — uses an embedded PGlite database. No external dependencies. Data lives in your working directory. Perfect for single-machine setups and development.
+
+**Server** — connects to an external PostgreSQL database. Use this for production or multi-machine setups.
+
+```bash
+# Local mode (default)
+npx @shackleai/orchestrator init
+# Select "Local" when prompted
+
+# Server mode
+npx @shackleai/orchestrator init
+# Select "Server" and enter DATABASE_URL
+```
+
+---
+
+## CLI Reference
+
+```bash
+shackleai init                   # Interactive setup wizard
+shackleai start [--port 4800]    # Start the API server
+
+shackleai agent list             # List all agents
+shackleai agent create           # Create a new agent (interactive)
+shackleai agent pause <id>       # Pause an agent
+shackleai agent resume <id>      # Resume a paused agent
+shackleai agent terminate <id>   # Terminate an agent
+
+shackleai task list              # List all tasks
+shackleai task create            # Create a task (interactive)
+shackleai task assign <taskId> <agentId>   # Assign task to agent
+shackleai task complete <taskId>           # Mark task as done
+
+shackleai run <agentId>          # Trigger on-demand agent wakeup
+shackleai doctor                 # Run diagnostics
+shackleai upgrade [--key <key>]  # Activate license key
+shackleai upgrade --status       # Show license status
+```
+
+---
+
+## Upgrade
+
+```bash
+# Check current version
+npx @shackleai/orchestrator --version
+
+# Upgrade to the latest version
+npx @shackleai/orchestrator@latest start
+```
+
+---
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — 5-minute tutorial
+- [Concepts](docs/concepts.md) — Companies, agents, tasks, heartbeats, governance, budgets
+- [Adapters](docs/adapters.md) — Process, HTTP, Claude, MCP adapter guide
+- [Governance](docs/governance.md) — Policy engine and tool access control
+- [API Reference](docs/api-reference.md) — Full REST API with curl examples
+- [CLI Reference](docs/cli-reference.md) — All CLI commands
+- [Configuration](docs/configuration.md) — Config file, env vars, deployment modes
+- [Deployment](docs/deployment.md) — Local, Docker, VPS, cloud
+- [FAQ](docs/faq.md) — Common questions
+
+---
+
+## Contributing
+
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+**Quick setup:**
+
+```bash
+git clone https://github.com/shackleai/orchestrator.git
+cd orchestrator
+pnpm install
+pnpm build && pnpm test
+```
+
+---
+
+## License
+
+[MIT](LICENSE) — Copyright (c) 2026 shackleai

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,299 @@
+# Adapters
+
+An **Adapter** is how the orchestrator executes an agent heartbeat. When a heartbeat fires — by cron schedule or on-demand — the adapter takes over: it runs a subprocess, calls a webhook, invokes Claude, or connects to an MCP server. Every adapter returns a standardized `AdapterResult`.
+
+---
+
+## Adapter interface
+
+Every adapter implements:
+
+```typescript
+interface AdapterModule {
+  type: string                       // e.g. 'process', 'claude'
+  label: string                      // Display label
+  execute(ctx: AdapterContext): Promise<AdapterResult>
+  testEnvironment?(): Promise<{ ok: boolean; error?: string }>
+}
+```
+
+The `AdapterContext` passed to `execute` contains:
+
+| Field | Description |
+|---|---|
+| `agentId` | UUID of the agent |
+| `companyId` | UUID of the company |
+| `heartbeatRunId` | UUID of this run — useful for callback |
+| `task` | Optional task ID if the agent was given one |
+| `adapterConfig` | The adapter-specific config from the agent record |
+| `env` | Environment variables to inject |
+| `sessionState` | Optional carry-over session state from previous run |
+
+The `AdapterResult` returned:
+
+| Field | Description |
+|---|---|
+| `exitCode` | 0 = success, non-zero = failure, 124 = timeout |
+| `stdout` | Captured standard output |
+| `stderr` | Captured standard error |
+| `sessionState` | Optional state to carry forward to next run |
+| `usage` | Optional token usage: `inputTokens`, `outputTokens`, `costCents`, `model`, `provider` |
+
+---
+
+## Process adapter
+
+**Type:** `process`
+
+Spawns any executable as a subprocess. The simplest adapter — use it for shell scripts, Python programs, or any language runtime.
+
+**Config:**
+
+| Key | Required | Description |
+|---|---|---|
+| `command` | Yes | Executable to run (e.g. `python3`, `node`, `./my-agent.sh`) |
+| `args` | No | Array of arguments |
+| `timeout` | No | Timeout in seconds (default: 300) |
+| `cron` | No | Cron expression for scheduled runs |
+
+**Injected environment variables:**
+
+| Variable | Value |
+|---|---|
+| `SHACKLEAI_RUN_ID` | Heartbeat run UUID |
+| `SHACKLEAI_AGENT_ID` | Agent UUID |
+| `SHACKLEAI_TASK_ID` | Task ID (if assigned) |
+| `SHACKLEAI_API_KEY` | Agent API key (if present in env) |
+| `SHACKLEAI_SESSION_STATE` | Session state from previous run (if any) |
+
+**Example config:**
+
+```json
+{
+  "adapter_type": "process",
+  "adapter_config": {
+    "command": "python3",
+    "args": ["/home/user/agents/my-agent.py"],
+    "timeout": 120,
+    "cron": "*/10 * * * *"
+  }
+}
+```
+
+**Create via API:**
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "data-agent",
+    "role": "worker",
+    "adapter_type": "process",
+    "adapter_config": {
+      "command": "python3",
+      "args": ["/path/to/agent.py"],
+      "cron": "0 * * * *"
+    }
+  }'
+```
+
+**Graceful termination:** Process adapter sends SIGTERM first, waits 5 seconds, then sends SIGKILL. Exit code 124 means the process was killed for timeout.
+
+---
+
+## HTTP adapter
+
+**Type:** `http`
+
+Sends a POST request to a webhook URL. Use this when your agent logic lives behind an HTTP endpoint — a Lambda function, a Fly.io app, or a local service.
+
+**Config:**
+
+| Key | Required | Description |
+|---|---|---|
+| `url` | Yes | Webhook URL to POST to |
+| `headers` | No | Additional HTTP headers |
+| `authToken` | No | Bearer token — sent as `Authorization: Bearer <token>` |
+| `timeout` | No | Timeout in seconds (default: 300) |
+| `cron` | No | Cron expression |
+
+**Request payload** (sent as JSON body):
+
+```json
+{
+  "agentId": "uuid...",
+  "companyId": "uuid...",
+  "heartbeatRunId": "uuid...",
+  "task": "task-id or null",
+  "sessionState": "state string or null"
+}
+```
+
+**Response:** The endpoint should return a 200 response. If it returns a JSON body with a `__shackleai_result__` key, the orchestrator extracts `sessionState` and `usage` from it:
+
+```json
+{
+  "__shackleai_result__": {
+    "sessionState": "optional carry-forward state",
+    "usage": {
+      "inputTokens": 1500,
+      "outputTokens": 300,
+      "costCents": 4,
+      "model": "gpt-4o",
+      "provider": "openai"
+    }
+  }
+}
+```
+
+**Example config:**
+
+```json
+{
+  "adapter_type": "http",
+  "adapter_config": {
+    "url": "https://my-agent.example.com/heartbeat",
+    "authToken": "my-secret-token",
+    "timeout": 60,
+    "cron": "*/5 * * * *"
+  }
+}
+```
+
+---
+
+## Claude adapter
+
+**Type:** `claude`
+
+Invokes the Claude Code CLI (`claude`) to run a prompt. The orchestrator spawns `claude --print <prompt>` and captures the output.
+
+**Requirements:** The `claude` CLI must be installed and available in PATH. Install it from [claude.ai/code](https://claude.ai/code).
+
+**Config:**
+
+| Key | Required | Description |
+|---|---|---|
+| `prompt` | Yes | The prompt to run |
+| `model` | No | Model name (e.g. `claude-opus-4-5`) — sets `CLAUDE_MODEL` env var |
+| `timeout` | No | Timeout in seconds (default: 300) |
+| `cron` | No | Cron expression |
+
+**Injected environment variables** (in addition to the standard SHACKLEAI_* vars):
+
+| Variable | Value |
+|---|---|
+| `CLAUDE_MODEL` | Model name from config (if set) |
+
+**Result parsing:** The adapter looks for a `__shackleai_result__` JSON block anywhere in stdout. If found, it extracts `sessionState` and `usage`. Your Claude agent scripts can emit this block to report token usage back to the orchestrator.
+
+**Example config:**
+
+```json
+{
+  "adapter_type": "claude",
+  "adapter_config": {
+    "prompt": "You are a code review agent. Check the latest PR and leave a comment.",
+    "model": "claude-opus-4-5",
+    "timeout": 180,
+    "cron": "0 9 * * 1-5"
+  }
+}
+```
+
+**Verify the environment:**
+
+```bash
+npx @shackleai/orchestrator doctor
+# The doctor command checks if the claude CLI is reachable
+```
+
+---
+
+## MCP adapter
+
+**Type:** `mcp`
+
+Connects to an HTTP-based MCP (Model Context Protocol) server and calls a named tool. Uses `@modelcontextprotocol/sdk` under the hood.
+
+**Config:**
+
+| Key | Required | Description |
+|---|---|---|
+| `url` | Yes | MCP server URL |
+| `toolName` | Yes | Name of the MCP tool to call |
+| `toolParams` | No | Parameters to pass to the tool |
+| `timeout` | No | Timeout in seconds (default: 300) |
+| `cron` | No | Cron expression |
+
+**Context enrichment:** The adapter automatically appends a `_shackleai` object to `toolParams` containing the run context:
+
+```json
+{
+  "_shackleai": {
+    "agentId": "uuid...",
+    "companyId": "uuid...",
+    "heartbeatRunId": "uuid...",
+    "task": "task-id or null",
+    "sessionState": "state or null"
+  }
+}
+```
+
+**Example config:**
+
+```json
+{
+  "adapter_type": "mcp",
+  "adapter_config": {
+    "url": "http://localhost:3001/mcp",
+    "toolName": "run_agent_step",
+    "toolParams": {
+      "agent_persona": "code_reviewer"
+    },
+    "timeout": 120,
+    "cron": "*/15 * * * *"
+  }
+}
+```
+
+---
+
+## OpenClaw adapter
+
+**Type:** `openclaw`
+
+Integration with the OpenClaw agent framework. Configuration details are framework-specific — see the OpenClaw documentation for the expected `adapter_config` shape.
+
+---
+
+## CrewAI adapter
+
+**Type:** `crewai`
+
+Integration with CrewAI crews. Configuration details are CrewAI-specific — see the CrewAI documentation for the expected `adapter_config` shape.
+
+---
+
+## Adapter selection guide
+
+| Use case | Adapter |
+|---|---|
+| Shell script or any language | `process` |
+| Existing HTTP service | `http` |
+| Claude Code CLI agent | `claude` |
+| MCP-compatible tool server | `mcp` |
+| OpenClaw-based agent | `openclaw` |
+| CrewAI crew | `crewai` |
+
+---
+
+## Timeout and exit codes
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Generic failure |
+| `124` | Killed by timeout (SIGTERM → SIGKILL) |
+| `127` | Executable not found (process/claude adapters) |
+| Any other | Subprocess-specific exit code |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,617 @@
+# API Reference
+
+The ShackleAI Orchestrator exposes a local REST API on `http://localhost:4800` (or the port specified with `--port`). The API is built with [Hono](https://hono.dev) and uses JSON throughout.
+
+---
+
+## Base URL
+
+```
+http://localhost:4800
+```
+
+---
+
+## Response envelope
+
+All responses use a consistent envelope:
+
+**Success:**
+
+```json
+{ "data": <payload> }
+```
+
+**Error:**
+
+```json
+{ "error": "Human-readable message", "details": { ... } }
+```
+
+---
+
+## Error codes
+
+| HTTP Status | Meaning |
+|---|---|
+| `400` | Validation failed — check `details` for field-level errors |
+| `401` | Unauthorized — missing or invalid Bearer token |
+| `404` | Resource not found |
+| `409` | Conflict — e.g. task already checked out by another agent |
+| `500` | Internal server error |
+
+---
+
+## Authentication
+
+Most endpoints do not require authentication in the default local deployment. The `agentAuth` middleware is available for endpoints that should only be callable with an agent API key.
+
+To generate an agent API key:
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/api-keys \
+  -H "Content-Type: application/json" \
+  -d '{ "label": "my-agent-key" }'
+```
+
+The response includes a `key` field — this is the only time the plain key is returned. Store it securely.
+
+To use an API key:
+
+```
+Authorization: Bearer <key>
+```
+
+---
+
+## Health
+
+### GET /api/health
+
+Check if the server is running.
+
+**Response:**
+
+```json
+{ "status": "ok", "version": "0.1.0" }
+```
+
+**Example:**
+
+```bash
+curl http://localhost:4800/api/health
+```
+
+---
+
+## Companies
+
+### GET /api/companies
+
+List all companies.
+
+```bash
+curl http://localhost:4800/api/companies
+```
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "Acme Corp",
+      "description": null,
+      "status": "active",
+      "issue_prefix": "ACME",
+      "issue_counter": 5,
+      "budget_monthly_cents": 0,
+      "spent_monthly_cents": 1240,
+      "created_at": "2026-03-01T00:00:00Z",
+      "updated_at": "2026-03-16T12:00:00Z"
+    }
+  ]
+}
+```
+
+### POST /api/companies
+
+Create a company.
+
+**Body:**
+
+```json
+{
+  "name": "Acme Corp",
+  "description": "Optional description",
+  "issue_prefix": "ACME",
+  "budget_monthly_cents": 1000
+}
+```
+
+```bash
+curl -X POST http://localhost:4800/api/companies \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Acme Corp", "issue_prefix": "ACME" }'
+```
+
+### GET /api/companies/:id
+
+Get a company by ID.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}
+```
+
+### PATCH /api/companies/:id
+
+Update a company.
+
+```bash
+curl -X PATCH http://localhost:4800/api/companies/${COMPANY_ID} \
+  -H "Content-Type: application/json" \
+  -d '{ "budget_monthly_cents": 5000 }'
+```
+
+---
+
+## Dashboard
+
+### GET /api/companies/:id/dashboard
+
+Get aggregate metrics for a company.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/dashboard
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "agentCount": 3,
+    "taskCount": 42,
+    "openTasks": 8,
+    "completedTasks": 34,
+    "totalSpendCents": 4820,
+    "recentActivity": [...]
+  }
+}
+```
+
+---
+
+## Agents
+
+### GET /api/companies/:id/agents
+
+List all agents for a company.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/agents
+```
+
+### POST /api/companies/:id/agents
+
+Create an agent.
+
+**Required fields:** `name`, `adapter_type`
+
+**Optional fields:** `title`, `role` (default: `worker`), `reports_to`, `capabilities`, `adapter_config`, `budget_monthly_cents` (default: 0)
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "coder-bot",
+    "title": "Senior Engineer",
+    "role": "worker",
+    "adapter_type": "process",
+    "adapter_config": {
+      "command": "python3",
+      "args": ["/path/to/agent.py"],
+      "cron": "*/5 * * * *"
+    },
+    "budget_monthly_cents": 2000
+  }'
+```
+
+**Response:** `201 Created` with the created agent object.
+
+### GET /api/companies/:id/agents/:agentId
+
+Get a single agent.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}
+```
+
+### PATCH /api/companies/:id/agents/:agentId
+
+Update an agent.
+
+```bash
+curl -X PATCH http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID} \
+  -H "Content-Type: application/json" \
+  -d '{ "title": "Lead Engineer", "budget_monthly_cents": 3000 }'
+```
+
+### POST /api/companies/:id/agents/:agentId/pause
+
+Set agent status to `paused`.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/pause
+```
+
+### POST /api/companies/:id/agents/:agentId/resume
+
+Set agent status back to `idle`.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/resume
+```
+
+### POST /api/companies/:id/agents/:agentId/terminate
+
+Set agent status to `terminated`. This is irreversible via API.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/terminate
+```
+
+### POST /api/companies/:id/agents/:agentId/wakeup
+
+Trigger an on-demand heartbeat. Updates `last_heartbeat_at` to now.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/wakeup
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "agent": { ...agent object... },
+    "triggered": true
+  }
+}
+```
+
+### POST /api/companies/:id/agents/:agentId/api-keys
+
+Generate an API key for an agent. The plain key is returned once and never stored.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents/${AGENT_ID}/api-keys \
+  -H "Content-Type: application/json" \
+  -d '{ "label": "production-key" }'
+```
+
+**Response:** `201 Created`
+
+```json
+{
+  "data": {
+    "id": "uuid",
+    "agent_id": "uuid",
+    "company_id": "uuid",
+    "label": "production-key",
+    "status": "active",
+    "key": "64-char-hex-string",
+    "last_used_at": null,
+    "created_at": "2026-03-16T12:00:00Z"
+  }
+}
+```
+
+---
+
+## Tasks (Issues)
+
+### GET /api/companies/:id/issues
+
+List tasks. Supports query filters:
+
+| Query param | Description |
+|---|---|
+| `status` | Filter by status (e.g. `in_progress`) |
+| `priority` | Filter by priority (e.g. `high`) |
+| `assignee` | Filter by assignee agent ID |
+
+```bash
+curl "http://localhost:4800/api/companies/${COMPANY_ID}/issues?status=in_progress"
+curl "http://localhost:4800/api/companies/${COMPANY_ID}/issues?priority=critical&status=todo"
+```
+
+### POST /api/companies/:id/issues
+
+Create a task. Identifiers are auto-generated (`ACME-1`, `ACME-2`, ...).
+
+**Required:** `title`
+
+**Optional:** `description`, `priority` (default: `medium`), `status` (default: `backlog`), `parent_id`, `goal_id`, `project_id`, `assignee_agent_id`
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/issues \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Implement feature X",
+    "description": "Detailed description",
+    "priority": "high"
+  }'
+```
+
+**Response:** `201 Created` with the issue object, including the generated `identifier`.
+
+### GET /api/companies/:id/issues/:issueId
+
+Get a single task.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID}
+```
+
+### PATCH /api/companies/:id/issues/:issueId
+
+Update a task's fields.
+
+```bash
+curl -X PATCH http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID} \
+  -H "Content-Type: application/json" \
+  -d '{ "status": "done" }'
+```
+
+### POST /api/companies/:id/issues/:issueId/checkout
+
+Atomically claim a task. Only succeeds if the task is unassigned and in `backlog` or `todo` status. Returns `409` if already claimed.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID}/checkout \
+  -H "Content-Type: application/json" \
+  -d '{ "agent_id": "'${AGENT_ID}'" }'
+```
+
+### POST /api/companies/:id/issues/:issueId/release
+
+Unassign a task and set its status back to `todo`.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID}/release
+```
+
+### POST /api/companies/:id/issues/:issueId/comments
+
+Add a comment to a task.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID}/comments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Starting work on this task.",
+    "author_agent_id": "'${AGENT_ID}'"
+  }'
+```
+
+### GET /api/companies/:id/issues/:issueId/comments
+
+List comments on a task, ordered by creation time.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/issues/${ISSUE_ID}/comments
+```
+
+---
+
+## Policies
+
+### GET /api/companies/:id/policies
+
+List all policies, ordered by priority descending.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/policies
+```
+
+### POST /api/companies/:id/policies
+
+Create a policy.
+
+**Required:** `name`, `tool_pattern`, `action`, `priority`
+
+**Optional:** `agent_id` (null = company-wide), `max_calls_per_hour`
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "allow-github",
+    "tool_pattern": "github:*",
+    "action": "allow",
+    "priority": 10
+  }'
+```
+
+### PATCH /api/companies/:id/policies/:policyId
+
+Update a policy.
+
+```bash
+curl -X PATCH http://localhost:4800/api/companies/${COMPANY_ID}/policies/${POLICY_ID} \
+  -H "Content-Type: application/json" \
+  -d '{ "priority": 20 }'
+```
+
+### DELETE /api/companies/:id/policies/:policyId
+
+Delete a policy.
+
+```bash
+curl -X DELETE http://localhost:4800/api/companies/${COMPANY_ID}/policies/${POLICY_ID}
+```
+
+**Response:**
+
+```json
+{ "data": { "deleted": true, "id": "uuid" } }
+```
+
+---
+
+## Costs
+
+### GET /api/companies/:id/costs
+
+List cost events. Supports optional date range filters:
+
+| Query param | Format | Description |
+|---|---|---|
+| `from` | ISO 8601 | Start of date range |
+| `to` | ISO 8601 | End of date range |
+
+```bash
+curl "http://localhost:4800/api/companies/${COMPANY_ID}/costs?from=2026-03-01&to=2026-03-31"
+```
+
+### GET /api/companies/:id/costs/by-agent
+
+Get costs aggregated by agent.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/costs/by-agent
+```
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "agent_id": "uuid",
+      "total_cost_cents": 4820,
+      "total_input_tokens": 150000,
+      "total_output_tokens": 35000,
+      "event_count": 42
+    }
+  ]
+}
+```
+
+### POST /api/companies/:id/costs/events
+
+Record a cost event manually (e.g. from an HTTP adapter that tracks its own token usage).
+
+**Required:** `input_tokens`, `output_tokens`, `cost_cents`
+
+**Optional:** `agent_id`, `issue_id`, `provider`, `model`
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/costs/events \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "'${AGENT_ID}'",
+    "provider": "anthropic",
+    "model": "claude-opus-4-5",
+    "input_tokens": 2500,
+    "output_tokens": 400,
+    "cost_cents": 12
+  }'
+```
+
+---
+
+## Heartbeats
+
+### GET /api/companies/:id/heartbeats
+
+List all heartbeat runs, most recent first.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/heartbeats
+```
+
+### GET /api/companies/:id/heartbeats/:runId
+
+Get a single heartbeat run by ID.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/heartbeats/${RUN_ID}
+```
+
+**Response fields:**
+
+| Field | Description |
+|---|---|
+| `status` | `queued` / `running` / `success` / `failed` / `timeout` |
+| `trigger_type` | `cron` / `manual` / `event` / `api` |
+| `exit_code` | 0 = success, 124 = timeout |
+| `stdout_excerpt` | First 4000 chars of stdout |
+| `error` | Error message if failed |
+| `usage_json` | Token usage if reported by adapter |
+
+---
+
+## Activity
+
+### GET /api/companies/:id/activity
+
+List activity log entries, most recent first.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/activity
+```
+
+---
+
+## Goals
+
+### GET /api/companies/:id/goals
+
+List goals.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/goals
+```
+
+### POST /api/companies/:id/goals
+
+Create a goal.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/goals \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Ship v1.0",
+    "level": "strategic",
+    "description": "Launch the first stable release"
+  }'
+```
+
+---
+
+## Projects
+
+### GET /api/companies/:id/projects
+
+List projects.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/projects
+```
+
+### POST /api/companies/:id/projects
+
+Create a project.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/projects \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "API v2",
+    "description": "Redesign the API layer",
+    "target_date": "2026-06-01"
+  }'
+```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,306 @@
+# CLI Reference
+
+The `shackleai` CLI is installed via `npm` / `npx` as `@shackleai/orchestrator`. All commands connect to the running server at `http://localhost:4800` unless you override the port.
+
+---
+
+## Installation
+
+```bash
+# Run without installing (recommended for first-time use)
+npx @shackleai/orchestrator <command>
+
+# Install globally
+npm install -g @shackleai/orchestrator
+
+# After global install
+shackleai <command>
+```
+
+---
+
+## Global options
+
+```
+--version    Print the version number
+--help       Show help for any command
+```
+
+---
+
+## shackleai init
+
+Interactive setup wizard. Run this once to configure a new orchestrator.
+
+```bash
+shackleai init
+```
+
+**What it does:**
+
+1. Asks for deployment mode: `Local` (embedded PGlite) or `Server` (external PostgreSQL).
+2. Asks for company name and optional mission.
+3. If `Server` mode: asks for `DATABASE_URL`.
+4. Runs all database migrations.
+5. Creates the company record.
+6. Optionally creates the first agent.
+7. Writes config to `~/.shackleai/config.json`.
+
+**Config file location:** `~/.shackleai/config.json`
+
+**Config schema:**
+
+```json
+{
+  "mode": "local",
+  "companyId": "uuid",
+  "companyName": "Acme Corp",
+  "dataDir": "default"
+}
+```
+
+For server mode:
+
+```json
+{
+  "mode": "server",
+  "companyId": "uuid",
+  "companyName": "Acme Corp",
+  "databaseUrl": "postgresql://user:pass@host:5432/dbname"
+}
+```
+
+---
+
+## shackleai start
+
+Start the local API server.
+
+```bash
+shackleai start [--port <number>]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--port`, `-p` | `4800` | Port to listen on |
+
+**What it does:**
+- Reads `~/.shackleai/config.json`.
+- Connects to the database (PGlite or PostgreSQL based on mode).
+- Runs any pending migrations.
+- Starts the Hono HTTP server.
+
+The server must be running for all other CLI commands and for agent heartbeats to work.
+
+---
+
+## shackleai agent
+
+Manage agents.
+
+### shackleai agent list
+
+```bash
+shackleai agent list
+```
+
+Displays a table of all agents with columns: ID (truncated), Name, Role, Status, Adapter, Last Heartbeat.
+
+### shackleai agent create
+
+```bash
+shackleai agent create
+```
+
+Interactive wizard to create a new agent. Prompts for name, role, and adapter type.
+
+### shackleai agent pause
+
+```bash
+shackleai agent pause <id>
+```
+
+Sets the agent's status to `paused`. Paused agents do not execute scheduled heartbeats.
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `<id>` | Agent UUID |
+
+### shackleai agent resume
+
+```bash
+shackleai agent resume <id>
+```
+
+Sets the agent's status back to `idle`. The agent will resume its cron schedule on the next tick.
+
+### shackleai agent terminate
+
+```bash
+shackleai agent terminate <id>
+```
+
+Sets the agent's status to `terminated`. Terminated agents cannot be reactivated via the CLI.
+
+---
+
+## shackleai task
+
+Manage tasks.
+
+### shackleai task list
+
+```bash
+shackleai task list
+```
+
+Displays a table with: ID (truncated), Identifier (e.g. ACME-5), Title (truncated at 40 chars), Status, Priority, Assignee ID (truncated).
+
+### shackleai task create
+
+```bash
+shackleai task create
+```
+
+Interactive wizard. Prompts for title, optional description, and priority.
+
+### shackleai task assign
+
+```bash
+shackleai task assign <taskId> <agentId>
+```
+
+Atomically assigns a task to an agent. Sets status to `in_progress`. Fails with an error if the task is already assigned to another agent.
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `<taskId>` | Task UUID |
+| `<agentId>` | Agent UUID |
+
+### shackleai task complete
+
+```bash
+shackleai task complete <taskId>
+```
+
+Sets the task status to `done`.
+
+---
+
+## shackleai run
+
+Trigger an immediate on-demand agent wakeup.
+
+```bash
+shackleai run <agentId>
+```
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `<agentId>` | Agent UUID |
+
+**Output:**
+
+```
+Triggering wakeup for agent <agentId>...
+Triggered: true
+Agent:     coder-bot (uuid)
+Status:    idle
+Heartbeat: 3/16/2026, 12:30:00 PM
+```
+
+This updates `last_heartbeat_at` on the agent record. If the agent has an adapter that actually executes a process, use the API's `/wakeup` endpoint in a future version that integrates with the scheduler.
+
+---
+
+## shackleai doctor
+
+Run health checks and diagnostics.
+
+```bash
+shackleai doctor
+```
+
+**Checks performed:**
+
+1. Config file exists at `~/.shackleai/config.json`.
+2. Server is reachable at `http://localhost:4800/api/health`.
+3. Database is connected (via dashboard metrics endpoint).
+
+**Output:**
+
+```
+ShackleAI Orchestrator v0.1.0 — Doctor
+
+Config path: /Users/yourname/.shackleai/config.json
+[OK]   Config loaded
+       Company: Acme Corp (uuid)
+       Mode:    local
+[OK]   Server reachable (v0.1.0)
+[OK]   Database connected
+       Agents: 2
+       Tasks:  8 (3 open, 5 completed)
+
+All checks passed.
+```
+
+---
+
+## shackleai upgrade
+
+Manage your license key.
+
+### Show license status (default)
+
+```bash
+shackleai upgrade
+# or
+shackleai upgrade --status
+```
+
+**Output:**
+
+```
+License status:
+  Tier:      free
+  Valid:     indefinite
+  Validated: never
+```
+
+### Activate a license key
+
+```bash
+shackleai upgrade --key <your-license-key>
+```
+
+**Output:**
+
+```
+Activating license key...
+License activated.
+  Tier:  pro
+  Valid: 1/1/2027
+```
+
+**Options:**
+
+| Option | Description |
+|---|---|
+| `--key <key>` | License key to activate |
+| `--status` | Show current license status |
+
+---
+
+## Environment and config
+
+The CLI reads its active company ID and server connection settings from `~/.shackleai/config.json`. There is no way to target a different company from the CLI without editing this file or re-running `shackleai init`.
+
+To target a specific API server (e.g. a remote deployment), the CLI currently only supports the local default (`http://localhost:4800`). Use the API directly for remote operations.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,174 @@
+# Concepts
+
+ShackleAI Orchestrator is built around six primitives: **Companies**, **Agents**, **Tasks**, **Heartbeats**, **Governance**, and **Budgets**. Understanding how they relate makes the rest of the system straightforward.
+
+---
+
+## Companies
+
+A **Company** is the top-level organizational unit. Everything in the orchestrator — agents, tasks, policies, costs — belongs to exactly one company. Think of it as a tenant namespace.
+
+Key properties:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | UUID | Primary key |
+| `name` | string | Display name (e.g. "Acme Corp") |
+| `issue_prefix` | string | Short prefix for task identifiers (e.g. "ACME") |
+| `issue_counter` | integer | Monotonically increasing, used to generate `ACME-1`, `ACME-2` |
+| `budget_monthly_cents` | integer | Monthly token budget in cents (0 = unlimited) |
+| `spent_monthly_cents` | integer | Running total of token spend this month |
+| `status` | `active` / `inactive` | Whether the company is active |
+
+A single orchestrator instance can host multiple companies. Each company is fully isolated — agents cannot see or interact with resources from other companies.
+
+---
+
+## Agents
+
+An **Agent** is an AI worker. It has a role in the org chart, a connection method (adapter), and its own budget.
+
+Key properties:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | UUID | Primary key |
+| `company_id` | UUID | The company this agent belongs to |
+| `name` | string | Short identifier (e.g. "coder-bot") |
+| `title` | string / null | Display title (e.g. "Senior Engineer") |
+| `role` | `ceo` / `manager` / `worker` / `general` | Position in the org chart |
+| `reports_to` | UUID / null | Parent agent ID — defines the hierarchy |
+| `adapter_type` | string | How the agent is executed (see [Adapters](adapters.md)) |
+| `adapter_config` | JSON | Adapter-specific configuration |
+| `budget_monthly_cents` | integer | Per-agent monthly budget (0 = unlimited) |
+| `spent_monthly_cents` | integer | Spend this month |
+| `last_heartbeat_at` | timestamp / null | When the agent last ran |
+| `status` | `idle` / `active` / `paused` / `terminated` / `error` | Current state |
+
+**Agent lifecycle:**
+
+```
+idle -> active (when heartbeat starts)
+active -> idle (after heartbeat completes successfully)
+active -> error (after heartbeat fails)
+idle / active -> paused (manual pause via CLI or API)
+paused -> idle (resume via CLI or API)
+any -> terminated (terminate via CLI or API)
+```
+
+---
+
+## Tasks (Issues)
+
+A **Task** (stored as `Issue` in the database) is a unit of work. Tasks follow a lifecycle similar to GitHub Issues or Linear tickets.
+
+Key properties:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | UUID | Primary key |
+| `identifier` | string | Human-readable ID (e.g. `ACME-42`) |
+| `title` | string | Brief description of the work |
+| `description` | string / null | Detailed description |
+| `status` | see below | Current lifecycle state |
+| `priority` | `critical` / `high` / `medium` / `low` | Importance |
+| `assignee_agent_id` | UUID / null | Assigned agent (null = unassigned) |
+| `parent_id` | UUID / null | Parent task for sub-tasks |
+| `goal_id` | UUID / null | Strategic goal this task supports |
+| `project_id` | UUID / null | Project this task belongs to |
+
+**Task status lifecycle:**
+
+```
+backlog -> todo -> in_progress -> in_review -> done
+                             |
+                             +-> cancelled
+```
+
+**Atomic checkout:** When an agent claims a task, the system uses an atomic database update that only succeeds if the task is unassigned and in `backlog` or `todo` state. This prevents two agents from claiming the same task simultaneously. A 409 response means the task was already taken.
+
+---
+
+## Heartbeats
+
+A **Heartbeat** is a single execution run of an agent. Every time an agent wakes up — whether triggered by a cron schedule or an on-demand `shackleai run` call — the orchestrator creates a `HeartbeatRun` record.
+
+Key properties:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | UUID | Run ID, injected as `SHACKLEAI_RUN_ID` env var |
+| `agent_id` | UUID | Which agent ran |
+| `trigger_type` | `cron` / `manual` / `event` / `api` | What caused the run |
+| `status` | `queued` / `running` / `success` / `failed` / `timeout` | Current state |
+| `started_at` | timestamp | When execution began |
+| `finished_at` | timestamp / null | When execution ended |
+| `exit_code` | integer / null | Process exit code (0 = success) |
+| `stdout_excerpt` | string / null | First 4000 characters of stdout |
+| `error` | string / null | Error message if failed |
+| `usage_json` | JSON / null | Token usage data if reported |
+
+**Coalescing:** The scheduler skips a heartbeat if the agent already has one running. This prevents pile-up under slow or long-running agents.
+
+**Scheduling:** Agents with a `cron` expression in their `adapter_config` are scheduled automatically when `shackleai start` runs. Any standard cron expression works (e.g. `"*/5 * * * *"` for every 5 minutes).
+
+---
+
+## Governance
+
+The **Governance Engine** controls which tools an agent is allowed to call. The security model is **default-deny**: unless a policy explicitly allows a tool, access is denied.
+
+A **Policy** has:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Human-readable label |
+| `tool_pattern` | string | Glob pattern matched against tool names (e.g. `github:*`, `file:read`) |
+| `action` | `allow` / `deny` / `log` | What happens when the pattern matches |
+| `priority` | integer | Higher number = evaluated first |
+| `agent_id` | UUID / null | Null = company-wide policy |
+| `max_calls_per_hour` | integer / null | Optional rate limit |
+
+**Resolution order:**
+1. Fetch all policies for the company that apply to this agent (agent-specific + company-wide).
+2. Sort by `priority` descending. At equal priority, agent-specific policies beat company-wide.
+3. Match `tool_pattern` using glob (micromatch).
+4. Return the first matching policy's action.
+5. If no policy matches, deny.
+
+See [Governance](governance.md) for a full guide.
+
+---
+
+## Budgets
+
+Budgets control token spending. Every cost-generating adapter action is recorded as a `CostEvent`.
+
+**Budget enforcement:**
+- A budget of `0` means unlimited — always within budget.
+- At 80% spend, a `softAlert: true` signal is raised.
+- At 100% spend, `withinBudget: false` — agents should stop incurring costs.
+
+**Budget hierarchy:**
+1. Per-agent budget: `agents.budget_monthly_cents`
+2. Per-company budget: `companies.budget_monthly_cents`
+
+Both are checked independently. An agent can be within its own budget while the company is at the limit.
+
+**Cost data:** The `CostEvent` table records `provider`, `model`, `input_tokens`, `output_tokens`, and `cost_cents` per run. Costs are aggregated on the company and agent rows for fast budget checks, and also queryable via `/api/companies/:id/costs/by-agent`.
+
+---
+
+## Goals and Projects
+
+**Goals** form a strategy hierarchy with four levels: `strategic` → `initiative` → `project` → `task`. They have owner agents and lifecycle status (`active`, `completed`, `cancelled`).
+
+**Projects** group tasks under a goal. They have a lead agent, a target date, and a status (`active`, `completed`, `on_hold`, `cancelled`).
+
+Tasks can be linked to both a goal and a project via `goal_id` and `project_id`.
+
+---
+
+## Activity Log
+
+The **Activity Log** is an immutable audit trail. Every entity change — agent created, task status changed, policy added — is recorded with `entity_type`, `entity_id`, `actor_type`, `actor_id`, `action`, and a `changes` JSON diff. The dashboard endpoint returns the 5 most recent activity entries.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,199 @@
+# Configuration
+
+ShackleAI Orchestrator is configured through a JSON file written by `shackleai init`. No environment variables are required for basic local operation.
+
+---
+
+## Config file
+
+**Location:** `~/.shackleai/config.json`
+
+The config file is written by `shackleai init` and read by `shackleai start` and all CLI commands.
+
+### Local mode
+
+```json
+{
+  "mode": "local",
+  "companyId": "uuid-of-your-company",
+  "companyName": "Acme Corp",
+  "dataDir": "default"
+}
+```
+
+| Field | Description |
+|---|---|
+| `mode` | `"local"` — use embedded PGlite database |
+| `companyId` | UUID created during `init`, used by CLI commands |
+| `companyName` | Display name for the company |
+| `dataDir` | PGlite data directory name (relative to the PGlite storage path) |
+
+### Server mode
+
+```json
+{
+  "mode": "server",
+  "companyId": "uuid-of-your-company",
+  "companyName": "Acme Corp",
+  "databaseUrl": "postgresql://user:password@localhost:5432/orchestrator"
+}
+```
+
+| Field | Description |
+|---|---|
+| `mode` | `"server"` — use external PostgreSQL |
+| `databaseUrl` | Full PostgreSQL connection string |
+
+---
+
+## Deployment modes
+
+### Local (PGlite)
+
+The default. An embedded PostgreSQL-compatible database runs in-process using PGlite. No external dependencies.
+
+**When to use:**
+- Single-machine setup
+- Development and testing
+- Simple personal agents
+
+**Limitations:**
+- Single process only — does not support multiple workers connecting to the same database
+- Data lives on disk in the working directory
+
+### Server (PostgreSQL)
+
+Connects to any PostgreSQL 14+ database. The schema is identical to local mode — all 12 migrations run against the target database.
+
+**When to use:**
+- Production deployments
+- Multi-machine setups
+- When you want to run the API server on a separate host from your agents
+
+**Requirements:**
+- PostgreSQL 14 or later
+- A database and user with `CREATE TABLE`, `INSERT`, `UPDATE`, `DELETE`, `SELECT` privileges
+
+**Setup:**
+
+```bash
+# Create the database
+psql -c "CREATE DATABASE orchestrator;"
+psql -c "CREATE USER orchestrator_user WITH PASSWORD 'your_password';"
+psql -c "GRANT ALL PRIVILEGES ON DATABASE orchestrator TO orchestrator_user;"
+
+# Initialize
+npx @shackleai/orchestrator init
+# Select "Server" and enter: postgresql://orchestrator_user:your_password@localhost:5432/orchestrator
+```
+
+---
+
+## Server options
+
+The `shackleai start` command accepts:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port`, `-p` | `4800` | HTTP port to listen on |
+
+```bash
+shackleai start --port 9000
+```
+
+---
+
+## Agent adapter configuration
+
+Each agent has an `adapter_config` JSON field. The fields available depend on the adapter type.
+
+### Common fields (all adapters)
+
+| Field | Type | Description |
+|---|---|---|
+| `cron` | string / null | Cron expression for scheduled heartbeats |
+| `timeout` | integer / null | Execution timeout in seconds |
+
+### Process adapter
+
+```json
+{
+  "command": "python3",
+  "args": ["/path/to/agent.py"],
+  "timeout": 120,
+  "cron": "*/5 * * * *"
+}
+```
+
+### HTTP adapter
+
+```json
+{
+  "url": "https://my-agent.example.com/heartbeat",
+  "headers": { "X-Custom-Header": "value" },
+  "authToken": "secret-token",
+  "timeout": 60,
+  "cron": "0 * * * *"
+}
+```
+
+### Claude adapter
+
+```json
+{
+  "prompt": "You are a code review agent. Check the latest PRs.",
+  "model": "claude-opus-4-5",
+  "timeout": 300,
+  "cron": "0 9 * * 1-5"
+}
+```
+
+### MCP adapter
+
+```json
+{
+  "url": "http://localhost:3001/mcp",
+  "toolName": "run_agent_step",
+  "toolParams": { "persona": "engineer" },
+  "timeout": 120,
+  "cron": "*/10 * * * *"
+}
+```
+
+---
+
+## Cron expressions
+
+Standard 5-field cron syntax is used (via node-cron). The orchestrator validates cron expressions at startup and logs an error for invalid ones without crashing.
+
+| Expression | Runs |
+|---|---|
+| `*/5 * * * *` | Every 5 minutes |
+| `0 * * * *` | Every hour at :00 |
+| `0 9 * * 1-5` | Weekdays at 9am |
+| `0 0 * * *` | Daily at midnight |
+
+Agents without a `cron` expression in their `adapter_config` are on-demand only — they only run when `shackleai run <id>` or the wakeup API endpoint is called.
+
+---
+
+## Database schema
+
+The database has 12 tables created by migrations that run automatically on `start`:
+
+| Table | Description |
+|---|---|
+| `companies` | Organizational units |
+| `agents` | AI workers |
+| `issues` | Tasks / tickets |
+| `goals` | Strategic goal hierarchy |
+| `projects` | Project groupings |
+| `issue_comments` | Comments on tasks |
+| `policies` | Governance rules |
+| `cost_events` | Token usage ledger |
+| `heartbeat_runs` | Execution history |
+| `activity_log` | Audit trail |
+| `agent_api_keys` | API key records (hashed) |
+| `license_keys` | License key records |
+
+Migrations are idempotent and run in order. Re-running `start` on an already-migrated database is safe.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,257 @@
+# Deployment
+
+ShackleAI Orchestrator runs anywhere Node.js 18+ runs. This guide covers four deployment scenarios: local development, Docker, a Linux VPS, and cloud platforms.
+
+---
+
+## Local (development)
+
+The simplest setup — everything runs on your machine with an embedded database.
+
+```bash
+npx @shackleai/orchestrator init   # One-time setup
+npx @shackleai/orchestrator start  # Start the server
+```
+
+The server runs until you stop it (Ctrl+C). Data persists in the PGlite database between restarts.
+
+To keep the server running in the background:
+
+```bash
+npx @shackleai/orchestrator start &
+```
+
+Or use a process manager like [PM2](https://pm2.keymetrics.io):
+
+```bash
+npm install -g pm2
+pm2 start "npx @shackleai/orchestrator start" --name shackleai
+pm2 save
+pm2 startup   # Generate startup script
+```
+
+---
+
+## Docker
+
+Use Docker to run the orchestrator in a container. The example below uses server mode with an external PostgreSQL container.
+
+**`docker-compose.yml`:**
+
+```yaml
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: orchestrator
+      POSTGRES_PASSWORD: change-me
+      POSTGRES_DB: orchestrator
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U orchestrator"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  orchestrator:
+    image: node:20-alpine
+    working_dir: /app
+    command: >
+      sh -c "
+        npx @shackleai/orchestrator@latest start --port 4800
+      "
+    environment:
+      NODE_ENV: production
+    ports:
+      - "4800:4800"
+    volumes:
+      - orchestrator_config:/root/.shackleai
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  orchestrator_config:
+```
+
+**First-time setup:**
+
+```bash
+# Run init interactively to create the config
+docker run -it --rm \
+  --network $(docker network ls -q | head -1) \
+  -v orchestrator_config:/root/.shackleai \
+  node:20-alpine \
+  sh -c "npx @shackleai/orchestrator@latest init"
+# Select Server mode, enter: postgresql://orchestrator:change-me@postgres:5432/orchestrator
+
+# Then start the stack
+docker compose up -d
+```
+
+**Verify:**
+
+```bash
+curl http://localhost:4800/api/health
+```
+
+---
+
+## Linux VPS
+
+This example uses Ubuntu 24.04 and systemd to run the orchestrator as a managed service.
+
+### 1. Install Node.js 20
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node --version  # Should be >= 20
+```
+
+### 2. Install PostgreSQL (if using server mode)
+
+```bash
+sudo apt-get install -y postgresql
+sudo systemctl start postgresql
+sudo systemctl enable postgresql
+
+# Create database and user
+sudo -u postgres psql <<SQL
+CREATE USER orchestrator WITH PASSWORD 'your-password';
+CREATE DATABASE orchestrator OWNER orchestrator;
+SQL
+```
+
+### 3. Initialize the orchestrator
+
+Run as the user who will own the process (e.g. `ubuntu`):
+
+```bash
+npx @shackleai/orchestrator init
+# Select Server mode
+# DATABASE_URL: postgresql://orchestrator:your-password@localhost:5432/orchestrator
+```
+
+### 4. Create a systemd service
+
+```bash
+sudo nano /etc/systemd/system/shackleai.service
+```
+
+```ini
+[Unit]
+Description=ShackleAI Orchestrator
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu
+ExecStart=/usr/bin/npx @shackleai/orchestrator start --port 4800
+Restart=on-failure
+RestartSec=5s
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable shackleai
+sudo systemctl start shackleai
+sudo systemctl status shackleai
+```
+
+### 5. Verify
+
+```bash
+curl http://localhost:4800/api/health
+```
+
+### 6. Reverse proxy with Caddy (optional)
+
+To expose the API over HTTPS with automatic TLS:
+
+```bash
+sudo apt-get install -y caddy
+```
+
+`/etc/caddy/Caddyfile`:
+
+```
+your-domain.example.com {
+    reverse_proxy localhost:4800
+}
+```
+
+```bash
+sudo systemctl restart caddy
+```
+
+---
+
+## Cloud platforms
+
+### Railway
+
+1. Create a new project and add a PostgreSQL plugin.
+2. Deploy the orchestrator as a Node.js service.
+3. Set `DATABASE_URL` to the Railway PostgreSQL URL.
+4. On first deploy, run `init` via the Railway console to write the config.
+
+### Fly.io
+
+```bash
+fly launch --name my-orchestrator --image node:20-alpine
+fly postgres create --name orchestrator-db
+fly postgres attach orchestrator-db
+
+# Set environment
+fly secrets set DATABASE_URL=<connection-string>
+
+# Deploy
+fly deploy
+```
+
+### AWS EC2 / GCP Compute Engine / Azure VM
+
+Follow the Linux VPS instructions above. The steps are identical regardless of cloud provider.
+
+---
+
+## Networking and ports
+
+| Port | Service |
+|---|---|
+| `4800` | ShackleAI Orchestrator API (default) |
+
+The orchestrator binds to `0.0.0.0` (all interfaces) by default. In production, place it behind a reverse proxy (Nginx, Caddy) and do not expose port 4800 directly to the internet unless you have authentication middleware in front of it.
+
+---
+
+## Upgrades
+
+To upgrade to a new version:
+
+```bash
+# Using npx (always pulls latest)
+npx @shackleai/orchestrator@latest start
+
+# Or update a globally installed version
+npm update -g @shackleai/orchestrator
+```
+
+Database migrations run automatically on startup. New migrations are always additive — no manual migration steps are needed.
+
+To check your current version:
+
+```bash
+npx @shackleai/orchestrator --version
+curl http://localhost:4800/api/health   # Returns version in response
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,170 @@
+# FAQ
+
+---
+
+## General
+
+**What is ShackleAI Orchestrator?**
+
+It is an open-source agent orchestrator. You install it with `npx @shackleai/orchestrator init`, and it gives your AI agents a company structure: org chart, task backlog, governance policies, token budgets, and a heartbeat scheduler. Agents check in periodically (or on-demand), pick up tasks, and run under policies that control what tools they can use.
+
+**Who is it for?**
+
+Developers building multi-agent systems who want structure beyond ad-hoc scripts. If you have more than one AI worker and you want to track what they are doing, what they are spending, and what they are allowed to access, ShackleAI Orchestrator provides that infrastructure.
+
+**Is it free?**
+
+Yes. The core orchestrator is MIT licensed. There is no usage cost for the open-source package.
+
+**Does it require a ShackleAI account?**
+
+No. It runs entirely locally. You can use it without an internet connection (except for the initial npm install).
+
+---
+
+## Installation and setup
+
+**`npx @shackleai/orchestrator init` is failing. What do I do?**
+
+Check your Node.js version first:
+
+```bash
+node --version
+```
+
+You need 18.12 or later. If you are on an older version, upgrade via [nvm](https://github.com/nvm-sh/nvm) or the [official installer](https://nodejs.org).
+
+**Can I re-run `init` if I made a mistake?**
+
+Yes. Running `init` again creates a new company record and overwrites `~/.shackleai/config.json`. Your old data in the database is preserved (the old company record remains).
+
+**Where is my data stored in local mode?**
+
+PGlite stores data in a directory relative to where the orchestrator server process runs. The `dataDir` value in your config (default: `"default"`) is the directory name. The data lives in the working directory of the `shackleai start` process.
+
+---
+
+## Agents and adapters
+
+**How do I connect my existing Python agent?**
+
+Use the `process` adapter:
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-python-agent",
+    "role": "worker",
+    "adapter_type": "process",
+    "adapter_config": {
+      "command": "python3",
+      "args": ["/path/to/my_agent.py"],
+      "cron": "*/10 * * * *"
+    }
+  }'
+```
+
+Your Python script receives `SHACKLEAI_AGENT_ID`, `SHACKLEAI_RUN_ID`, and (if assigned) `SHACKLEAI_TASK_ID` as environment variables.
+
+**Can I run an agent without a cron schedule?**
+
+Yes. Simply do not include a `cron` key in `adapter_config`. The agent will only run when you call `shackleai run <id>` or POST to `/api/companies/:id/agents/:agentId/wakeup`.
+
+**What happens if my agent takes longer than the timeout?**
+
+The adapter sends SIGTERM to the process, waits 5 seconds for a graceful shutdown, then sends SIGKILL. The heartbeat run is recorded as `failed` with exit code `124` and the stderr includes the timeout message.
+
+**Can two agents pick up the same task at the same time?**
+
+No. Task checkout is atomic — only one agent can claim a task. If a second agent tries to check out the same task, the API returns `409 Conflict`.
+
+---
+
+## Governance
+
+**My agent keeps getting denied. I set up an allow policy but it is not working.**
+
+Check two things:
+
+1. Is the tool name an exact match for your glob pattern? Tool names are case-sensitive. Use the exact string your agent passes to `checkPolicy`.
+2. Is there a higher-priority deny policy overriding your allow? List all policies and sort by priority descending.
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/policies
+```
+
+**What is default-deny?**
+
+If no policy matches a tool call, access is denied. This is intentional — it prevents unconfigured tools from being accessible by default. Add an explicit `allow` policy for each tool your agents need.
+
+**Can I disable governance for development?**
+
+Add a company-wide `allow *` policy at priority 1:
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "dev-allow-all", "tool_pattern": "*", "action": "allow", "priority": 1 }'
+```
+
+Delete this policy before going to production.
+
+---
+
+## Costs and budgets
+
+**How is cost tracked?**
+
+Adapters that report token usage (Claude, HTTP, MCP) can include a `__shackleai_result__` JSON block in their output with `usage.costCents`. The orchestrator records these as `CostEvent` rows and increments `spent_monthly_cents` on the agent and company records.
+
+**What happens when an agent exceeds its budget?**
+
+The `CostTracker.checkBudget` method returns `withinBudget: false` at 100% spend. Enforcement is in your adapter code — the orchestrator surfaces budget status but does not automatically stop agents. Build budget checks into your agent logic using the `/costs/by-agent` endpoint.
+
+**How do I reset monthly spend?**
+
+Monthly reset is not automatic in v0.1.0. Use the `CostTracker.resetMonthlySpend` method programmatically, or update the database directly:
+
+```sql
+UPDATE agents SET spent_monthly_cents = 0 WHERE company_id = 'your-company-id';
+UPDATE companies SET spent_monthly_cents = 0 WHERE id = 'your-company-id';
+```
+
+---
+
+## Database
+
+**Can I use a managed PostgreSQL service like RDS or Supabase?**
+
+Yes. Use server mode and set `databaseUrl` to the connection string provided by your managed database service. All migrations run automatically.
+
+**Can I inspect the database directly?**
+
+In local (PGlite) mode, the database is stored in a custom file format and is not directly accessible with standard PostgreSQL tools. In server mode, you can connect with any PostgreSQL client (e.g. `psql`, TablePlus, DBeaver).
+
+**How do I back up my data?**
+
+In server mode: use standard PostgreSQL backup tools (`pg_dump`).
+
+In local mode: copy the PGlite data directory. Stop the server first to avoid corruption.
+
+---
+
+## Multiple companies
+
+**Can I manage multiple AI teams from one orchestrator?**
+
+Yes. Run `npx @shackleai/orchestrator init` to create a second company record. However, the CLI defaults to the company in your config file. To work with a different company, update `companyId` in `~/.shackleai/config.json` or use the REST API directly.
+
+---
+
+## Contributing
+
+**I found a bug. Where do I report it?**
+
+Open an issue at https://github.com/shackleai/orchestrator/issues.
+
+**I want to add a new adapter. Where do I start?**
+
+Implement the `AdapterModule` interface from `@shackleai/core`. See `packages/core/src/adapters/adapter.ts` for the interface definition and any existing adapter for a reference implementation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,156 @@
+# Getting Started
+
+Get from zero to a running agent orchestrator in under 5 minutes.
+
+---
+
+## Prerequisites
+
+- **Node.js** 18.12 or later (`node --version`)
+- **npm** 7 or later (comes with Node.js)
+
+That is all. No cloud account, no Docker, no database to install for local mode.
+
+---
+
+## Step 1 — Initialize
+
+Run the setup wizard:
+
+```bash
+npx @shackleai/orchestrator init
+```
+
+The wizard asks:
+
+1. **Deployment mode** — choose `Local` for an embedded database (recommended for getting started) or `Server` if you have an external PostgreSQL instance.
+2. **Company name** — the name of your AI organization (e.g. "Acme Corp"). This becomes the prefix for task identifiers: `ACME-1`, `ACME-2`, etc.
+3. **Company mission** — optional description.
+4. **Create your first agent?** — choose `Yes` and fill in a name, role, and adapter type.
+
+When it finishes you will see:
+
+```
+Setup complete! Run `shackleai start` to launch the server.
+```
+
+The wizard has written a config file to `~/.shackleai/config.json` and run all 12 database migrations.
+
+---
+
+## Step 2 — Start the server
+
+```bash
+npx @shackleai/orchestrator start
+```
+
+Output:
+
+```
+ShackleAI Orchestrator v0.1.0
+Company: Acme Corp
+Mode:    local
+
+Dashboard: http://localhost:4800
+Health:    http://localhost:4800/api/health
+```
+
+The server is now running on port 4800. Keep this terminal open.
+
+To use a different port:
+
+```bash
+npx @shackleai/orchestrator start --port 9000
+```
+
+---
+
+## Step 3 — Verify with doctor
+
+Open a new terminal and run:
+
+```bash
+npx @shackleai/orchestrator doctor
+```
+
+Expected output:
+
+```
+ShackleAI Orchestrator v0.1.0 — Doctor
+
+Config path: /Users/yourname/.shackleai/config.json
+[OK]   Config loaded
+       Company: Acme Corp (uuid...)
+       Mode:    local
+[OK]   Server reachable (v0.1.0)
+[OK]   Database connected
+       Agents: 1
+       Tasks:  0 (0 open, 0 completed)
+
+All checks passed.
+```
+
+---
+
+## Step 4 — Create a task
+
+```bash
+npx @shackleai/orchestrator task create
+```
+
+Follow the prompts to enter a title, optional description, and priority. The task receives an auto-numbered identifier like `ACME-1`.
+
+List all tasks:
+
+```bash
+npx @shackleai/orchestrator task list
+```
+
+---
+
+## Step 5 — Assign and trigger an agent
+
+List your agents to get the agent ID:
+
+```bash
+npx @shackleai/orchestrator agent list
+```
+
+Assign the task to the agent (replace the IDs with your actual UUIDs):
+
+```bash
+npx @shackleai/orchestrator task assign <taskId> <agentId>
+```
+
+Trigger the agent to run immediately:
+
+```bash
+npx @shackleai/orchestrator run <agentId>
+```
+
+---
+
+## Step 6 — Check the API directly
+
+The local API is a standard HTTP server. You can query it with curl:
+
+```bash
+# Health check
+curl http://localhost:4800/api/health
+
+# List agents
+COMPANY_ID=$(cat ~/.shackleai/config.json | python3 -c "import sys,json; print(json.load(sys.stdin)['companyId'])")
+curl "http://localhost:4800/api/companies/${COMPANY_ID}/agents"
+
+# Dashboard metrics
+curl "http://localhost:4800/api/companies/${COMPANY_ID}/dashboard"
+```
+
+---
+
+## What's next
+
+- Read [Concepts](concepts.md) to understand how companies, agents, tasks, and governance fit together.
+- Read [Adapters](adapters.md) to connect your agents to Claude Code CLI, HTTP webhooks, MCP servers, or any subprocess.
+- Read [Governance](governance.md) to set up tool access policies for your agents.
+- Read [API Reference](api-reference.md) for the complete HTTP API.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,234 @@
+# Governance
+
+The Governance Engine controls which tools agents are allowed to call. The security model is **default-deny**: if no policy explicitly permits a tool, access is denied. This prevents privilege escalation from unconfigured or newly-added tools.
+
+---
+
+## How it works
+
+When an agent attempts to call a tool, the engine:
+
+1. Fetches all policies for the company that apply to this agent (both agent-specific policies and company-wide policies where `agent_id IS NULL`).
+2. Sorts by `priority` descending. At equal priority, agent-specific policies take precedence over company-wide ones.
+3. Matches `tool_pattern` against the tool name using glob matching (micromatch).
+4. Returns the first matching policy's action.
+5. If nothing matches, denies access.
+
+**Default-deny is the key guarantee.** A new tool that no policy covers is automatically blocked until you add an allow policy.
+
+---
+
+## Policy structure
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | UUID | Policy ID |
+| `company_id` | UUID | The company this policy belongs to |
+| `agent_id` | UUID / null | Null means the policy applies company-wide |
+| `name` | string | Human-readable label |
+| `tool_pattern` | string | Glob pattern (e.g. `github:*`, `file:read`, `*`) |
+| `action` | `allow` / `deny` / `log` | What happens on match |
+| `priority` | integer | Higher = evaluated first |
+| `max_calls_per_hour` | integer / null | Optional rate limit (reserved for future enforcement) |
+
+---
+
+## Actions
+
+**`allow`** — permits the tool call.
+
+**`deny`** — blocks the tool call and returns a denial reason.
+
+**`log`** — permits the tool call but flags it in the audit log (treated as allow for access purposes).
+
+---
+
+## Glob patterns
+
+Tool names are namespaced strings like `github:list_issues`, `file:write`, `shell:exec`. Patterns use standard glob syntax:
+
+| Pattern | Matches |
+|---|---|
+| `github:*` | All GitHub tools |
+| `file:read` | Only the exact `file:read` tool |
+| `file:*` | All file tools |
+| `*` | Every tool |
+| `shell:*` | All shell tools |
+
+Patterns are matched using [micromatch](https://github.com/micromatch/micromatch), which supports `*`, `**`, `?`, and character ranges.
+
+---
+
+## Priority resolution
+
+When multiple policies could match, the first match wins based on this order:
+
+1. Higher `priority` number wins.
+2. At equal priority, agent-specific policies (where `agent_id` is set) win over company-wide policies.
+
+**Example — overriding a company-wide block:**
+
+```
+Priority 10: company-wide DENY shell:*
+Priority 20: agent-specific ALLOW shell:exec (for agent "deploy-bot")
+```
+
+When `deploy-bot` attempts `shell:exec`, the priority-20 agent-specific allow fires first, granting access.
+
+---
+
+## Common policy patterns
+
+### Allow all tools (development mode)
+
+Use this for trusted agents in a controlled environment. Not recommended for production.
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "allow-all",
+    "tool_pattern": "*",
+    "action": "allow",
+    "priority": 1
+  }'
+```
+
+### Allow all GitHub tools, deny everything else
+
+```bash
+# Allow GitHub
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "allow-github",
+    "tool_pattern": "github:*",
+    "action": "allow",
+    "priority": 10
+  }'
+
+# The default-deny behavior blocks everything else automatically.
+# No deny-all policy is needed.
+```
+
+### Agent-specific allow with company-wide deny
+
+```bash
+# Company-wide: deny shell tools
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "deny-shell",
+    "tool_pattern": "shell:*",
+    "action": "deny",
+    "priority": 10
+  }'
+
+# Agent-specific: allow one agent to use shell
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "deploy-bot-shell-allow",
+    "agent_id": "<deploy-bot-agent-id>",
+    "tool_pattern": "shell:*",
+    "action": "allow",
+    "priority": 20
+  }'
+```
+
+### Log sensitive tool calls
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "log-database-writes",
+    "tool_pattern": "db:write*",
+    "action": "log",
+    "priority": 15
+  }'
+```
+
+---
+
+## Managing policies via CLI
+
+Currently policies must be managed via the REST API directly. The CLI does not have a `policy` subcommand in v0.1.0.
+
+**List all policies:**
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/policies
+```
+
+**Create a policy:**
+
+```bash
+curl -X POST http://localhost:4800/api/companies/${COMPANY_ID}/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-policy",
+    "tool_pattern": "github:*",
+    "action": "allow",
+    "priority": 10
+  }'
+```
+
+**Update a policy:**
+
+```bash
+curl -X PATCH http://localhost:4800/api/companies/${COMPANY_ID}/policies/${POLICY_ID} \
+  -H "Content-Type: application/json" \
+  -d '{ "priority": 20 }'
+```
+
+**Delete a policy:**
+
+```bash
+curl -X DELETE http://localhost:4800/api/companies/${COMPANY_ID}/policies/${POLICY_ID}
+```
+
+---
+
+## Checking a policy programmatically
+
+The `GovernanceEngine` from `@shackleai/core` can be used directly in your agent code:
+
+```typescript
+import { GovernanceEngine } from '@shackleai/core'
+
+const engine = new GovernanceEngine(db)
+
+const result = await engine.checkPolicy(
+  companyId,
+  agentId,
+  'github:create_pr',
+)
+
+if (!result.allowed) {
+  console.error(`Blocked: ${result.reason}`)
+  process.exit(1)
+}
+```
+
+---
+
+## Troubleshooting
+
+**My agent is being denied a tool I expected to be allowed.**
+
+Check the current policies and verify the `tool_pattern` glob matches the exact tool name your agent is using:
+
+```bash
+curl http://localhost:4800/api/companies/${COMPANY_ID}/policies
+```
+
+Remember that tool names are case-sensitive. `GitHub:*` does not match `github:list_issues`.
+
+**I have conflicting policies and the wrong one is winning.**
+
+Check priorities. The higher number wins. At equal priority, agent-specific beats company-wide. You can adjust priority via PATCH.
+
+**I want to start permissive and tighten later.**
+
+Add a single `allow *` policy at priority 1. Then add deny policies at higher priorities as you identify tools that should be blocked. Remove the catch-all when you are ready to enforce default-deny fully.


### PR DESCRIPTION
## Summary

- Adds `README.md` at the repo root: one-liner, quickstart, feature table, ASCII architecture diagram, comparison table (DIY / LangChain / CrewAI / AutoGen vs ShackleAI), CLI reference summary, and links to all docs
- Adds `docs/getting-started.md`: 6-step tutorial from `npx init` to a running agent with task assignment
- Adds `docs/concepts.md`: Companies, Agents, Tasks, Heartbeats, Governance, Budgets, Goals, Projects, Activity Log — all based on the actual TypeScript types and database schema
- Adds `docs/adapters.md`: Process, HTTP, Claude Code CLI, MCP adapters — config schemas, injected env vars, `__shackleai_result__` protocol, and curl examples
- Adds `docs/governance.md`: Default-deny policy engine — resolution order, glob patterns, priority tiebreaking, common patterns with curl examples
- Adds `docs/api-reference.md`: Every endpoint with method, URL, description, request body, response shape, and curl examples
- Adds `docs/cli-reference.md`: All 15 commands/subcommands with options and expected output
- Adds `docs/configuration.md`: Config file schema for both modes, deployment modes, adapter config fields, cron expressions, database schema overview
- Adds `docs/deployment.md`: Local, Docker Compose, Linux VPS (systemd), and cloud platform instructions
- Adds `docs/faq.md`: 20+ common questions grounded in what the code actually does

All documentation is based on reading the actual source code — no assumptions. `pnpm build` passes.

## Test plan

- [ ] Verify `pnpm build` passes (confirmed in branch)
- [ ] Review README on GitHub rendered view
- [ ] Spot-check a curl example from `api-reference.md` against a running local server
- [ ] Verify all links in README point to existing files in `docs/`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)