### PR TITLE
fix: wakeup route triggers real execution + deduplicate heartbeat_runs

### DIFF
--- a/apps/cli/__tests__/agents.test.ts
+++ b/apps/cli/__tests__/agents.test.ts
@@ -228,13 +228,14 @@ describe('agents routes — lifecycle', () => {
     expect(body.data.status).toBe(AgentStatus.Terminated)
   })
 
-  it('POST /:agentId/wakeup updates last_heartbeat_at', async () => {
+  it('POST /:agentId/wakeup updates last_heartbeat_at (no scheduler fallback)', async () => {
     const res = await app.request(`/api/companies/${companyId}/agents/${agentId}/wakeup`, {
       method: 'POST',
     })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { data: { triggered: boolean; agent: { last_heartbeat_at: string } } }
-    expect(body.data.triggered).toBe(true)
+    // Without a scheduler, triggered is false (fallback mode)
+    expect(body.data.triggered).toBe(false)
     expect(body.data.agent.last_heartbeat_at).toBeTruthy()
   })
 

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -6,10 +6,18 @@ import type { Command } from 'commander'
 import type { Agent } from '@shackleai/shared'
 import { apiClient, getCompanyId } from '../api-client.js'
 
+interface WakeupResult {
+  exitCode: number
+  stdout?: string
+  stderr?: string
+}
+
 interface WakeupResponse {
   data: {
     agent: Agent
     triggered: boolean
+    reason?: string
+    result?: WakeupResult
   }
   error?: string
 }
@@ -31,7 +39,7 @@ async function runAgent(agentId: string): Promise<void> {
   }
 
   const body = (await res.json()) as WakeupResponse
-  const { agent, triggered } = body.data
+  const { agent, triggered, reason, result } = body.data
 
   console.log(`Triggered: ${triggered}`)
   console.log(`Agent:     ${agent.name} (${agent.id})`)
@@ -39,6 +47,20 @@ async function runAgent(agentId: string): Promise<void> {
   console.log(
     `Heartbeat: ${agent.last_heartbeat_at ? new Date(agent.last_heartbeat_at).toLocaleString() : '-'}`,
   )
+
+  if (!triggered && reason) {
+    console.log(`Reason:    ${reason}`)
+  }
+
+  if (result) {
+    console.log(`Exit code: ${result.exitCode}`)
+    if (result.stdout) {
+      console.log(`Output:    ${result.stdout.slice(0, 500)}`)
+    }
+    if (result.stderr) {
+      console.error(`Error:     ${result.stderr.slice(0, 500)}`)
+    }
+  }
 }
 
 export function registerRunCommand(program: Command): void {

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -5,6 +5,19 @@
 import { serve } from '@hono/node-server'
 import { PGliteProvider, PgProvider, runMigrations } from '@shackleai/db'
 import type { DatabaseProvider } from '@shackleai/db'
+import {
+  Scheduler,
+  HeartbeatExecutor,
+  CostTracker,
+  Observatory,
+  AdapterRegistry,
+  ProcessAdapter,
+  HttpAdapter,
+  ClaudeAdapter,
+  McpAdapter,
+  OpenClawAdapter,
+  CrewAIAdapter,
+} from '@shackleai/core'
 import { readConfig, writeConfig } from '../config.js'
 import { createApp } from '../server/index.js'
 import { VERSION } from '../index.js'
@@ -35,7 +48,27 @@ export async function startCommand(options: { port: number }): Promise<void> {
 
   await runMigrations(db)
 
-  const app = createApp(db)
+  // Initialize core services
+  const costTracker = new CostTracker(db)
+  const observatory = new Observatory(db)
+  const adapterRegistry = new AdapterRegistry()
+  adapterRegistry.register(new ProcessAdapter())
+  adapterRegistry.register(new HttpAdapter())
+  adapterRegistry.register(new ClaudeAdapter())
+  adapterRegistry.register(new McpAdapter())
+  adapterRegistry.register(new OpenClawAdapter())
+  adapterRegistry.register(new CrewAIAdapter())
+
+  // HeartbeatExecutor is the single source of truth for heartbeat_run records
+  const executor = new HeartbeatExecutor(db, costTracker, observatory, adapterRegistry)
+
+  // Scheduler wraps executor with coalescing and cron scheduling
+  const scheduler = new Scheduler(db, (agentId, trigger) =>
+    executor.execute(agentId, trigger),
+  )
+  await scheduler.start()
+
+  const app = createApp(db, { scheduler })
 
   const port = options.port
 

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -4,6 +4,7 @@
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
+import type { Scheduler } from '@shackleai/core'
 import { companiesRouter } from './routes/companies.js'
 import { dashboardRouter } from './routes/dashboard.js'
 import { agentsRouter } from './routes/agents.js'
@@ -18,7 +19,11 @@ import { worktreesRouter } from './routes/worktrees.js'
 
 import { VERSION } from '../index.js'
 
-export function createApp(db: DatabaseProvider): Hono {
+export interface CreateAppOptions {
+  scheduler?: Scheduler
+}
+
+export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hono {
   const app = new Hono()
 
   app.get('/api/health', (c) => {
@@ -27,7 +32,7 @@ export function createApp(db: DatabaseProvider): Hono {
 
   app.route('/api/companies', companiesRouter(db))
   app.route('/api/companies', dashboardRouter(db))
-  app.route('/api/companies', agentsRouter(db))
+  app.route('/api/companies', agentsRouter(db, options?.scheduler))
   app.route('/api/companies', issuesRouter(db))
   app.route('/api/companies', policiesRouter(db))
   app.route('/api/companies', costsRouter(db))

--- a/apps/cli/src/server/routes/agents.ts
+++ b/apps/cli/src/server/routes/agents.ts
@@ -6,14 +6,15 @@ import { Hono } from 'hono'
 import { createHash, randomBytes } from 'node:crypto'
 import type { DatabaseProvider } from '@shackleai/db'
 import type { Agent, AgentApiKey } from '@shackleai/shared'
-import { CreateAgentInput, UpdateAgentInput } from '@shackleai/shared'
+import { CreateAgentInput, UpdateAgentInput, TriggerType } from '@shackleai/shared'
 import { AgentStatus, AgentApiKeyStatus } from '@shackleai/shared'
+import type { Scheduler } from '@shackleai/core'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
 
 type Variables = CompanyScopeVariables
 
-export function agentsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+export function agentsRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<{ Variables: Variables }> {
   const app = new Hono<{ Variables: Variables }>()
 
   // Inject db into context for all routes
@@ -220,21 +221,64 @@ export function agentsRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
 
   // POST /api/companies/:id/agents/:agentId/wakeup — on-demand heartbeat
   app.post('/:id/agents/:agentId/wakeup', companyScope, async (c) => {
-    const companyId = c.req.param('id')
-    const agentId = c.req.param('agentId')
+    const companyId = c.req.param('id') as string
+    const agentId = c.req.param('agentId') as string
 
-    const result = await db.query<Agent>(
-      `UPDATE agents SET last_heartbeat_at = NOW(), updated_at = NOW()
-       WHERE id = $1 AND company_id = $2
-       RETURNING *`,
+    // Verify agent exists and belongs to company
+    const agentResult = await db.query<Agent>(
+      `SELECT * FROM agents WHERE id = $1 AND company_id = $2`,
       [agentId, companyId],
     )
 
-    if (result.rows.length === 0) {
+    if (agentResult.rows.length === 0) {
       return c.json({ error: 'Agent not found' }, 404)
     }
 
-    return c.json({ data: { agent: result.rows[0], triggered: true } })
+    // If no scheduler is available, fall back to just updating the timestamp
+    if (!scheduler) {
+      const updated = await db.query<Agent>(
+        `UPDATE agents SET last_heartbeat_at = NOW(), updated_at = NOW()
+         WHERE id = $1 AND company_id = $2
+         RETURNING *`,
+        [agentId, companyId],
+      )
+      return c.json({ data: { agent: updated.rows[0], triggered: false } })
+    }
+
+    // Trigger real execution via the scheduler (which handles coalescing)
+    const runResult = await scheduler.triggerNow(agentId, TriggerType.Manual)
+
+    if (!runResult) {
+      // Coalesced (agent already running) or failed to start
+      const agent = agentResult.rows[0]
+      return c.json({
+        data: {
+          agent,
+          triggered: false,
+          reason: scheduler.isRunning(agentId)
+            ? 'Agent heartbeat already in progress'
+            : 'Execution could not be started',
+        },
+      })
+    }
+
+    // Re-fetch agent to get updated state after execution
+    const updatedAgent = await db.query<Agent>(
+      `SELECT * FROM agents WHERE id = $1 AND company_id = $2`,
+      [agentId, companyId],
+    )
+
+    return c.json({
+      data: {
+        agent: updatedAgent.rows[0] ?? agentResult.rows[0],
+        triggered: true,
+        result: {
+          exitCode: runResult.exitCode,
+          stdout: runResult.stdout,
+          stderr: runResult.stderr,
+        },
+      },
+    })
   })
 
   // POST /api/companies/:id/agents/:agentId/api-keys — generate API key

--- a/packages/core/__tests__/scheduler.test.ts
+++ b/packages/core/__tests__/scheduler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { PGliteProvider, runMigrations } from '@shackleai/db'
 import type { DatabaseProvider } from '@shackleai/db'
-import { TriggerType, HeartbeatRunStatus } from '@shackleai/shared'
+import { TriggerType } from '@shackleai/shared'
 import { Scheduler } from '../src/scheduler.js'
 import type { RunnerExecutor } from '../src/scheduler.js'
 
@@ -127,7 +127,7 @@ describe('Scheduler', () => {
   })
 
   describe('triggerNow — on-demand', () => {
-    it('executes heartbeat and creates a run record', async () => {
+    it('delegates execution to the executor and returns its result', async () => {
       const executor: RunnerExecutor = vi.fn(async () => ({
         exitCode: 0,
         stdout: 'done',
@@ -136,82 +136,53 @@ describe('Scheduler', () => {
       }))
 
       scheduler = new Scheduler(db, executor)
-      const runId = await scheduler.triggerNow(
+      const result = await scheduler.triggerNow(
         AGENT_ONDEMAND_ID,
         TriggerType.Manual,
       )
 
-      expect(runId).toBeTruthy()
+      expect(result).not.toBeNull()
+      expect(result!.exitCode).toBe(0)
+      expect(result!.stdout).toBe('done')
       expect(executor).toHaveBeenCalledWith(
         AGENT_ONDEMAND_ID,
         TriggerType.Manual,
       )
-
-      // Verify heartbeat_runs record
-      const runs = await db.query<{
-        id: string
-        status: string
-        trigger_type: string
-        exit_code: number
-        stdout_excerpt: string
-        session_id_after: string
-      }>('SELECT * FROM heartbeat_runs WHERE id = $1', [runId])
-
-      expect(runs.rows).toHaveLength(1)
-      expect(runs.rows[0].status).toBe(HeartbeatRunStatus.Success)
-      expect(runs.rows[0].trigger_type).toBe(TriggerType.Manual)
-      expect(runs.rows[0].exit_code).toBe(0)
-      expect(runs.rows[0].stdout_excerpt).toBe('done')
-      expect(runs.rows[0].session_id_after).toBe('sess-123')
     })
 
-    it('marks failed runs with exit code and error', async () => {
+    it('returns result with non-zero exit code from executor', async () => {
       const failExecutor: RunnerExecutor = vi.fn(async () => ({
         exitCode: 1,
         stderr: 'crash',
       }))
 
       scheduler = new Scheduler(db, failExecutor)
-      const runId = await scheduler.triggerNow(
+      const result = await scheduler.triggerNow(
         AGENT_ONDEMAND_ID,
         TriggerType.Api,
       )
 
-      expect(runId).toBeTruthy()
-
-      const runs = await db.query<{ status: string; error: string }>(
-        'SELECT status, error FROM heartbeat_runs WHERE id = $1',
-        [runId],
-      )
-      expect(runs.rows[0].status).toBe(HeartbeatRunStatus.Failed)
-      expect(runs.rows[0].error).toBe('crash')
+      expect(result).not.toBeNull()
+      expect(result!.exitCode).toBe(1)
+      expect(result!.stderr).toBe('crash')
     })
 
-    it('returns null for unknown agent', async () => {
-      scheduler = new Scheduler(db, successExecutor)
-      const runId = await scheduler.triggerNow(
+    it('returns result for unknown agent (executor handles error)', async () => {
+      // The executor is responsible for returning an error result for unknown agents.
+      // The scheduler just forwards whatever the executor returns.
+      const executor: RunnerExecutor = vi.fn(async () => ({
+        exitCode: 1,
+        stderr: 'Agent not found',
+      }))
+
+      scheduler = new Scheduler(db, executor)
+      const result = await scheduler.triggerNow(
         '00000000-0000-4000-a000-999999999999',
         TriggerType.Manual,
       )
-      expect(runId).toBeNull()
-    })
 
-    it('updates agent last_heartbeat_at', async () => {
-      scheduler = new Scheduler(db, successExecutor)
-
-      // Clear existing heartbeat_at
-      await db.query(
-        'UPDATE agents SET last_heartbeat_at = NULL WHERE id = $1',
-        [AGENT_ONDEMAND_ID],
-      )
-
-      await scheduler.triggerNow(AGENT_ONDEMAND_ID, TriggerType.Manual)
-
-      const agent = await db.query<{ last_heartbeat_at: Date | null }>(
-        'SELECT last_heartbeat_at FROM agents WHERE id = $1',
-        [AGENT_ONDEMAND_ID],
-      )
-      expect(agent.rows[0].last_heartbeat_at).not.toBeNull()
+      expect(result).not.toBeNull()
+      expect(result!.exitCode).toBe(1)
     })
   })
 
@@ -252,7 +223,8 @@ describe('Scheduler', () => {
       // Unblock first
       resolveFirst!()
       const firstResult = await firstPromise
-      expect(firstResult).toBeTruthy()
+      expect(firstResult).not.toBeNull()
+      expect(firstResult!.exitCode).toBe(0)
 
       // Executor was only called once
       expect(callCount).toBe(1)
@@ -266,13 +238,13 @@ describe('Scheduler', () => {
       })
 
       scheduler = new Scheduler(db, throwingExecutor)
-      const runId = await scheduler.triggerNow(
+      const result = await scheduler.triggerNow(
         AGENT_ONDEMAND_ID,
         TriggerType.Manual,
       )
 
       // Returns null on error
-      expect(runId).toBeNull()
+      expect(result).toBeNull()
 
       // Agent should no longer be marked as running
       expect(scheduler.isRunning(AGENT_ONDEMAND_ID)).toBe(false)

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -11,9 +11,7 @@
 
 import type { DatabaseProvider } from '@shackleai/db'
 import type { TriggerType } from '@shackleai/shared'
-import { HeartbeatRunStatus } from '@shackleai/shared'
 import cron from 'node-cron'
-import { randomUUID } from 'node:crypto'
 
 /** Result returned by the runner executor callback. */
 export interface RunnerResult {
@@ -133,9 +131,9 @@ export class Scheduler {
 
   /**
    * Trigger an immediate on-demand heartbeat for an agent.
-   * Returns the heartbeat run ID.
+   * Returns the RunnerResult from the executor, or null if coalesced/skipped.
    */
-  async triggerNow(agentId: string, reason: TriggerType): Promise<string | null> {
+  async triggerNow(agentId: string, reason: TriggerType): Promise<RunnerResult | null> {
     return this.executeHeartbeat(agentId, reason)
   }
 
@@ -156,101 +154,26 @@ export class Scheduler {
 
   /**
    * Execute a heartbeat for the given agent.
-   * Creates a heartbeat_run record, calls the executor, updates status.
+   * Delegates all run-record management and agent status to the executor.
    * Coalescing: if agent already running, skip and return null.
    */
   private async executeHeartbeat(
     agentId: string,
     trigger: TriggerType,
-  ): Promise<string | null> {
+  ): Promise<RunnerResult | null> {
     // Coalescing — skip if already running
     if (this.running.has(agentId)) {
       return null
     }
 
     this.running.add(agentId)
-    const runId = randomUUID()
 
     try {
-      // Look up agent's company_id
-      const agentResult = await this.db.query<{ company_id: string }>(
-        'SELECT company_id FROM agents WHERE id = $1',
-        [agentId],
-      )
-
-      if (agentResult.rows.length === 0) {
-        return null
-      }
-
-      const companyId = agentResult.rows[0].company_id
-
-      // Insert queued heartbeat_run
-      await this.db.query(
-        `INSERT INTO heartbeat_runs (id, company_id, agent_id, trigger_type, status, created_at)
-         VALUES ($1, $2, $3, $4, $5, NOW())`,
-        [runId, companyId, agentId, trigger, HeartbeatRunStatus.Queued],
-      )
-
-      // Mark as running
-      await this.db.query(
-        `UPDATE heartbeat_runs SET status = $1, started_at = NOW() WHERE id = $2`,
-        [HeartbeatRunStatus.Running, runId],
-      )
-
-      // Execute the runner
+      // Delegate entirely to the executor — it owns heartbeat_run
+      // creation, agent status transitions, and result recording.
       const result = await this.executor(agentId, trigger)
-
-      // Determine final status
-      const finalStatus =
-        result.exitCode === 0
-          ? HeartbeatRunStatus.Success
-          : HeartbeatRunStatus.Failed
-
-      // Update heartbeat_run with result
-      await this.db.query(
-        `UPDATE heartbeat_runs
-         SET status = $1,
-             finished_at = NOW(),
-             exit_code = $2,
-             stdout_excerpt = $3,
-             error = $4,
-             usage_json = $5,
-             session_id_after = $6
-         WHERE id = $7`,
-        [
-          finalStatus,
-          result.exitCode,
-          result.stdout?.slice(0, 4000) ?? null,
-          result.stderr ?? null,
-          result.usage ? JSON.stringify(result.usage) : null,
-          result.sessionIdAfter ?? null,
-          runId,
-        ],
-      )
-
-      // Update agent's last_heartbeat_at
-      await this.db.query(
-        'UPDATE agents SET last_heartbeat_at = NOW() WHERE id = $1',
-        [agentId],
-      )
-
-      return runId
-    } catch (err) {
-      // Mark the run as failed if possible
-      try {
-        await this.db.query(
-          `UPDATE heartbeat_runs
-           SET status = $1, finished_at = NOW(), error = $2
-           WHERE id = $3`,
-          [
-            HeartbeatRunStatus.Failed,
-            err instanceof Error ? err.message : String(err),
-            runId,
-          ],
-        )
-      } catch {
-        // Best-effort — don't let logging failure mask the real error
-      }
+      return result
+    } catch {
       return null
     } finally {
       this.running.delete(agentId)


### PR DESCRIPTION
## Summary

- **Wakeup route now triggers real heartbeat execution** (#68): `POST /agents/:agentId/wakeup` now accepts an optional `Scheduler` and calls `scheduler.triggerNow()` to execute a full heartbeat (adapter load, budget check, context build, execution). Returns the actual `RunnerResult` including exit code, stdout, and stderr. Falls back to timestamp-only update when no scheduler is wired.
- **Deduplicated heartbeat_runs** (#69): Stripped the `Scheduler.executeHeartbeat()` down to coalescing + delegation. It no longer creates `heartbeat_runs` records or manages agent status — that is now exclusively the `HeartbeatExecutor`'s responsibility.
- **Wired up full stack in `start.ts`**: The `startCommand` now creates `CostTracker`, `Observatory`, `AdapterRegistry`, `HeartbeatExecutor`, and `Scheduler`, passing the scheduler into `createApp()` so the wakeup route has access to it.

Closes #68, closes #69

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Scheduler tests updated — 12/12 pass (no longer assert heartbeat_run creation in scheduler)
- [x] Executor tests unchanged — 12/12 pass (executor remains the single source of truth)
- [x] Agents route wakeup test updated for fallback behavior (no scheduler = `triggered: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)