### PR TITLE
Phase 15: Runtime skill injection via ContextBuilder

### DIFF
--- a/packages/core/__tests__/context-builder.test.ts
+++ b/packages/core/__tests__/context-builder.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ContextBuilder } from '../src/context-builder.js'
+import type { DatabaseProvider, QueryResult } from '@shackleai/db'
+
+/**
+ * Creates a mock DatabaseProvider that returns preset rows for known queries.
+ */
+function createMockDb(overrides: {
+  agent?: Record<string, unknown> | null
+  company?: Record<string, unknown> | null
+  team?: Record<string, unknown>[]
+  tasks?: Record<string, unknown>[]
+  policies?: Record<string, unknown>[]
+  reports?: Record<string, unknown>[]
+} = {}): DatabaseProvider {
+  const queryFn = vi.fn(async (sql: string): Promise<QueryResult> => {
+    const sqlLower = sql.toLowerCase()
+
+    // Order matters: check more specific patterns first
+    if (sqlLower.includes('reports_to')) {
+      return { rows: overrides.reports ?? [] }
+    }
+
+    if (sqlLower.includes('from agents') && sqlLower.includes('id != $2')) {
+      return { rows: overrides.team ?? [] }
+    }
+
+    if (sqlLower.includes('from agents') && sqlLower.includes('id = $1')) {
+      return { rows: overrides.agent ? [overrides.agent] : [] }
+    }
+
+    if (sqlLower.includes('from companies')) {
+      return { rows: overrides.company ? [overrides.company] : [] }
+    }
+
+    if (sqlLower.includes('from issues')) {
+      return { rows: overrides.tasks ?? [] }
+    }
+
+    if (sqlLower.includes('from policies')) {
+      return { rows: overrides.policies ?? [] }
+    }
+
+    return { rows: [] }
+  })
+
+  return {
+    query: queryFn,
+    exec: vi.fn(),
+    close: vi.fn(),
+  }
+}
+
+describe('ContextBuilder', () => {
+  const AGENT_ID = 'agent-001'
+  const COMPANY_ID = 'company-001'
+
+  it('builds context with team, tasks, policies, and reports', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: 'Senior Engineer', capabilities: 'coding', status: 'idle' },
+      company: { name: 'Acme Corp', description: 'Build the future' },
+      team: [
+        { name: 'bob', role: 'researcher', status: 'active' },
+        { name: 'carol', role: 'designer', status: 'idle' },
+      ],
+      tasks: [
+        { identifier: 'ACME-42', title: 'Fix login bug', status: 'in_progress', priority: 'high' },
+        { identifier: 'ACME-45', title: 'Update docs', status: 'todo', priority: 'medium' },
+      ],
+      policies: [
+        { resource: 'github.*', action: 'read' },
+        { resource: 'github.*', action: 'write' },
+      ],
+      reports: [
+        { name: 'charlie', role: 'worker' },
+      ],
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    // Identity section
+    expect(context).toContain('# ShackleAI Agent Context')
+    expect(context).toContain('- Name: alice')
+    expect(context).toContain('- Role: engineer')
+    expect(context).toContain('- Title: Senior Engineer')
+    expect(context).toContain('- Company: Acme Corp')
+    expect(context).toContain('- Mission: Build the future')
+
+    // Team section
+    expect(context).toContain('## Your Team')
+    expect(context).toContain('| bob | researcher | active |')
+    expect(context).toContain('| carol | designer | idle |')
+
+    // Reports section
+    expect(context).toContain('## Your Direct Reports')
+    expect(context).toContain('- charlie (worker)')
+
+    // Tasks section
+    expect(context).toContain('## Active Tasks')
+    expect(context).toContain('- ACME-42: Fix login bug [in_progress, high]')
+    expect(context).toContain('- ACME-45: Update docs [todo, medium]')
+
+    // Policies section
+    expect(context).toContain('## Governance Policies')
+    expect(context).toContain('- github.*: read')
+    expect(context).toContain('- github.*: write')
+
+    // API reference section
+    expect(context).toContain('## Reporting Results')
+    expect(context).toContain('__shackleai_result__')
+  })
+
+  it('shows "No active tasks" when agent has no tasks', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: null, capabilities: null, status: 'idle' },
+      company: { name: 'Acme Corp', description: null },
+      team: [{ name: 'bob', role: 'researcher', status: 'idle' }],
+      tasks: [],
+      policies: [],
+      reports: [],
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('No active tasks.')
+  })
+
+  it('shows "No team members" when agent has no team', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: null, capabilities: null, status: 'idle' },
+      company: { name: 'Acme Corp', description: null },
+      team: [],
+      tasks: [],
+      policies: [],
+      reports: [],
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('No team members.')
+  })
+
+  it('includes API reference section in all contexts', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'agent', title: null, capabilities: null, status: 'idle' },
+      company: { name: 'Test', description: null },
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('## Reporting Results')
+    expect(context).toContain('__shackleai_result__')
+    expect(context).toContain('sessionState')
+    expect(context).toContain('inputTokens')
+  })
+
+  it('handles missing agent gracefully', async () => {
+    const db = createMockDb({
+      agent: null,
+      company: { name: 'Test', description: null },
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('- Name: Unknown')
+    expect(context).toContain('- Role: agent')
+  })
+
+  it('handles missing company gracefully', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: null, capabilities: null, status: 'idle' },
+      company: null,
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('- Company: Unknown')
+  })
+
+  it('shows "No direct reports" when agent has no reports', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: null, capabilities: null, status: 'idle' },
+      company: { name: 'Test', description: null },
+      reports: [],
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('No direct reports.')
+  })
+
+  it('shows "No policies configured" when no policies exist', async () => {
+    const db = createMockDb({
+      agent: { id: AGENT_ID, name: 'alice', role: 'engineer', title: null, capabilities: null, status: 'idle' },
+      company: { name: 'Test', description: null },
+      policies: [],
+    })
+
+    const builder = new ContextBuilder(db)
+    const context = await builder.build(AGENT_ID, COMPANY_ID)
+
+    expect(context).toContain('No policies configured.')
+  })
+})

--- a/packages/core/src/adapters/adapter.ts
+++ b/packages/core/src/adapters/adapter.ts
@@ -38,6 +38,9 @@ export interface AdapterContext {
 
   /** Full ancestry chain: mission → project → goal → task. */
   ancestry?: GoalAncestry
+
+  /** Structured system context built by ContextBuilder (Markdown). */
+  systemContext?: string
 }
 
 export interface AdapterResult {

--- a/packages/core/src/adapters/claude.ts
+++ b/packages/core/src/adapters/claude.ts
@@ -86,15 +86,20 @@ export class ClaudeAdapter implements AdapterModule {
       }
     }
 
-    // Prepend ancestry context to the prompt if available
+    // Prepend system context and ancestry to the prompt
     let fullPrompt = prompt
+
+    if (ctx.systemContext) {
+      fullPrompt = `${ctx.systemContext}\n\n${fullPrompt}`
+    }
+
     if (ctx.ancestry) {
       const parts: string[] = []
       if (ctx.ancestry.mission) parts.push(`Mission: ${ctx.ancestry.mission}`)
       if (ctx.ancestry.project) parts.push(`Project: ${ctx.ancestry.project.name}`)
       if (ctx.ancestry.goal) parts.push(`Goal: ${ctx.ancestry.goal.name}`)
       if (parts.length > 0) {
-        fullPrompt = `Context: ${parts.join(' | ')}\n\n${prompt}`
+        fullPrompt = `Context: ${parts.join(' | ')}\n\n${fullPrompt}`
       }
     }
 

--- a/packages/core/src/adapters/crewai.ts
+++ b/packages/core/src/adapters/crewai.ts
@@ -163,6 +163,7 @@ export class CrewAIAdapter implements AdapterModule {
       heartbeatRunId: ctx.heartbeatRunId,
       sessionState: ctx.sessionState ?? null,
       ancestry: ctx.ancestry ?? null,
+      systemContext: ctx.systemContext ?? null,
     })
 
     // Build args

--- a/packages/core/src/adapters/http.ts
+++ b/packages/core/src/adapters/http.ts
@@ -48,6 +48,7 @@ export class HttpAdapter implements AdapterModule {
       task: ctx.task ?? null,
       sessionState: ctx.sessionState ?? null,
       ancestry: ctx.ancestry ?? null,
+      systemContext: ctx.systemContext ?? null,
     }
 
     const controller = new AbortController()

--- a/packages/core/src/adapters/mcp.ts
+++ b/packages/core/src/adapters/mcp.ts
@@ -83,6 +83,7 @@ export class McpAdapter implements AdapterModule {
           task: ctx.task ?? null,
           sessionState: ctx.sessionState ?? null,
           ancestry: ctx.ancestry ?? null,
+          systemContext: ctx.systemContext ?? null,
         },
       }
 

--- a/packages/core/src/adapters/openclaw.ts
+++ b/packages/core/src/adapters/openclaw.ts
@@ -100,6 +100,7 @@ export class OpenClawAdapter implements AdapterModule {
       heartbeatRunId: ctx.heartbeatRunId,
       sessionState: ctx.sessionState ?? null,
       ancestry: ctx.ancestry ?? null,
+      systemContext: ctx.systemContext ?? null,
     })
 
     const sessionId = ctx.sessionState ?? ctx.heartbeatRunId

--- a/packages/core/src/adapters/process.ts
+++ b/packages/core/src/adapters/process.ts
@@ -7,6 +7,10 @@
  */
 
 import { spawn } from 'node:child_process'
+import { writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
 import type { WorktreeConfig } from '@shackleai/shared'
 import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
 import { getSafeEnv } from './env.js'
@@ -69,6 +73,19 @@ export class ProcessAdapter implements AdapterModule {
       env.SHACKLEAI_SESSION_STATE = ctx.sessionState
     }
 
+    // Inject system context via env var or temp file (if > 8KB)
+    let contextTmpFile: string | undefined
+    if (ctx.systemContext) {
+      const MAX_ENV_BYTES = 8 * 1024
+      if (Buffer.byteLength(ctx.systemContext, 'utf-8') > MAX_ENV_BYTES) {
+        contextTmpFile = join(tmpdir(), `shackleai-ctx-${randomUUID()}.md`)
+        writeFileSync(contextTmpFile, ctx.systemContext, 'utf-8')
+        env.SHACKLEAI_CONTEXT_FILE = contextTmpFile
+      } else {
+        env.SHACKLEAI_CONTEXT = ctx.systemContext
+      }
+    }
+
     // Worktree-aware execution: inject worktree env vars and set cwd
     const worktreeConfig = ctx.adapterConfig.worktree as
       | WorktreeConfig
@@ -111,6 +128,7 @@ export class ProcessAdapter implements AdapterModule {
       child.on('close', (code) => {
         clearTimeout(timeoutId)
         if (killTimer) clearTimeout(killTimer)
+        this.cleanupTmpFile(contextTmpFile)
 
         const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
         const stderr = Buffer.concat(stderrChunks).toString('utf-8')
@@ -125,6 +143,7 @@ export class ProcessAdapter implements AdapterModule {
       child.on('error', (err) => {
         clearTimeout(timeoutId)
         if (killTimer) clearTimeout(killTimer)
+        this.cleanupTmpFile(contextTmpFile)
 
         resolve({
           exitCode: 127,
@@ -138,5 +157,14 @@ export class ProcessAdapter implements AdapterModule {
   async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
     // Basic check — Node.js can always spawn processes
     return { ok: true }
+  }
+
+  private cleanupTmpFile(filePath: string | undefined): void {
+    if (!filePath) return
+    try {
+      unlinkSync(filePath)
+    } catch {
+      // Best-effort cleanup
+    }
   }
 }

--- a/packages/core/src/context-builder.ts
+++ b/packages/core/src/context-builder.ts
@@ -1,0 +1,227 @@
+/**
+ * ContextBuilder — generates structured system context for agent heartbeats.
+ *
+ * Builds a Markdown document that teaches an agent about its identity, team,
+ * tasks, governance policies, and how to report results back to the orchestrator.
+ * This context is injected into every heartbeat prompt so agents can interact
+ * with the ShackleAI API without being pre-trained.
+ *
+ * Read-only — only SELECT queries. No mutations.
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+
+interface AgentRow {
+  id: string
+  name: string
+  role: string | null
+  title: string | null
+  capabilities: string | null
+  status: string
+}
+
+interface CompanyRow {
+  name: string
+  description: string | null
+}
+
+interface TeamMemberRow {
+  name: string
+  role: string | null
+  status: string
+}
+
+interface TaskRow {
+  identifier: string | null
+  title: string
+  status: string
+  priority: string | null
+}
+
+interface PolicyRow {
+  resource: string
+  action: string
+}
+
+interface ReportRow {
+  name: string
+  role: string | null
+}
+
+export class ContextBuilder {
+  constructor(private db: DatabaseProvider) {}
+
+  /**
+   * Build a structured context string for an agent's heartbeat.
+   * Includes: role, team, tasks, policies, company info, API reference.
+   */
+  async build(agentId: string, companyId: string): Promise<string> {
+    const [agent, company, team, tasks, policies, reports] = await Promise.all([
+      this.getAgent(agentId),
+      this.getCompany(companyId),
+      this.getTeamMembers(agentId, companyId),
+      this.getActiveTasks(agentId),
+      this.getPolicies(companyId),
+      this.getDirectReports(agentId),
+    ])
+
+    const sections: string[] = ['# ShackleAI Agent Context']
+
+    // Identity
+    sections.push(this.buildIdentitySection(agent, company))
+
+    // Team
+    sections.push(this.buildTeamSection(team))
+
+    // Direct Reports
+    sections.push(this.buildReportsSection(reports))
+
+    // Active Tasks
+    sections.push(this.buildTasksSection(tasks))
+
+    // Governance Policies
+    sections.push(this.buildPoliciesSection(policies))
+
+    // API Reference — reporting results
+    sections.push(this.buildApiReferenceSection())
+
+    return sections.join('\n\n')
+  }
+
+  // ── Data fetchers (read-only) ────────────────────────────────────────
+
+  private async getAgent(agentId: string): Promise<AgentRow | null> {
+    const result = await this.db.query<AgentRow>(
+      `SELECT id, name, role, title, capabilities, status
+       FROM agents WHERE id = $1`,
+      [agentId],
+    )
+    return result.rows[0] ?? null
+  }
+
+  private async getCompany(companyId: string): Promise<CompanyRow | null> {
+    const result = await this.db.query<CompanyRow>(
+      `SELECT name, description FROM companies WHERE id = $1`,
+      [companyId],
+    )
+    return result.rows[0] ?? null
+  }
+
+  private async getTeamMembers(
+    agentId: string,
+    companyId: string,
+  ): Promise<TeamMemberRow[]> {
+    const result = await this.db.query<TeamMemberRow>(
+      `SELECT name, role, status FROM agents
+       WHERE company_id = $1 AND id != $2
+       ORDER BY name`,
+      [companyId, agentId],
+    )
+    return result.rows
+  }
+
+  private async getActiveTasks(agentId: string): Promise<TaskRow[]> {
+    const result = await this.db.query<TaskRow>(
+      `SELECT identifier, title, status, priority FROM issues
+       WHERE assignee_agent_id = $1
+         AND status NOT IN ('done', 'cancelled')
+       ORDER BY priority, created_at`,
+      [agentId],
+    )
+    return result.rows
+  }
+
+  private async getPolicies(companyId: string): Promise<PolicyRow[]> {
+    const result = await this.db.query<PolicyRow>(
+      `SELECT resource, action FROM policies
+       WHERE company_id = $1
+       ORDER BY resource, action`,
+      [companyId],
+    )
+    return result.rows
+  }
+
+  private async getDirectReports(agentId: string): Promise<ReportRow[]> {
+    const result = await this.db.query<ReportRow>(
+      `SELECT name, role FROM agents WHERE reports_to = $1 ORDER BY name`,
+      [agentId],
+    )
+    return result.rows
+  }
+
+  // ── Section builders ─────────────────────────────────────────────────
+
+  private buildIdentitySection(
+    agent: AgentRow | null,
+    company: CompanyRow | null,
+  ): string {
+    const lines = ['## Your Identity']
+    lines.push(`- Name: ${agent?.name ?? 'Unknown'}`)
+    lines.push(`- Role: ${agent?.role ?? 'agent'}`)
+    if (agent?.title) lines.push(`- Title: ${agent.title}`)
+    lines.push(`- Company: ${company?.name ?? 'Unknown'}`)
+    if (company?.description) lines.push(`- Mission: ${company.description}`)
+    return lines.join('\n')
+  }
+
+  private buildTeamSection(team: TeamMemberRow[]): string {
+    if (team.length === 0) {
+      return '## Your Team\n\nNo team members.'
+    }
+
+    const lines = ['## Your Team', '', '| Name | Role | Status |', '|------|------|--------|']
+    for (const m of team) {
+      lines.push(`| ${m.name} | ${m.role ?? 'agent'} | ${m.status} |`)
+    }
+    return lines.join('\n')
+  }
+
+  private buildReportsSection(reports: ReportRow[]): string {
+    if (reports.length === 0) {
+      return '## Your Direct Reports\n\nNo direct reports.'
+    }
+
+    const lines = ['## Your Direct Reports']
+    for (const r of reports) {
+      lines.push(`- ${r.name} (${r.role ?? 'agent'})`)
+    }
+    return lines.join('\n')
+  }
+
+  private buildTasksSection(tasks: TaskRow[]): string {
+    if (tasks.length === 0) {
+      return '## Active Tasks\n\nNo active tasks.'
+    }
+
+    const lines = ['## Active Tasks']
+    for (const t of tasks) {
+      const id = t.identifier ?? 'N/A'
+      const priority = t.priority ?? 'medium'
+      lines.push(`- ${id}: ${t.title} [${t.status}, ${priority}]`)
+    }
+    return lines.join('\n')
+  }
+
+  private buildPoliciesSection(policies: PolicyRow[]): string {
+    if (policies.length === 0) {
+      return '## Governance Policies\n\nNo policies configured.'
+    }
+
+    const lines = ['## Governance Policies']
+    for (const p of policies) {
+      lines.push(`- ${p.resource}: ${p.action}`)
+    }
+    return lines.join('\n')
+  }
+
+  private buildApiReferenceSection(): string {
+    return [
+      '## Reporting Results',
+      '',
+      'To report tool usage and session state, include in your output:',
+      '```',
+      '__shackleai_result__{"sessionState":"...","usage":{"inputTokens":N,"outputTokens":N,"costCents":N,"model":"...","provider":"..."}}__shackleai_result__',
+      '```',
+    ].join('\n')
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export const VERSION = '0.1.0'
 export { GovernanceEngine, RateLimiter } from './governance/index.js'
 export type { PolicyCheckResult } from './governance/index.js'
 
+export { ContextBuilder } from './context-builder.js'
+
 export { CostTracker } from './cost-tracker.js'
 export type {
   RecordCostInput,

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -32,6 +32,7 @@ import {
 } from '@shackleai/shared'
 import type { CostTracker } from '../cost-tracker.js'
 import type { Observatory } from '../observatory.js'
+import { ContextBuilder } from '../context-builder.js'
 import type { AdapterRegistry } from '../adapters/index.js'
 import type { AdapterContext, AdapterResult, GoalAncestry } from '../adapters/index.js'
 import { getLastSessionState, saveSessionState } from '../adapters/index.js'
@@ -79,6 +80,7 @@ export class HeartbeatExecutor {
   private costTracker: CostTracker
   private observatory: Observatory
   private adapterRegistry: AdapterRegistry
+  private contextBuilder: ContextBuilder
 
   constructor(
     db: DatabaseProvider,
@@ -90,6 +92,7 @@ export class HeartbeatExecutor {
     this.costTracker = costTracker
     this.observatory = observatory
     this.adapterRegistry = adapterRegistry
+    this.contextBuilder = new ContextBuilder(db)
   }
 
   /**
@@ -173,12 +176,13 @@ export class HeartbeatExecutor {
 
       // Build agent communication context (async awareness)
       const lastHeartbeat = agent.last_heartbeat_at ?? null
-      const [recentActivity, assignedTasks, unreadComments, ancestry] =
+      const [recentActivity, assignedTasks, unreadComments, ancestry, systemContext] =
         await Promise.all([
           this.getRecentActivity(companyId, lastHeartbeat),
           this.getAssignedTasks(agentId),
           this.getUnreadComments(agentId, lastHeartbeat),
           this.resolveAncestry(companyId, task),
+          this.contextBuilder.build(agentId, companyId),
         ])
 
       const ctx: AdapterContext = {
@@ -193,6 +197,7 @@ export class HeartbeatExecutor {
         assignedTasks,
         unreadComments,
         ancestry,
+        systemContext,
       }
 
       // Mark run as running


### PR DESCRIPTION
## Summary
- **New `ContextBuilder`** (`packages/core/src/context-builder.ts`) that generates structured Markdown context for agent heartbeats, including identity, team, tasks, governance policies, and API reference for result reporting
- **Extended `AdapterContext`** with `systemContext` field carrying the built context string
- **Wired into `HeartbeatExecutor`** — builds context in the existing `Promise.all` block alongside other async queries
- **Updated all 6 adapters** to consume `systemContext`:
  - `claude.ts` — prepends to prompt before ancestry context
  - `process.ts` — sets `SHACKLEAI_CONTEXT` env var (or `SHACKLEAI_CONTEXT_FILE` temp file if > 8KB)
  - `http.ts` — adds to POST payload
  - `mcp.ts` — adds to `_shackleai` enrichment
  - `openclaw.ts` + `crewai.ts` — adds to `--task` JSON payload
- **8 unit tests** covering all sections, empty states, missing data, and API reference inclusion

## Test plan
- [x] `pnpm build` passes (all packages)
- [x] `pnpm lint` passes for `@shackleai/core`
- [x] 8/8 new tests pass in `packages/core/__tests__/context-builder.test.ts`
- [ ] Code review by `code-reviewer` agent
- [ ] Integration test with live heartbeat execution

Closes #103

Generated with [Claude Code](https://claude.com/claude-code)