### PR TITLE
fix: wave 1 core/shared/db bug fixes

### DIFF
--- a/packages/core/src/adapters/claude.ts
+++ b/packages/core/src/adapters/claude.ts
@@ -9,6 +9,7 @@
 
 import { spawn } from 'node:child_process'
 import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
 
 /** Default timeout in milliseconds (300 seconds). */
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -89,12 +90,13 @@ export class ClaudeAdapter implements AdapterModule {
         ? ctx.adapterConfig.timeout * 1000
         : DEFAULT_TIMEOUT_MS
 
-    const env: Record<string, string> = {
-      ...process.env,
+    const shackleEnv: Record<string, string> = {
       ...ctx.env,
       SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
       SHACKLEAI_AGENT_ID: ctx.agentId,
     }
+
+    const env: Record<string, string> = getSafeEnv(shackleEnv)
 
     if (ctx.task) {
       env.SHACKLEAI_TASK_ID = ctx.task

--- a/packages/core/src/adapters/crewai.ts
+++ b/packages/core/src/adapters/crewai.ts
@@ -13,6 +13,7 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
 
 /** Default timeout in milliseconds (600 seconds). */
 const DEFAULT_TIMEOUT_MS = 600_000
@@ -38,23 +39,54 @@ interface CrewAIUsage {
 }
 
 /**
+ * Extract JSON blocks delimited by RESULT_MARKER from stdout.
+ * Uses brace-depth counting to handle nested JSON (not a simple regex).
+ */
+function extractResultBlocks(stdout: string): string[] {
+  const blocks: string[] = []
+  let searchFrom = 0
+
+  while (true) {
+    const startIdx = stdout.indexOf(RESULT_MARKER, searchFrom)
+    if (startIdx === -1) break
+
+    const jsonStart = startIdx + RESULT_MARKER.length
+    if (jsonStart >= stdout.length || stdout[jsonStart] !== '{') {
+      searchFrom = jsonStart
+      continue
+    }
+
+    // Walk forward with brace-depth counting
+    let depth = 0
+    let jsonEnd = -1
+    for (let i = jsonStart; i < stdout.length; i++) {
+      if (stdout[i] === '{') depth++
+      else if (stdout[i] === '}') depth--
+      if (depth === 0) {
+        jsonEnd = i + 1
+        break
+      }
+    }
+
+    if (jsonEnd === -1) break
+
+    blocks.push(stdout.slice(jsonStart, jsonEnd))
+    searchFrom = jsonEnd
+  }
+
+  return blocks
+}
+
+/**
  * Parse the last `__shackleai_result__` JSON block from stdout.
  * Expected format in stdout:
  *   __shackleai_result__{"inputTokens":…,"outputTokens":…,…}__shackleai_result__
  */
 function parseUsageFromStdout(stdout: string): CrewAIUsage | undefined {
-  const regex = new RegExp(
-    `${RESULT_MARKER}(\\{[^}]+\\})${RESULT_MARKER}`,
-    'g',
-  )
+  const blocks = extractResultBlocks(stdout)
+  if (blocks.length === 0) return undefined
 
-  let last: string | undefined
-  let match: RegExpExecArray | null
-  while ((match = regex.exec(stdout)) !== null) {
-    last = match[1]
-  }
-
-  if (!last) return undefined
+  const last = blocks[blocks.length - 1]
 
   try {
     const parsed: unknown = JSON.parse(last)
@@ -138,13 +170,14 @@ export class CrewAIAdapter implements AdapterModule {
       args.push('--config', crewConfig)
     }
 
-    // Build env
-    const env: Record<string, string> = {
-      ...process.env,
+    // Build env — whitelist safe vars, never leak host secrets
+    const shackleEnv: Record<string, string> = {
       ...ctx.env,
       SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
       SHACKLEAI_AGENT_ID: ctx.agentId,
     }
+
+    const env: Record<string, string> = getSafeEnv(shackleEnv)
 
     if (ctx.task) {
       env.SHACKLEAI_TASK_ID = ctx.task
@@ -204,20 +237,11 @@ export class CrewAIAdapter implements AdapterModule {
 
         // Parse session state from result block if present
         let sessionState: string | null = null
-        const sessionRegex = new RegExp(
-          `${RESULT_MARKER}(\\{[^}]+\\})${RESULT_MARKER}`,
-          'g',
-        )
-        let lastSessionMatch: string | undefined
-        let sessionMatch: RegExpExecArray | null
-        while (
-          (sessionMatch = sessionRegex.exec(rawStdout)) !== null
-        ) {
-          lastSessionMatch = sessionMatch[1]
-        }
-        if (lastSessionMatch) {
+        const sessionBlocks = extractResultBlocks(rawStdout)
+        if (sessionBlocks.length > 0) {
+          const lastBlock = sessionBlocks[sessionBlocks.length - 1]
           try {
-            const parsed = JSON.parse(lastSessionMatch) as Record<
+            const parsed = JSON.parse(lastBlock) as Record<
               string,
               unknown
             >

--- a/packages/core/src/adapters/env.ts
+++ b/packages/core/src/adapters/env.ts
@@ -1,0 +1,33 @@
+/** Whitelist safe env vars for child processes — never leak host secrets */
+export function getSafeEnv(
+  extra: Record<string, string> = {},
+): Record<string, string> {
+  const safe: Record<string, string> = {}
+  const ALLOWED_PREFIXES = [
+    'PATH',
+    'HOME',
+    'USERPROFILE',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'LANG',
+    'LC_',
+    'SHACKLEAI_',
+    'NODE_',
+  ]
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (
+      value !== undefined &&
+      ALLOWED_PREFIXES.some((p) => key.startsWith(p))
+    ) {
+      safe[key] = value
+    }
+  }
+
+  // Also include SystemRoot and COMSPEC on Windows
+  if (process.env.SystemRoot) safe.SystemRoot = process.env.SystemRoot
+  if (process.env.COMSPEC) safe.COMSPEC = process.env.COMSPEC
+
+  return { ...safe, ...extra }
+}

--- a/packages/core/src/adapters/mcp.ts
+++ b/packages/core/src/adapters/mcp.ts
@@ -60,9 +60,6 @@ export class McpAdapter implements AdapterModule {
       }
     }
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeoutSeconds * 1000)
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let client: any
 
@@ -88,12 +85,19 @@ export class McpAdapter implements AdapterModule {
         },
       }
 
-      const result = await client.callTool({
-        name: toolName,
-        arguments: enrichedParams,
-      })
-
-      clearTimeout(timeoutId)
+      const timeoutMs = timeoutSeconds * 1000
+      const result = await Promise.race([
+        client.callTool({
+          name: toolName,
+          arguments: enrichedParams,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('MCP call timed out')),
+            timeoutMs,
+          ),
+        ),
+      ])
 
       const content = result.content as Array<{ type: string; text?: string }> | undefined
       const textParts = (content ?? [])
@@ -139,9 +143,10 @@ export class McpAdapter implements AdapterModule {
         usage,
       }
     } catch (err) {
-      clearTimeout(timeoutId)
+      const message = err instanceof Error ? err.message : String(err)
 
-      if (err instanceof DOMException && err.name === 'AbortError') {
+      // Check for our Promise.race timeout
+      if (message === 'MCP call timed out') {
         return {
           exitCode: 124,
           stdout: '',
@@ -149,7 +154,6 @@ export class McpAdapter implements AdapterModule {
         }
       }
 
-      const message = err instanceof Error ? err.message : String(err)
       return {
         exitCode: 1,
         stdout: '',

--- a/packages/core/src/adapters/openclaw.ts
+++ b/packages/core/src/adapters/openclaw.ts
@@ -12,6 +12,7 @@
 import { spawn } from 'node:child_process'
 import { access, constants } from 'node:fs/promises'
 import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
 
 /** Default timeout in milliseconds (300 seconds). */
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -104,13 +105,14 @@ export class OpenClawAdapter implements AdapterModule {
     // Build environment: inject SHACKLEAI_* vars
     // Note: adapterConfig.envFile is supported for documentation purposes but
     // env file parsing is not implemented — users should set env vars directly.
-    const env: Record<string, string> = {
-      ...process.env,
+    const shackleEnv: Record<string, string> = {
       ...ctx.env,
       SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
       SHACKLEAI_AGENT_ID: ctx.agentId,
       SHACKLEAI_API_URL: (ctx.env.SHACKLEAI_API_URL as string) ?? '',
     }
+
+    const env: Record<string, string> = getSafeEnv(shackleEnv)
 
     if (ctx.task) {
       env.SHACKLEAI_TASK_ID = ctx.task

--- a/packages/core/src/adapters/process.ts
+++ b/packages/core/src/adapters/process.ts
@@ -9,6 +9,7 @@
 import { spawn } from 'node:child_process'
 import type { WorktreeConfig } from '@shackleai/shared'
 import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
 
 /** Default timeout in milliseconds (300 seconds). */
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -36,12 +37,13 @@ export class ProcessAdapter implements AdapterModule {
         ? ctx.adapterConfig.timeout * 1000
         : DEFAULT_TIMEOUT_MS
 
-    const env: Record<string, string> = {
-      ...process.env,
+    const shackleEnv: Record<string, string> = {
       ...ctx.env,
       SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
       SHACKLEAI_AGENT_ID: ctx.agentId,
     }
+
+    const env: Record<string, string> = getSafeEnv(shackleEnv)
 
     if (ctx.task) {
       env.SHACKLEAI_TASK_ID = ctx.task

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @shackleai/core — Core orchestration engine
  */
-export const VERSION = '0.0.0'
+export const VERSION = '0.1.0'
 
 export { GovernanceEngine, RateLimiter } from './governance/index.js'
 export type { PolicyCheckResult } from './governance/index.js'

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -115,8 +115,12 @@ export class LicenseManager {
     const keyHash = this.hashKey(key)
 
     // Attempt API validation — gracefully handle offline
-    let tier: string = LicenseTier.Pro // default if API unreachable
+    // Default to Free tier if API is unreachable — never grant paid features offline.
+    // The key is marked as pending_validation; periodicValidation() will upgrade
+    // the tier when connectivity returns and the API confirms the key.
+    let tier: string = LicenseTier.Free
     let validUntil: string | null = null
+    let pendingValidation = true
 
     try {
       const response = await fetch(`${API_BASE}/license/validate`, {
@@ -136,9 +140,9 @@ export class LicenseManager {
       }
       tier = data.tier
       validUntil = data.valid_until
+      pendingValidation = false
     } catch {
-      // Offline or API error — accept the key with Pro tier as fallback.
-      // The key format was valid, so we trust it for now.
+      // Offline or API error — default to Free tier (pending_validation).
       // periodicValidation() will re-check when connectivity returns.
     }
 
@@ -149,9 +153,11 @@ export class LicenseManager {
     )
 
     // Store the hash, NEVER the plaintext key
+    // If API was unreachable, mark as pending_validation so periodicValidation()
+    // knows to re-check when connectivity returns.
     await this.db.query(
       `INSERT INTO license_keys (company_id, key_hash, tier, valid_until, last_validated_at)
-       VALUES ($1, $2, $3, $4, NOW())`,
+       VALUES ($1, $2, $3, $4, ${pendingValidation ? 'NULL' : 'NOW()'})`,
       [this.companyId, keyHash, tier, validUntil],
     )
 

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -95,10 +95,17 @@ export class HeartbeatExecutor {
 
     const agent = agentResult.rows[0]
     const companyId = agent.company_id
-    const adapterConfig =
-      typeof agent.adapter_config === 'string'
-        ? (JSON.parse(agent.adapter_config) as Record<string, unknown>)
-        : agent.adapter_config
+    let adapterConfig: Record<string, unknown>
+    try {
+      adapterConfig =
+        typeof agent.adapter_config === 'string'
+          ? (JSON.parse(agent.adapter_config) as Record<string, unknown>)
+          : agent.adapter_config
+    } catch {
+      const errMsg = `Invalid adapter_config JSON for agent ${agentId}`
+      await this.markRunFailed(runId, errMsg)
+      return { exitCode: 1, stderr: errMsg }
+    }
 
     // ── Step 1: Create heartbeat_run (queued) ───────────────────────
     await this.db.query(
@@ -408,7 +415,7 @@ export class HeartbeatExecutor {
       return result.rows
     }
 
-    // No previous heartbeat � return empty (no baseline to compare against)
+    // No previous heartbeat � return empty (no baseline to compare against)
     return []
   }
 

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -51,24 +51,40 @@ export class Scheduler {
    * Start the scheduler — loads all agents with cron expressions from DB
    * and registers their schedules.
    */
-  async start(): Promise<void> {
+  async start(companyId?: string): Promise<void> {
     if (this.started) return
     this.started = true
+
+    const query = companyId
+      ? {
+          text: `SELECT id, adapter_config FROM agents
+                 WHERE status IN ('idle', 'active') AND company_id = $1`,
+          params: [companyId],
+        }
+      : {
+          text: `SELECT id, adapter_config FROM agents
+                 WHERE status IN ('idle', 'active')`,
+          params: [] as string[],
+        }
 
     const result = await this.db.query<{
       id: string
       adapter_config: Record<string, unknown> | string
-    }>(
-      `SELECT id, adapter_config FROM agents
-       WHERE status IN ('idle', 'active')`,
-      [],
-    )
+    }>(query.text, query.params)
 
     for (const row of result.rows) {
-      const config =
-        typeof row.adapter_config === 'string'
-          ? (JSON.parse(row.adapter_config) as Record<string, unknown>)
-          : row.adapter_config
+      let config: Record<string, unknown>
+      try {
+        config =
+          typeof row.adapter_config === 'string'
+            ? (JSON.parse(row.adapter_config) as Record<string, unknown>)
+            : row.adapter_config
+      } catch {
+        console.error(
+          `[Scheduler] Invalid adapter_config JSON for agent ${row.id}, skipping`,
+        )
+        continue
+      }
 
       const cronExpr = config?.cron as string | undefined
       if (cronExpr && cron.validate(cronExpr)) {

--- a/packages/core/src/worktree/manager.ts
+++ b/packages/core/src/worktree/manager.ts
@@ -7,7 +7,7 @@
  */
 
 import { execFile } from 'node:child_process'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { stat } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import { randomUUID } from 'node:crypto'
@@ -485,9 +485,17 @@ export class WorktreeManager {
   private async getDbRecordByPath(
     worktreePath: string,
   ): Promise<AgentWorktree | null> {
+    // Normalize path for case-insensitive Windows filesystems
+    let normalized = resolve(worktreePath)
+    if (process.platform === 'win32') {
+      normalized = normalized.toLowerCase()
+    }
+
     const result = await this.db.query<AgentWorktree>(
-      `SELECT * FROM agent_worktrees WHERE worktree_path = $1`,
-      [worktreePath],
+      process.platform === 'win32'
+        ? `SELECT * FROM agent_worktrees WHERE LOWER(worktree_path) = $1`
+        : `SELECT * FROM agent_worktrees WHERE worktree_path = $1`,
+      [normalized],
     )
     return result.rows[0] ?? null
   }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: { hookTimeout: 30000 },
+})

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,7 +5,7 @@
  * - PGliteProvider: Embedded PostgreSQL for local development (via @electric-sql/pglite)
  * - PgProvider: Standard PostgreSQL for production (via pg)
  *
- * Also includes a migration runner that applies 12 schema migrations.
+ * Also includes a migration runner that applies 13 schema migrations.
  */
 
 export type { DatabaseProvider, QueryResult } from './provider.js'

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -17,7 +17,6 @@ import {
   GoalStatus,
   ProjectStatus,
   AgentApiKeyStatus,
-  WorktreeStatus,
 } from './constants.js'
 
 // ---------------------------------------------------------------------------
@@ -223,7 +222,8 @@ export const CreateCostEventInput = z.object({
   model: z.string().nullable().optional(),
   input_tokens: z.number().int().min(0),
   output_tokens: z.number().int().min(0),
-  cost_cents: z.number().int().min(0),
+  /** Cost in cents — may be fractional (e.g. 0.35 cents for a cheap model call). */
+  cost_cents: z.number().min(0),
 })
 export type CreateCostEventInput = z.infer<typeof CreateCostEventInput>
 
@@ -286,11 +286,6 @@ export type CreateAgentApiKeyInput = z.infer<typeof CreateAgentApiKeyInput>
 // AgentWorktree
 // ---------------------------------------------------------------------------
 
-const worktreeStatusValues = Object.values(WorktreeStatus) as [
-  string,
-  ...string[],
-]
-
 export const CreateWorktreeInput = z.object({
   agent_id: uuid,
   company_id: uuid,
@@ -307,9 +302,3 @@ export const WorktreeCleanupInput = z.object({
 })
 export type WorktreeCleanupInput = z.infer<typeof WorktreeCleanupInput>
 
-export const UpdateWorktreeStatusInput = z.object({
-  status: z.enum(worktreeStatusValues),
-})
-export type UpdateWorktreeStatusInput = z.infer<
-  typeof UpdateWorktreeStatusInput
->


### PR DESCRIPTION
## Summary

Fixes 13 bugs identified during the pre-release audit across `packages/core/`, `packages/shared/`, and `packages/db/`:

- **#71** — Flaky tests: add `vitest.config.ts` with `hookTimeout: 30000`
- **#72** — process.env leak: replace `...process.env` with `getSafeEnv()` whitelist in all 4 adapters (process, claude, openclaw, crewai)
- **#74** — Offline license bypass: default to Free tier (not Pro) when API unreachable, mark key as `pending_validation`
- **#76** — MCP adapter timeout: replace unused AbortController with `Promise.race` timeout
- **#78** — JSON.parse without try/catch: wrap `adapter_config` parsing in scheduler and executor
- **#80** — cost_cents precision: allow fractional values (e.g. 0.35 cents)
- **#81** — Scheduler company_id scoping: add optional `companyId` parameter to `start()`
- **#82** — Worktree Windows path: normalize with `path.resolve()` + case-insensitive lookup
- **#84** — CrewAI regex fails on nested JSON: replace `[^}]+` regex with brace-depth counting
- **#85** — VERSION constant: bump from `0.0.0` to `0.1.0`
- **#86** — Dead `UpdateWorktreeStatusInput`: removed unused validator and imports
- **#87** — process.env undefined values: fixed by #72 (`getSafeEnv` filters undefined)
- **#88** — DB doc comment: update migration count from 12 to 13

Closes #71, closes #72, closes #74, closes #76, closes #78, closes #80, closes #81, closes #82, closes #84, closes #85, closes #86, closes #87, closes #88

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (zero errors/warnings)
- [x] `pnpm build` passes
- [x] `pnpm test` — core/shared/db tests pass; CLI test failures are pre-existing (commander process.exit + migration timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)