### PR TITLE
fix: add pagination (limit/offset) to all list endpoints

### DIFF
--- a/apps/cli/src/server/pagination.ts
+++ b/apps/cli/src/server/pagination.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared pagination helper for list endpoints.
+ *
+ * Parses `limit` and `offset` query params with safe defaults and bounds.
+ */
+
+import type { Context } from 'hono'
+
+export interface PaginationParams {
+  limit: number
+  offset: number
+}
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
+/**
+ * Parse pagination params from a Hono request context.
+ *
+ * - `limit`: clamped to [1, 1000], default 100
+ * - `offset`: clamped to [0, Infinity), default 0
+ */
+export function parsePagination(c: Context): PaginationParams {
+  const rawLimit = c.req.query('limit')
+  const rawOffset = c.req.query('offset')
+
+  const limit = rawLimit
+    ? Math.min(Math.max(parseInt(rawLimit, 10) || DEFAULT_LIMIT, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT
+
+  const offset = rawOffset ? Math.max(parseInt(rawOffset, 10) || 0, 0) : 0
+
+  return { limit, offset }
+}

--- a/apps/cli/src/server/routes/activity.ts
+++ b/apps/cli/src/server/routes/activity.ts
@@ -65,10 +65,13 @@ export function activityRouter(db: DatabaseProvider): Hono<{ Variables: Variable
       }
     }
 
+    const { offset: offsetStr } = c.req.query()
+    const offset = offsetStr ? Math.max(parseInt(offsetStr, 10) || 0, 0) : 0
+
     const where = conditions.join(' AND ')
     const result = await db.query<ActivityLogEntry>(
-      `SELECT * FROM activity_log WHERE ${where} ORDER BY created_at DESC LIMIT $${paramIndex}`,
-      [...params, limit],
+      `SELECT * FROM activity_log WHERE ${where} ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
     )
 
     return c.json({ data: result.rows })

--- a/apps/cli/src/server/routes/agents.ts
+++ b/apps/cli/src/server/routes/agents.ts
@@ -10,6 +10,7 @@ import { CreateAgentInput, UpdateAgentInput } from '@shackleai/shared'
 import { AgentStatus, AgentApiKeyStatus } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -25,9 +26,10 @@ export function agentsRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
   // GET /api/companies/:id/agents — list agents with status, budget, last_heartbeat_at
   app.get('/:id/agents', companyScope, async (c) => {
     const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<Agent>(
-      `SELECT * FROM agents WHERE company_id = $1 ORDER BY created_at DESC`,
-      [companyId],
+      `SELECT * FROM agents WHERE company_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return c.json({ data: result.rows })
   })

--- a/apps/cli/src/server/routes/companies.ts
+++ b/apps/cli/src/server/routes/companies.ts
@@ -8,6 +8,7 @@ import type { Company } from '@shackleai/shared'
 import { CreateCompanyInput, UpdateCompanyInput } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -22,7 +23,11 @@ export function companiesRouter(db: DatabaseProvider): Hono<{ Variables: Variabl
 
   // GET /api/companies — list all companies
   app.get('/', async (c) => {
-    const result = await db.query<Company>('SELECT * FROM companies ORDER BY created_at DESC')
+    const { limit, offset } = parsePagination(c)
+    const result = await db.query<Company>(
+      'SELECT * FROM companies ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+      [limit, offset],
+    )
     return c.json({ data: result.rows })
   })
 

--- a/apps/cli/src/server/routes/costs.ts
+++ b/apps/cli/src/server/routes/costs.ts
@@ -8,6 +8,7 @@ import type { CostEvent } from '@shackleai/shared'
 import { CreateCostEventInput } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -47,10 +48,12 @@ export function costsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }
       params.push(to)
     }
 
+    const { limit, offset } = parsePagination(c)
+
     const where = conditions.join(' AND ')
     const result = await db.query<CostEvent>(
-      `SELECT * FROM cost_events WHERE ${where} ORDER BY occurred_at DESC`,
-      params,
+      `SELECT * FROM cost_events WHERE ${where} ORDER BY occurred_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
     )
 
     return c.json({ data: result.rows })

--- a/apps/cli/src/server/routes/goals.ts
+++ b/apps/cli/src/server/routes/goals.ts
@@ -8,6 +8,7 @@ import type { Goal } from '@shackleai/shared'
 import { CreateGoalInput } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -23,9 +24,10 @@ export function goalsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }
   // GET /api/companies/:id/goals — list goals
   app.get('/:id/goals', companyScope, async (c) => {
     const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<Goal>(
-      `SELECT * FROM goals WHERE company_id = $1 ORDER BY created_at DESC`,
-      [companyId],
+      `SELECT * FROM goals WHERE company_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return c.json({ data: result.rows })
   })

--- a/apps/cli/src/server/routes/heartbeats.ts
+++ b/apps/cli/src/server/routes/heartbeats.ts
@@ -7,6 +7,7 @@ import type { DatabaseProvider } from '@shackleai/db'
 import type { HeartbeatRun } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -22,9 +23,10 @@ export function heartbeatsRouter(db: DatabaseProvider): Hono<{ Variables: Variab
   // GET /api/companies/:id/heartbeats — list heartbeat runs ordered by created_at DESC
   app.get('/:id/heartbeats', companyScope, async (c) => {
     const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<HeartbeatRun>(
-      `SELECT * FROM heartbeat_runs WHERE company_id = $1 ORDER BY created_at DESC`,
-      [companyId],
+      `SELECT * FROM heartbeat_runs WHERE company_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return c.json({ data: result.rows })
   })

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -9,6 +9,7 @@ import { CreateIssueInput, UpdateIssueInput, CreateIssueCommentInput } from '@sh
 import { IssueStatus } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -45,10 +46,12 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
       params.push(assignee)
     }
 
+    const { limit, offset } = parsePagination(c)
+
     const where = conditions.join(' AND ')
     const result = await db.query<Issue>(
-      `SELECT * FROM issues WHERE ${where} ORDER BY created_at DESC`,
-      params,
+      `SELECT * FROM issues WHERE ${where} ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
     )
 
     return c.json({ data: result.rows })
@@ -296,9 +299,10 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
       return c.json({ error: 'Issue not found' }, 404)
     }
 
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<IssueComment>(
-      `SELECT * FROM issue_comments WHERE issue_id = $1 ORDER BY created_at ASC`,
-      [issueId],
+      `SELECT * FROM issue_comments WHERE issue_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3`,
+      [issueId, limit, offset],
     )
 
     return c.json({ data: result.rows })

--- a/apps/cli/src/server/routes/policies.ts
+++ b/apps/cli/src/server/routes/policies.ts
@@ -8,6 +8,7 @@ import type { Policy } from '@shackleai/shared'
 import { CreatePolicyInput, UpdatePolicyInput } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -23,9 +24,10 @@ export function policiesRouter(db: DatabaseProvider): Hono<{ Variables: Variable
   // GET /api/companies/:id/policies — list policies for company
   app.get('/:id/policies', companyScope, async (c) => {
     const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<Policy>(
-      `SELECT * FROM policies WHERE company_id = $1 ORDER BY priority DESC, created_at DESC`,
-      [companyId],
+      `SELECT * FROM policies WHERE company_id = $1 ORDER BY priority DESC, created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return c.json({ data: result.rows })
   })

--- a/apps/cli/src/server/routes/projects.ts
+++ b/apps/cli/src/server/routes/projects.ts
@@ -8,6 +8,7 @@ import type { Project } from '@shackleai/shared'
 import { CreateProjectInput } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -23,9 +24,10 @@ export function projectsRouter(db: DatabaseProvider): Hono<{ Variables: Variable
   // GET /api/companies/:id/projects — list projects
   app.get('/:id/projects', companyScope, async (c) => {
     const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
     const result = await db.query<Project>(
-      `SELECT * FROM projects WHERE company_id = $1 ORDER BY created_at DESC`,
-      [companyId],
+      `SELECT * FROM projects WHERE company_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return c.json({ data: result.rows })
   })

--- a/apps/cli/src/server/routes/worktrees.ts
+++ b/apps/cli/src/server/routes/worktrees.ts
@@ -13,6 +13,7 @@ import {
 import { WorktreeManager } from '@shackleai/core'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
@@ -45,7 +46,8 @@ export function worktreesRouter(
         return c.json({ error: 'Agent not found' }, 404)
       }
 
-      const worktrees = await manager.list(companyId, agentId)
+      const { limit, offset } = parsePagination(c)
+      const worktrees = await manager.list(companyId, agentId, { limit, offset })
       return c.json({ data: worktrees })
     },
   )

--- a/packages/core/src/worktree/manager.ts
+++ b/packages/core/src/worktree/manager.ts
@@ -273,13 +273,18 @@ export class WorktreeManager {
   async list(
     companyId: string,
     agentId?: string,
+    pagination?: { limit: number; offset: number },
   ): Promise<AgentWorktree[]> {
+    const limit = pagination?.limit ?? 100
+    const offset = pagination?.offset ?? 0
+
     if (agentId) {
       const result = await this.db.query<AgentWorktree>(
         `SELECT * FROM agent_worktrees
          WHERE company_id = $1 AND agent_id = $2
-         ORDER BY created_at DESC`,
-        [companyId, agentId],
+         ORDER BY created_at DESC
+         LIMIT $3 OFFSET $4`,
+        [companyId, agentId, limit, offset],
       )
       return result.rows
     }
@@ -287,8 +292,9 @@ export class WorktreeManager {
     const result = await this.db.query<AgentWorktree>(
       `SELECT * FROM agent_worktrees
        WHERE company_id = $1
-       ORDER BY created_at DESC`,
-      [companyId],
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
     )
     return result.rows
   }


### PR DESCRIPTION
## Summary

- Adds `?limit=N&offset=N` query param support to all list endpoints (default limit 100, max 1000)
- Creates shared `parsePagination()` helper in `apps/cli/src/server/pagination.ts`
- Adds LIMIT/OFFSET to: agents, issues, issue comments, heartbeats, costs, policies, companies, goals, projects, worktrees
- Adds offset support to activity endpoint (already had limit capped at 50)
- Extends `WorktreeManager.list()` in `@shackleai/core` to accept pagination params

## Test plan

- [ ] Verify `GET /api/companies/:id/agents` returns at most 100 rows by default
- [ ] Verify `?limit=5&offset=10` correctly paginates results
- [ ] Verify `?limit=9999` is clamped to 1000
- [ ] Verify `?limit=-1` is clamped to 1
- [ ] Verify `?offset=-5` is clamped to 0
- [ ] Verify activity endpoint still caps at 50 and now supports offset

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)