### PR TITLE
feat: Tool-call tracing for agent heartbeats

### DIFF
--- a/apps/cli/__tests__/tool-calls.test.ts
+++ b/apps/cli/__tests__/tool-calls.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { AdapterType, TriggerType, HeartbeatRunStatus } from '@shackleai/shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createCompany(app: ReturnType<typeof createApp>, name = 'Test Corp') {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, issue_prefix: name.toUpperCase().slice(0, 4) }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createAgent(app: ReturnType<typeof createApp>, companyId: string) {
+  const res = await app.request(`/api/companies/${companyId}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'TC Agent', adapter_type: AdapterType.Claude }),
+  })
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function insertHeartbeatRun(db: PGliteProvider, companyId: string, agentId: string) {
+  const result = await db.query<{ id: string }>(
+    `INSERT INTO heartbeat_runs (company_id, agent_id, trigger_type, status)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [companyId, agentId, TriggerType.Manual, HeartbeatRunStatus.Success],
+  )
+  return result.rows[0].id
+}
+
+async function insertToolCall(
+  db: PGliteProvider,
+  runId: string,
+  agentId: string,
+  companyId: string,
+  toolName: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const result = await db.query<{ id: string }>(
+    `INSERT INTO tool_calls (heartbeat_run_id, agent_id, company_id, tool_name, tool_input, tool_output, duration_ms, status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id`,
+    [
+      runId,
+      agentId,
+      companyId,
+      toolName,
+      overrides.tool_input ? JSON.stringify(overrides.tool_input) : null,
+      (overrides.tool_output as string) ?? null,
+      (overrides.duration_ms as number) ?? null,
+      (overrides.status as string) ?? 'success',
+    ],
+  )
+  return result.rows[0].id
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('tool-calls routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+  let runId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    companyId = await createCompany(app, 'ToolCall Corp')
+    agentId = await createAgent(app, companyId)
+    runId = await insertHeartbeatRun(db, companyId, agentId)
+
+    // Insert some tool calls
+    await insertToolCall(db, runId, agentId, companyId, 'read_file', {
+      tool_input: { path: '/src/index.ts' },
+      tool_output: 'file contents',
+      duration_ms: 100,
+    })
+    await insertToolCall(db, runId, agentId, companyId, 'write_file', {
+      tool_input: { path: '/src/out.ts' },
+      duration_ms: 200,
+    })
+    await insertToolCall(db, runId, agentId, companyId, 'bash', {
+      status: 'error',
+      duration_ms: 50,
+    })
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/tool-calls returns all tool calls for the company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/tool-calls`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { tool_name: string }[] }
+    expect(body.data).toHaveLength(3)
+  })
+
+  it('GET /api/companies/:id/tool-calls?run_id= filters by heartbeat run', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?run_id=${runId}`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { tool_name: string }[] }
+    expect(body.data).toHaveLength(3)
+  })
+
+  it('GET /api/companies/:id/tool-calls?agent_id= filters by agent', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?agent_id=${agentId}`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { tool_name: string }[] }
+    expect(body.data).toHaveLength(3)
+  })
+
+  it('GET /api/companies/:id/tool-calls?tool_name= filters by tool name', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?tool_name=read_file`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { tool_name: string }[] }
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].tool_name).toBe('read_file')
+  })
+
+  it('GET /api/companies/:id/tool-calls?run_id= returns empty for unknown run', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?run_id=00000000-0000-0000-0000-000000000000`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('returns 404 for non-existent company', async () => {
+    const res = await app.request(
+      `/api/companies/00000000-0000-0000-0000-000000000000/tool-calls`,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('supports pagination with limit and offset', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?limit=2&offset=0`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toHaveLength(2)
+  })
+
+  it('supports combined filters', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/tool-calls?agent_id=${agentId}&tool_name=bash`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { tool_name: string; status: string }[] }
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].tool_name).toBe('bash')
+    expect(body.data[0].status).toBe('error')
+  })
+})

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -20,6 +20,7 @@ import { activityRouter } from './routes/activity.js'
 import { goalsRouter } from './routes/goals.js'
 import { projectsRouter } from './routes/projects.js'
 import { worktreesRouter } from './routes/worktrees.js'
+import { toolCallsRouter } from './routes/tool-calls.js'
 
 import { VERSION } from '../index.js'
 
@@ -45,6 +46,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', goalsRouter(db))
   app.route('/api/companies', projectsRouter(db))
   app.route('/api/companies', worktreesRouter(db))
+  app.route('/api/companies', toolCallsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/tool-calls.ts
+++ b/apps/cli/src/server/routes/tool-calls.ts
@@ -1,0 +1,67 @@
+/**
+ * Tool call routes — /api/companies/:id/tool-calls
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { ToolCall } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+export function toolCallsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/tool-calls — list tool calls with optional filters
+  app.get('/:id/tool-calls', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
+
+    const agentId = c.req.query('agent_id')
+    const runId = c.req.query('run_id')
+    const toolName = c.req.query('tool_name')
+
+    // Build dynamic WHERE clause with parameterized queries
+    const conditions: string[] = ['company_id = $1']
+    const params: unknown[] = [companyId]
+    let paramIdx = 2
+
+    if (agentId) {
+      conditions.push(`agent_id = $${paramIdx}`)
+      params.push(agentId)
+      paramIdx++
+    }
+
+    if (runId) {
+      conditions.push(`heartbeat_run_id = $${paramIdx}`)
+      params.push(runId)
+      paramIdx++
+    }
+
+    if (toolName) {
+      conditions.push(`tool_name = $${paramIdx}`)
+      params.push(toolName)
+      paramIdx++
+    }
+
+    const where = conditions.join(' AND ')
+    params.push(limit, offset)
+
+    const result = await db.query<ToolCall>(
+      `SELECT * FROM tool_calls WHERE ${where} ORDER BY created_at DESC LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+      params,
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  return app
+}

--- a/packages/core/__tests__/tool-calls.test.ts
+++ b/packages/core/__tests__/tool-calls.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import type { DatabaseProvider } from '@shackleai/db'
+import { TriggerType } from '@shackleai/shared'
+import { CostTracker } from '../src/cost-tracker.js'
+import { Observatory } from '../src/observatory.js'
+import { AdapterRegistry } from '../src/adapters/index.js'
+import type { AdapterModule, AdapterResult } from '../src/adapters/index.js'
+import { HeartbeatExecutor } from '../src/runner/executor.js'
+
+let db: PGliteProvider
+let costTracker: CostTracker
+let observatory: Observatory
+
+const COMPANY_ID = '00000000-0000-4000-a000-000000000101'
+const AGENT_ID = '00000000-0000-4000-a000-000000000110'
+
+async function seedTestData(provider: DatabaseProvider): Promise<void> {
+  await provider.query(
+    `INSERT INTO companies (id, name, status, issue_prefix, issue_counter, budget_monthly_cents, spent_monthly_cents)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [COMPANY_ID, 'ToolCall Co', 'active', 'TCC', 0, 100000, 0],
+  )
+
+  await provider.query(
+    `INSERT INTO agents (id, company_id, name, adapter_type, adapter_config, budget_monthly_cents, spent_monthly_cents)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      AGENT_ID,
+      COMPANY_ID,
+      'tool-bot',
+      'process',
+      JSON.stringify({ command: 'echo', args: ['hello'] }),
+      10000,
+      0,
+    ],
+  )
+}
+
+function createMockAdapter(overrides: Partial<AdapterResult> = {}): AdapterModule {
+  return {
+    type: 'process',
+    label: 'Mock Process',
+    execute: vi.fn(async () => ({
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+      ...overrides,
+    })),
+  }
+}
+
+beforeAll(async () => {
+  db = new PGliteProvider()
+  await runMigrations(db)
+  await seedTestData(db)
+  costTracker = new CostTracker(db)
+  observatory = new Observatory(db)
+})
+
+afterAll(async () => {
+  await db.close()
+})
+
+describe('Tool call tracing', () => {
+  it('inserts tool_calls rows when adapter returns toolCalls', async () => {
+    const mockAdapter = createMockAdapter({
+      toolCalls: [
+        {
+          toolName: 'read_file',
+          toolInput: { path: '/src/index.ts' },
+          toolOutput: 'file contents here',
+          durationMs: 150,
+          status: 'success',
+        },
+        {
+          toolName: 'write_file',
+          toolInput: { path: '/src/out.ts', content: 'new content' },
+          toolOutput: 'written',
+          durationMs: 200,
+          status: 'success',
+        },
+      ],
+    })
+
+    const registry = new AdapterRegistry()
+    registry.register(mockAdapter)
+    const executor = new HeartbeatExecutor(db, costTracker, observatory, registry)
+
+    const result = await executor.execute(AGENT_ID, TriggerType.Manual)
+    expect(result.exitCode).toBe(0)
+
+    // Verify tool_calls rows were inserted
+    const rows = await db.query<{
+      tool_name: string
+      tool_input: Record<string, unknown> | null
+      tool_output: string | null
+      duration_ms: number | null
+      status: string
+      agent_id: string
+      company_id: string
+    }>(
+      `SELECT tool_name, tool_input, tool_output, duration_ms, status, agent_id, company_id
+       FROM tool_calls WHERE agent_id = $1 ORDER BY created_at ASC`,
+      [AGENT_ID],
+    )
+
+    expect(rows.rows).toHaveLength(2)
+
+    expect(rows.rows[0].tool_name).toBe('read_file')
+    expect(rows.rows[0].tool_input).toEqual({ path: '/src/index.ts' })
+    expect(rows.rows[0].tool_output).toBe('file contents here')
+    expect(rows.rows[0].duration_ms).toBe(150)
+    expect(rows.rows[0].status).toBe('success')
+    expect(rows.rows[0].agent_id).toBe(AGENT_ID)
+    expect(rows.rows[0].company_id).toBe(COMPANY_ID)
+
+    expect(rows.rows[1].tool_name).toBe('write_file')
+    expect(rows.rows[1].duration_ms).toBe(200)
+  })
+
+  it('inserts no rows when adapter returns no toolCalls (backward compatible)', async () => {
+    // Create a separate agent to avoid interference
+    const AGENT_NO_TC = '00000000-0000-4000-a000-000000000111'
+    await db.query(
+      `INSERT INTO agents (id, company_id, name, adapter_type, adapter_config, budget_monthly_cents, spent_monthly_cents)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        AGENT_NO_TC,
+        COMPANY_ID,
+        'no-tool-bot',
+        'process',
+        JSON.stringify({ command: 'echo' }),
+        10000,
+        0,
+      ],
+    )
+
+    const mockAdapter = createMockAdapter() // no toolCalls
+    const registry = new AdapterRegistry()
+    registry.register(mockAdapter)
+    const executor = new HeartbeatExecutor(db, costTracker, observatory, registry)
+
+    await executor.execute(AGENT_NO_TC, TriggerType.Manual)
+
+    const rows = await db.query(
+      'SELECT * FROM tool_calls WHERE agent_id = $1',
+      [AGENT_NO_TC],
+    )
+    expect(rows.rows).toHaveLength(0)
+  })
+
+  it('handles tool calls with error status', async () => {
+    const AGENT_ERR_TC = '00000000-0000-4000-a000-000000000112'
+    await db.query(
+      `INSERT INTO agents (id, company_id, name, adapter_type, adapter_config, budget_monthly_cents, spent_monthly_cents)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        AGENT_ERR_TC,
+        COMPANY_ID,
+        'err-tool-bot',
+        'process',
+        JSON.stringify({ command: 'echo' }),
+        10000,
+        0,
+      ],
+    )
+
+    const mockAdapter = createMockAdapter({
+      toolCalls: [
+        {
+          toolName: 'bash',
+          toolInput: { command: 'rm -rf /' },
+          toolOutput: 'permission denied',
+          durationMs: 10,
+          status: 'error',
+        },
+      ],
+    })
+
+    const registry = new AdapterRegistry()
+    registry.register(mockAdapter)
+    const executor = new HeartbeatExecutor(db, costTracker, observatory, registry)
+
+    await executor.execute(AGENT_ERR_TC, TriggerType.Manual)
+
+    const rows = await db.query<{ tool_name: string; status: string }>(
+      'SELECT tool_name, status FROM tool_calls WHERE agent_id = $1',
+      [AGENT_ERR_TC],
+    )
+    expect(rows.rows).toHaveLength(1)
+    expect(rows.rows[0].status).toBe('error')
+  })
+
+  it('handles tool calls with minimal fields (optional fields null)', async () => {
+    const AGENT_MIN_TC = '00000000-0000-4000-a000-000000000113'
+    await db.query(
+      `INSERT INTO agents (id, company_id, name, adapter_type, adapter_config, budget_monthly_cents, spent_monthly_cents)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        AGENT_MIN_TC,
+        COMPANY_ID,
+        'min-tool-bot',
+        'process',
+        JSON.stringify({ command: 'echo' }),
+        10000,
+        0,
+      ],
+    )
+
+    const mockAdapter = createMockAdapter({
+      toolCalls: [
+        {
+          toolName: 'think',
+          // no toolInput, toolOutput, durationMs, or status
+        },
+      ],
+    })
+
+    const registry = new AdapterRegistry()
+    registry.register(mockAdapter)
+    const executor = new HeartbeatExecutor(db, costTracker, observatory, registry)
+
+    await executor.execute(AGENT_MIN_TC, TriggerType.Manual)
+
+    const rows = await db.query<{
+      tool_name: string
+      tool_input: Record<string, unknown> | null
+      tool_output: string | null
+      duration_ms: number | null
+      status: string
+    }>(
+      'SELECT tool_name, tool_input, tool_output, duration_ms, status FROM tool_calls WHERE agent_id = $1',
+      [AGENT_MIN_TC],
+    )
+    expect(rows.rows).toHaveLength(1)
+    expect(rows.rows[0].tool_name).toBe('think')
+    expect(rows.rows[0].tool_input).toBeNull()
+    expect(rows.rows[0].tool_output).toBeNull()
+    expect(rows.rows[0].duration_ms).toBeNull()
+    expect(rows.rows[0].status).toBe('success') // default
+  })
+})

--- a/packages/core/src/adapters/adapter.ts
+++ b/packages/core/src/adapters/adapter.ts
@@ -41,6 +41,13 @@ export interface AdapterResult {
     model: string
     provider: string
   }
+  toolCalls?: Array<{
+    toolName: string
+    toolInput?: Record<string, unknown>
+    toolOutput?: string
+    durationMs?: number
+    status?: 'success' | 'error'
+  }>
 }
 
 export interface AdapterModule {

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -250,6 +250,16 @@ export class HeartbeatExecutor {
         await saveSessionState(runId, adapterResult.sessionState, this.db)
       }
 
+      // ── Step 9b: Record tool calls ─────────────────────────────────
+      if (adapterResult.toolCalls && adapterResult.toolCalls.length > 0) {
+        await this.recordToolCalls(
+          runId,
+          agentId,
+          companyId,
+          adapterResult.toolCalls,
+        )
+      }
+
       // ── Step 10: Update heartbeat_run ───────────────────────────────
       await this.db.query(
         `UPDATE heartbeat_runs
@@ -312,6 +322,38 @@ export class HeartbeatExecutor {
   }
 
   // ── Private helpers ──────────────────────────────────────────────────
+
+  /**
+   * Insert tool call records for a heartbeat run.
+   * Best-effort — failures here should not fail the heartbeat.
+   */
+  private async recordToolCalls(
+    runId: string,
+    agentId: string,
+    companyId: string,
+    toolCalls: NonNullable<AdapterResult['toolCalls']>,
+  ): Promise<void> {
+    try {
+      for (const tc of toolCalls) {
+        await this.db.query(
+          `INSERT INTO tool_calls (heartbeat_run_id, agent_id, company_id, tool_name, tool_input, tool_output, duration_ms, status)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          [
+            runId,
+            agentId,
+            companyId,
+            tc.toolName,
+            tc.toolInput ? JSON.stringify(tc.toolInput) : null,
+            tc.toolOutput ?? null,
+            tc.durationMs ?? null,
+            tc.status ?? 'success',
+          ],
+        )
+      }
+    } catch {
+      // Best-effort — don't let tool call logging fail the heartbeat
+    }
+  }
 
   private async markRunFailed(runId: string, error: string): Promise<void> {
     try {

--- a/packages/db/src/migrations/014_tool_calls.ts
+++ b/packages/db/src/migrations/014_tool_calls.ts
@@ -1,0 +1,19 @@
+export const name = '014_tool_calls'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS tool_calls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  heartbeat_run_id UUID NOT NULL REFERENCES heartbeat_runs(id),
+  agent_id UUID NOT NULL REFERENCES agents(id),
+  company_id UUID NOT NULL REFERENCES companies(id),
+  tool_name TEXT NOT NULL,
+  tool_input JSONB,
+  tool_output TEXT,
+  duration_ms INTEGER,
+  status TEXT NOT NULL DEFAULT 'success',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_run ON tool_calls(heartbeat_run_id);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_agent ON tool_calls(agent_id);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_company ON tool_calls(company_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -12,6 +12,7 @@ import * as m010 from './010_activity.js'
 import * as m011 from './011_api_keys.js'
 import * as m012 from './012_license_keys.js'
 import * as m013 from './013_agent_worktrees.js'
+import * as m014 from './014_tool_calls.js'
 
 export interface Migration {
   name: string
@@ -32,6 +33,7 @@ const migrations: Migration[] = [
   m011,
   m012,
   m013,
+  m014,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -175,6 +175,19 @@ export interface AgentCommunicationContext {
   unreadComments: IssueComment[]
 }
 
+export interface ToolCall {
+  id: string
+  heartbeat_run_id: string
+  agent_id: string
+  company_id: string
+  tool_name: string
+  tool_input: Record<string, unknown> | null
+  tool_output: string | null
+  duration_ms: number | null
+  status: string
+  created_at: Date
+}
+
 export interface AgentWorktree {
   id: string
   agent_id: string


### PR DESCRIPTION
## Summary

- Adds a `tool_calls` table (migration 014) to record every tool invocation during agent heartbeat execution
- Extends `AdapterResult` with an optional `toolCalls` array — fully backward compatible, existing adapters unaffected
- Executor inserts tool call rows (best-effort, non-blocking) between session save and run finalization
- New `GET /api/companies/:id/tool-calls` endpoint with `agent_id`, `run_id`, `tool_name` query filters plus pagination

## Test plan

- [x] 4 unit tests: tool calls inserted, backward compat (no toolCalls = no rows), error status, minimal fields
- [x] 8 API route tests: list, filter by run/agent/tool_name, combined filters, pagination, 404 company, empty results
- [x] All 12 existing executor tests still pass
- [x] `pnpm build` passes
- [x] `pnpm lint` passes with zero warnings

Closes #101

Generated with [Claude Code](https://claude.com/claude-code)