### PR TITLE
Add event-based triggers for task assignment and mentions

### DIFF
--- a/apps/cli/__tests__/event-triggers.test.ts
+++ b/apps/cli/__tests__/event-triggers.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import { TriggerType } from '@shackleai/shared'
+import type { Scheduler } from '@shackleai/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type CompanyRow = { id: string; issue_prefix: string; issue_counter: number }
+type AgentRow = { id: string; name: string }
+type IssueRow = {
+  id: string
+  identifier: string
+  issue_number: number
+  title: string
+  status: string
+  priority: string
+  assignee_agent_id: string | null
+  company_id: string
+}
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  prefix: string,
+): Promise<CompanyRow> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: `Company ${prefix}`, issue_prefix: prefix }),
+  })
+  const body = (await res.json()) as { data: CompanyRow }
+  return body.data
+}
+
+async function createAgent(
+  db: PGliteProvider,
+  companyId: string,
+  name: string = 'Test Agent',
+): Promise<AgentRow> {
+  const result = await db.query<AgentRow>(
+    `INSERT INTO agents (company_id, name, adapter_type, adapter_config)
+     VALUES ($1, $2, 'process', '{}')
+     RETURNING id, name`,
+    [companyId, name],
+  )
+  return result.rows[0]
+}
+
+function createMockScheduler(): Scheduler & { triggerNow: ReturnType<typeof vi.fn> } {
+  return {
+    triggerNow: vi.fn().mockResolvedValue(null),
+  } as unknown as Scheduler & { triggerNow: ReturnType<typeof vi.fn> }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Task Assignment Triggers
+// ---------------------------------------------------------------------------
+
+describe('event triggers — task assignment', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+  let agentId2: string
+  let mockScheduler: ReturnType<typeof createMockScheduler>
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    mockScheduler = createMockScheduler()
+    app = createApp(db, { scheduler: mockScheduler })
+    const company = await createCompany(app, 'TRIG')
+    companyId = company.id
+    const agent = await createAgent(db, companyId, 'worker-alpha')
+    agentId = agent.id
+    const agent2 = await createAgent(db, companyId, 'worker-beta')
+    agentId2 = agent2.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('POST create issue with assignee triggers task_assigned', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Assigned on create', assignee_agent_id: agentId }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).toHaveBeenCalledWith(agentId, TriggerType.TaskAssigned)
+  })
+
+  it('POST create issue without assignee does not trigger', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'No assignee' }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).not.toHaveBeenCalled()
+  })
+
+  it('PATCH update assignee_agent_id triggers task_assigned for new assignee', async () => {
+    // Create issue without assignee
+    const createRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Will be assigned' }),
+    })
+    const issue = ((await createRes.json()) as { data: IssueRow }).data
+
+    mockScheduler.triggerNow.mockClear()
+
+    const patchRes = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee_agent_id: agentId }),
+    })
+    expect(patchRes.status).toBe(200)
+
+    expect(mockScheduler.triggerNow).toHaveBeenCalledWith(agentId, TriggerType.TaskAssigned)
+  })
+
+  it('PATCH reassign to different agent triggers for new agent only', async () => {
+    // Create issue assigned to agent1
+    const createRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Reassign me', assignee_agent_id: agentId }),
+    })
+    const issue = ((await createRes.json()) as { data: IssueRow }).data
+
+    mockScheduler.triggerNow.mockClear()
+
+    // Reassign to agent2
+    const patchRes = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee_agent_id: agentId2 }),
+    })
+    expect(patchRes.status).toBe(200)
+
+    expect(mockScheduler.triggerNow).toHaveBeenCalledWith(agentId2, TriggerType.TaskAssigned)
+    expect(mockScheduler.triggerNow).not.toHaveBeenCalledWith(agentId, expect.anything())
+  })
+
+  it('PATCH same assignee does not re-trigger', async () => {
+    // Create issue assigned to agent1
+    const createRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Same assignee', assignee_agent_id: agentId }),
+    })
+    const issue = ((await createRes.json()) as { data: IssueRow }).data
+
+    mockScheduler.triggerNow.mockClear()
+
+    // Update with same assignee
+    const patchRes = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee_agent_id: agentId }),
+    })
+    expect(patchRes.status).toBe(200)
+
+    expect(mockScheduler.triggerNow).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — Comment Mention Triggers
+// ---------------------------------------------------------------------------
+
+describe('event triggers — comment mentions', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let issueId: string
+  let agentId: string
+  let mockScheduler: ReturnType<typeof createMockScheduler>
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    mockScheduler = createMockScheduler()
+    app = createApp(db, { scheduler: mockScheduler })
+    const company = await createCompany(app, 'MENT')
+    companyId = company.id
+    const agent = await createAgent(db, companyId, 'review-bot')
+    agentId = agent.id
+
+    // Create an issue to attach comments to
+    const issueRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Mention Test Issue' }),
+    })
+    const issue = ((await issueRes.json()) as { data: IssueRow }).data
+    issueId = issue.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('comment mentioning @agent-name triggers mentioned for that agent', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Hey @review-bot please review this' }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).toHaveBeenCalledWith(agentId, TriggerType.Mentioned)
+  })
+
+  it('comment mentioning non-existent agent does not trigger and does not crash', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Hey @ghost-agent check this out' }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).not.toHaveBeenCalled()
+  })
+
+  it('comment with no mentions does not trigger', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Just a regular comment' }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).not.toHaveBeenCalled()
+  })
+
+  it('duplicate @mentions in a comment only trigger once', async () => {
+    mockScheduler.triggerNow.mockClear()
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: '@review-bot please @review-bot' }),
+    })
+    expect(res.status).toBe(201)
+
+    expect(mockScheduler.triggerNow).toHaveBeenCalledTimes(1)
+    expect(mockScheduler.triggerNow).toHaveBeenCalledWith(agentId, TriggerType.Mentioned)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — No Scheduler (graceful degradation)
+// ---------------------------------------------------------------------------
+
+describe('event triggers — no scheduler available', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    // No scheduler passed — should gracefully skip triggers
+    app = createApp(db)
+    const company = await createCompany(app, 'NOSC')
+    companyId = company.id
+    const agent = await createAgent(db, companyId, 'silent-agent')
+    agentId = agent.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('create issue with assignee does not crash without scheduler', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'No scheduler', assignee_agent_id: agentId }),
+    })
+    expect(res.status).toBe(201)
+  })
+
+  it('comment with @mention does not crash without scheduler', async () => {
+    const issueRes = await app.request(`/api/companies/${companyId}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Comment test no sched' }),
+    })
+    const issue = ((await issueRes.json()) as { data: IssueRow }).data
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: '@silent-agent do something' }),
+    })
+    expect(res.status).toBe(201)
+  })
+})

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -37,7 +37,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', companiesRouter(db))
   app.route('/api/companies', dashboardRouter(db))
   app.route('/api/companies', agentsRouter(db, options?.scheduler))
-  app.route('/api/companies', issuesRouter(db))
+  app.route('/api/companies', issuesRouter(db, options?.scheduler))
   app.route('/api/companies', policiesRouter(db))
   app.route('/api/companies', costsRouter(db))
   app.route('/api/companies', heartbeatsRouter(db))

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -6,14 +6,15 @@ import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
 import type { Issue, IssueComment } from '@shackleai/shared'
 import { CreateIssueInput, UpdateIssueInput, CreateIssueCommentInput } from '@shackleai/shared'
-import { IssueStatus } from '@shackleai/shared'
+import { IssueStatus, TriggerType } from '@shackleai/shared'
+import type { Scheduler } from '@shackleai/core'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
 import { parsePagination } from '../pagination.js'
 
 type Variables = CompanyScopeVariables
 
-export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<{ Variables: Variables }> {
   const app = new Hono<{ Variables: Variables }>()
 
   // Inject db into context for all routes
@@ -111,6 +112,11 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
       ],
     )
 
+    // Trigger agent wake-up on task assignment
+    if (assignee_agent_id && scheduler) {
+      void scheduler.triggerNow(assignee_agent_id, TriggerType.TaskAssigned)
+    }
+
     return c.json({ data: result.rows[0] }, 201)
   })
 
@@ -136,14 +142,16 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
     const companyId = c.req.param('id')
     const issueId = c.req.param('issueId')
 
-    // Verify issue exists and belongs to company
-    const existing = await db.query<Issue>(
-      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+    // Verify issue exists and belongs to company; fetch old assignee for trigger comparison
+    const existing = await db.query<Pick<Issue, 'id' | 'assignee_agent_id'>>(
+      `SELECT id, assignee_agent_id FROM issues WHERE id = $1 AND company_id = $2`,
       [issueId, companyId],
     )
     if (existing.rows.length === 0) {
       return c.json({ error: 'Issue not found' }, 404)
     }
+
+    const oldAssignee = existing.rows[0].assignee_agent_id
 
     let body: unknown
     try {
@@ -177,6 +185,12 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
        RETURNING *`,
       [issueId, companyId, ...values],
     )
+
+    // Trigger agent wake-up if assignee changed to a new agent
+    const newAssignee = result.rows[0].assignee_agent_id
+    if (scheduler && newAssignee && newAssignee !== oldAssignee) {
+      void scheduler.triggerNow(newAssignee, TriggerType.TaskAssigned)
+    }
 
     return c.json({ data: result.rows[0] })
   })
@@ -281,6 +295,23 @@ export function issuesRouter(db: DatabaseProvider): Hono<{ Variables: Variables 
        RETURNING *`,
       [issueId, author_agent_id ?? null, content, parent_id ?? null, is_resolved],
     )
+
+    // Trigger mentioned agents — scan for @agent-name patterns
+    if (scheduler) {
+      const mentions = content.match(/@([\w-]+)/g)
+      if (mentions) {
+        const uniqueNames = [...new Set(mentions.map((m) => m.slice(1)))]
+        for (const agentName of uniqueNames) {
+          const agentResult = await db.query<{ id: string }>(
+            `SELECT id FROM agents WHERE company_id = $1 AND name = $2`,
+            [companyId, agentName],
+          )
+          if (agentResult.rows.length > 0) {
+            void scheduler.triggerNow(agentResult.rows[0].id, TriggerType.Mentioned)
+          }
+        }
+      }
+    }
 
     return c.json({ data: result.rows[0] }, 201)
   })

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -47,6 +47,9 @@ export const TriggerType = {
   Manual: 'manual',
   Event: 'event',
   Api: 'api',
+  TaskAssigned: 'task_assigned',
+  Mentioned: 'mentioned',
+  Delegated: 'delegated',
 } as const
 export type TriggerType = (typeof TriggerType)[keyof typeof TriggerType]
 


### PR DESCRIPTION
## Summary

- Adds `TaskAssigned`, `Mentioned`, and `Delegated` trigger types to `@shackleai/shared` constants
- Passes scheduler to `issuesRouter` so issue routes can fire triggers
- When a task is assigned to an agent (via POST create or PATCH update), the agent auto-wakes with `task_assigned` trigger
- When a comment mentions `@agent-name`, the named agent auto-wakes with `mentioned` trigger
- Graceful no-op when scheduler is not available (e.g., test environments)
- Dedup: duplicate @mentions in a single comment only trigger once; same-assignee PATCH does not re-trigger

Closes #100

## Files Changed

- `packages/shared/src/constants.ts` — 3 new TriggerType values
- `apps/cli/src/server/index.ts` — pass scheduler to issuesRouter
- `apps/cli/src/server/routes/issues.ts` — trigger logic in POST, PATCH, and comment routes
- `apps/cli/__tests__/event-triggers.test.ts` — 11 tests (3 describe blocks)

## Test plan

- [x] POST create issue with assignee triggers `task_assigned`
- [x] POST create issue without assignee does not trigger
- [x] PATCH update assignee triggers `task_assigned` for new agent
- [x] PATCH reassign triggers only for new agent, not old
- [x] PATCH same assignee does not re-trigger
- [x] Comment with `@agent-name` triggers `mentioned`
- [x] Comment mentioning non-existent agent does not crash
- [x] Comment with no mentions does not trigger
- [x] Duplicate mentions in one comment trigger only once
- [x] No scheduler available — create with assignee works fine
- [x] No scheduler available — comment with mention works fine
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Existing issues tests (34) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)