### PR TITLE
fix: wave 1 CLI/server bug fixes

### DIFF
--- a/apps/cli/src/api-client.ts
+++ b/apps/cli/src/api-client.ts
@@ -2,9 +2,7 @@
  * Shared API client for CLI commands that call the local orchestrator server.
  */
 
-import { readConfig } from './config.js'
-
-const DEFAULT_PORT = 4800
+import { readConfig, DEFAULT_PORT } from './config.js'
 
 export async function apiClient(
   path: string,
@@ -16,7 +14,8 @@ export async function apiClient(
     process.exit(1)
   }
 
-  const baseUrl = `http://localhost:${DEFAULT_PORT}`
+  const port = config.port ?? DEFAULT_PORT
+  const baseUrl = `http://127.0.0.1:${port}`
   const url = path.startsWith('/') ? `${baseUrl}${path}` : `${baseUrl}/${path}`
 
   const res = await fetch(url, {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -5,9 +5,8 @@
 import type { Command } from 'commander'
 import { WorktreeManager } from '@shackleai/core'
 import { GIT_MIN_VERSION } from '@shackleai/shared'
-import { readConfig, getConfigPath } from '../config.js'
-
-const VERSION = '0.1.0'
+import { readConfig, getConfigPath, DEFAULT_PORT } from '../config.js'
+import { VERSION } from '../index.js'
 
 async function runDoctor(): Promise<void> {
   console.log(`ShackleAI Orchestrator v${VERSION} — Doctor\n`)
@@ -30,8 +29,10 @@ async function runDoctor(): Promise<void> {
 
   // 2. Check DB connection via API health endpoint
   if (config) {
+    const port = config.port ?? DEFAULT_PORT
+    const baseUrl = `http://127.0.0.1:${port}`
     try {
-      const healthRes = await fetch('http://localhost:4800/api/health')
+      const healthRes = await fetch(`${baseUrl}/api/health`)
       if (healthRes.ok) {
         const health = (await healthRes.json()) as {
           status: string
@@ -42,7 +43,7 @@ async function runDoctor(): Promise<void> {
         // 3. Fetch dashboard metrics for counts
         try {
           const dashRes = await fetch(
-            `http://localhost:4800/api/companies/${config.companyId}/dashboard`,
+            `${baseUrl}/api/companies/${config.companyId}/dashboard`,
           )
           if (dashRes.ok) {
             const dash = (await dashRes.json()) as {
@@ -68,7 +69,7 @@ async function runDoctor(): Promise<void> {
       }
     } catch {
       console.log(
-        '[FAIL] Server not reachable at http://localhost:4800. Is it running? (`shackleai start`)',
+        `[FAIL] Server not reachable at ${baseUrl}. Is it running? (\`shackleai start\`)`,
       )
       allOk = false
     }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -6,12 +6,21 @@ import * as p from '@clack/prompts'
 import { PGliteProvider, PgProvider, runMigrations } from '@shackleai/db'
 import { AdapterType } from '@shackleai/shared'
 import type { DatabaseProvider } from '@shackleai/db'
-import { writeConfig } from '../config.js'
+import { readConfig, writeConfig } from '../config.js'
+import { VERSION } from '../index.js'
 
-const VERSION = '0.1.0'
-
-export async function initCommand(): Promise<void> {
+export async function initCommand(options: { force?: boolean } = {}): Promise<void> {
   p.intro(`ShackleAI Orchestrator v${VERSION}`)
+
+  // Check if already initialized
+  const existingConfig = await readConfig()
+  if (existingConfig && !options.force) {
+    p.log.warning(
+      'ShackleAI is already initialized. Run with --force to reinitialize.',
+    )
+    p.outro(`Company: ${existingConfig.companyName} (${existingConfig.companyId})`)
+    return
+  }
 
   const mode = await p.select({
     message: 'Deployment mode',
@@ -94,13 +103,30 @@ export async function initCommand(): Promise<void> {
     .replace(/[^A-Z0-9]/g, '')
     .slice(0, 5)
 
-  const companyResult = await db.query<{ id: string }>(
-    `INSERT INTO companies (name, description, issue_prefix)
-     VALUES ($1, $2, $3)
-     RETURNING id`,
-    [companyName.trim(), mission?.trim() || null, issuePrefix || 'MAIN'],
-  )
-  const companyId = companyResult.rows[0].id
+  let companyId: string
+  try {
+    const companyResult = await db.query<{ id: string }>(
+      `INSERT INTO companies (name, description, issue_prefix)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      [companyName.trim(), mission?.trim() || null, issuePrefix || 'MAIN'],
+    )
+    companyId = companyResult.rows[0].id
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.includes('unique') || message.includes('duplicate')) {
+      spin.stop('Company already exists')
+      p.log.warning(
+        `A company named "${companyName.trim()}" already exists. Run with --force to reinitialize or choose a different name.`,
+      )
+      await db.close()
+      process.exit(1)
+    }
+    spin.stop('Failed to create company')
+    console.error(`Database error: ${message}`)
+    await db.close()
+    process.exit(1)
+  }
   spin.stop('Company created')
 
   // Optionally create first agent

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -5,10 +5,9 @@
 import { serve } from '@hono/node-server'
 import { PGliteProvider, PgProvider, runMigrations } from '@shackleai/db'
 import type { DatabaseProvider } from '@shackleai/db'
-import { readConfig } from '../config.js'
+import { readConfig, writeConfig } from '../config.js'
 import { createApp } from '../server/index.js'
-
-const VERSION = '0.1.0'
+import { VERSION } from '../index.js'
 
 export async function startCommand(options: { port: number }): Promise<void> {
   const config = await readConfig()
@@ -40,14 +39,17 @@ export async function startCommand(options: { port: number }): Promise<void> {
 
   const port = options.port
 
+  // Persist port to config so other CLI commands can find it
+  await writeConfig({ ...config, port })
+
   console.log(`
   ShackleAI Orchestrator v${VERSION}
   Company: ${config.companyName}
   Mode:    ${config.mode}
 
-  Dashboard: http://localhost:${port}
-  Health:    http://localhost:${port}/api/health
+  Dashboard: http://127.0.0.1:${port}
+  Health:    http://127.0.0.1:${port}/api/health
   `)
 
-  serve({ fetch: app.fetch, port })
+  serve({ fetch: app.fetch, port, hostname: '127.0.0.1' })
 }

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -12,7 +12,10 @@ export interface ShackleAIConfig {
   companyName: string
   databaseUrl?: string
   dataDir?: string
+  port?: number
 }
+
+export const DEFAULT_PORT = 4800
 
 export function getConfigPath(): string {
   return join(homedir(), '.shackleai', 'config.json')

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -26,8 +26,9 @@ program
 program
   .command('init')
   .description('Initialize a new ShackleAI orchestrator')
-  .action(async () => {
-    await initCommand()
+  .option('--force', 'Reinitialize even if already configured')
+  .action(async (opts: { force?: boolean }) => {
+    await initCommand({ force: opts.force })
   })
 
 program

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -16,7 +16,7 @@ import { goalsRouter } from './routes/goals.js'
 import { projectsRouter } from './routes/projects.js'
 import { worktreesRouter } from './routes/worktrees.js'
 
-const VERSION = '0.1.0'
+import { VERSION } from '../index.js'
 
 export function createApp(db: DatabaseProvider): Hono {
   const app = new Hono()


### PR DESCRIPTION
## Summary

- **#70**: Bind API server to `127.0.0.1` instead of `0.0.0.0` — prevents exposure on network interfaces
- **#73**: Centralize port configuration — `start` writes port to config, `api-client` and `doctor` read from config with fallback to 4800
- **#77**: Guard `init` against re-run crashes — checks for existing config, adds `--force` flag, wraps DB insert in try/catch for unique constraint violations
- **#83**: Deduplicate `VERSION` constant — single export from `apps/cli/src/index.ts`, all other files import it

Closes #70, closes #73, closes #77, closes #83

## Test plan

- [ ] Run `shackleai init` twice — second run should show "already initialized" message
- [ ] Run `shackleai init --force` — should reinitialize successfully
- [ ] Run `shackleai start --port 5000` then `shackleai doctor` — doctor should hit port 5000
- [ ] Verify server binds to `127.0.0.1` (not reachable from other machines on LAN)
- [ ] Verify `VERSION` is consistent across health endpoint, doctor, init, and start output

🤖 Generated with [Claude Code](https://claude.com/claude-code)