### PR TITLE
Add missing database indexes on FK and query columns

### DIFF
--- a/packages/db/src/migrations/015_indexes.ts
+++ b/packages/db/src/migrations/015_indexes.ts
@@ -1,0 +1,48 @@
+export const name = '015_indexes'
+export const sql = `
+  -- Agents
+  CREATE INDEX IF NOT EXISTS idx_agents_company ON agents(company_id);
+  CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+  CREATE INDEX IF NOT EXISTS idx_agents_reports_to ON agents(reports_to);
+
+  -- Issues
+  CREATE INDEX IF NOT EXISTS idx_issues_company ON issues(company_id);
+  CREATE INDEX IF NOT EXISTS idx_issues_assignee ON issues(assignee_agent_id);
+  CREATE INDEX IF NOT EXISTS idx_issues_parent ON issues(parent_id);
+  CREATE INDEX IF NOT EXISTS idx_issues_goal ON issues(goal_id);
+  CREATE INDEX IF NOT EXISTS idx_issues_project ON issues(project_id);
+  CREATE INDEX IF NOT EXISTS idx_issues_status ON issues(status);
+  CREATE INDEX IF NOT EXISTS idx_issues_created ON issues(created_at);
+
+  -- Goals
+  CREATE INDEX IF NOT EXISTS idx_goals_company ON goals(company_id);
+
+  -- Projects
+  CREATE INDEX IF NOT EXISTS idx_projects_company ON projects(company_id);
+
+  -- Policies
+  CREATE INDEX IF NOT EXISTS idx_policies_company ON policies(company_id);
+
+  -- Cost events
+  CREATE INDEX IF NOT EXISTS idx_cost_events_company ON cost_events(company_id);
+  CREATE INDEX IF NOT EXISTS idx_cost_events_agent ON cost_events(agent_id);
+  CREATE INDEX IF NOT EXISTS idx_cost_events_occurred ON cost_events(occurred_at);
+
+  -- Heartbeat runs
+  CREATE INDEX IF NOT EXISTS idx_heartbeat_runs_company ON heartbeat_runs(company_id);
+  CREATE INDEX IF NOT EXISTS idx_heartbeat_runs_agent ON heartbeat_runs(agent_id);
+  CREATE INDEX IF NOT EXISTS idx_heartbeat_runs_created ON heartbeat_runs(created_at);
+
+  -- Activity log
+  CREATE INDEX IF NOT EXISTS idx_activity_log_company ON activity_log(company_id);
+  CREATE INDEX IF NOT EXISTS idx_activity_log_entity ON activity_log(entity_type, entity_id);
+  CREATE INDEX IF NOT EXISTS idx_activity_log_created ON activity_log(created_at);
+
+  -- Issue comments
+  CREATE INDEX IF NOT EXISTS idx_issue_comments_issue ON issue_comments(issue_id);
+  CREATE INDEX IF NOT EXISTS idx_issue_comments_author ON issue_comments(author_agent_id);
+
+  -- Agent API keys
+  CREATE INDEX IF NOT EXISTS idx_agent_api_keys_agent ON agent_api_keys(agent_id);
+  CREATE INDEX IF NOT EXISTS idx_agent_api_keys_hash ON agent_api_keys(key_hash);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -13,6 +13,7 @@ import * as m011 from './011_api_keys.js'
 import * as m012 from './012_license_keys.js'
 import * as m013 from './013_agent_worktrees.js'
 import * as m014 from './014_tool_calls.js'
+import * as m015 from './015_indexes.js'
 
 export interface Migration {
   name: string
@@ -34,6 +35,7 @@ const migrations: Migration[] = [
   m012,
   m013,
   m014,
+  m015,
 ]
 
 /**


### PR DESCRIPTION
## Summary
- Adds migration `015_indexes` with indexes on all frequently queried columns across all tables
- Covers `company_id` (multi-tenant FK), `created_at`/`occurred_at` (time-range queries), `status` (filtered lists), and foreign key columns used in JOINs
- All indexes use `IF NOT EXISTS` for idempotent application

Closes #79

## Test plan
- [x] `pnpm build` passes (all 5 packages)
- [x] `@shackleai/db` tests pass (14/14) — includes migration runner applying all 15 migrations on a fresh database
- [ ] Verify query plans show index scans instead of sequential scans after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)