### PR TITLE
feat: Threaded comments — full CRUD API + CLI commands

### DIFF
--- a/apps/cli/__tests__/comments.test.ts
+++ b/apps/cli/__tests__/comments.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import type { Scheduler } from '@shackleai/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type CompanyRow = { id: string; issue_prefix: string; issue_counter: number }
+type AgentRow = { id: string; name: string }
+type IssueRow = { id: string; identifier: string; title: string; company_id: string }
+type CommentRow = {
+  id: string
+  issue_id: string
+  content: string
+  author_agent_id: string | null
+  parent_id: string | null
+  is_resolved: boolean
+  created_at: string
+}
+
+async function createCompany(
+  app: ReturnType<typeof createApp>,
+  prefix: string,
+): Promise<CompanyRow> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: `Company ${prefix}`, issue_prefix: prefix }),
+  })
+  const body = (await res.json()) as { data: CompanyRow }
+  return body.data
+}
+
+async function createAgent(
+  db: PGliteProvider,
+  companyId: string,
+  name: string = 'Test Agent',
+): Promise<AgentRow> {
+  const result = await db.query<AgentRow>(
+    `INSERT INTO agents (company_id, name, adapter_type, adapter_config)
+     VALUES ($1, $2, 'process', '{}')
+     RETURNING id, name`,
+    [companyId, name],
+  )
+  return result.rows[0]
+}
+
+async function createIssue(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<IssueRow> {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Default Issue', ...overrides }),
+  })
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+async function postComment(
+  app: ReturnType<typeof createApp>,
+  companyId: string,
+  issueId: string,
+  payload: Record<string, unknown>,
+): Promise<Response> {
+  return app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests — CRUD
+// ---------------------------------------------------------------------------
+
+describe('comments routes — CRUD', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let issueId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'CMTS')
+    companyId = company.id
+    const issue = await createIssue(app, companyId, { title: 'Comment Target' })
+    issueId = issue.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('POST creates a comment and returns 201', async () => {
+    const res = await postComment(app, companyId, issueId, { content: 'First comment' })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: CommentRow }
+    expect(body.data.content).toBe('First comment')
+    expect(body.data.issue_id).toBe(issueId)
+    expect(body.data.author_agent_id).toBeNull()
+    expect(body.data.parent_id).toBeNull()
+    expect(body.data.is_resolved).toBe(false)
+  })
+
+  it('GET list returns comments sorted by created_at ASC', async () => {
+    // Add a second comment
+    await postComment(app, companyId, issueId, { content: 'Second comment' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CommentRow[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data.length).toBeGreaterThanOrEqual(2)
+    // First created should be first in the list (ASC order)
+    expect(body.data[0].content).toBe('First comment')
+  })
+
+  it('GET single returns a specific comment', async () => {
+    // Create a comment and fetch it by ID
+    const createRes = await postComment(app, companyId, issueId, { content: 'Fetchable' })
+    const created = (await createRes.json()) as { data: CommentRow }
+    const commentId = created.data.id
+
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments/${commentId}`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: CommentRow }
+    expect(body.data.id).toBe(commentId)
+    expect(body.data.content).toBe('Fetchable')
+  })
+
+  it('DELETE removes a comment and returns 200', async () => {
+    const createRes = await postComment(app, companyId, issueId, { content: 'Delete me' })
+    const created = (await createRes.json()) as { data: CommentRow }
+    const commentId = created.data.id
+
+    // Delete
+    const deleteRes = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments/${commentId}`,
+      { method: 'DELETE' },
+    )
+    expect(deleteRes.status).toBe(200)
+    const deleteBody = (await deleteRes.json()) as { data: CommentRow }
+    expect(deleteBody.data.id).toBe(commentId)
+
+    // Verify it's gone
+    const getRes = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments/${commentId}`,
+    )
+    expect(getRes.status).toBe(404)
+  })
+
+  it('POST returns 400 on empty body (missing content)', async () => {
+    const res = await postComment(app, companyId, issueId, {})
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('POST returns 400 on invalid JSON', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not-json',
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('POST returns 404 for non-existent issue', async () => {
+    const res = await postComment(app, companyId, '00000000-0000-0000-0000-000000000000', {
+      content: 'Ghost',
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('GET list returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/comments`,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('GET single returns 404 for non-existent comment', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments/00000000-0000-0000-0000-000000000000`,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('DELETE returns 404 for non-existent comment', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments/00000000-0000-0000-0000-000000000000`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — Threading
+// ---------------------------------------------------------------------------
+
+describe('comments routes — threading', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let issueId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db)
+    const company = await createCompany(app, 'THRD')
+    companyId = company.id
+    const issue = await createIssue(app, companyId, { title: 'Thread Target' })
+    issueId = issue.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('supports threaded replies via parent_id', async () => {
+    // Create parent
+    const parentRes = await postComment(app, companyId, issueId, { content: 'Parent' })
+    const parent = (await parentRes.json()) as { data: CommentRow }
+
+    // Create reply
+    const replyRes = await postComment(app, companyId, issueId, {
+      content: 'Reply',
+      parent_id: parent.data.id,
+    })
+    expect(replyRes.status).toBe(201)
+    const reply = (await replyRes.json()) as { data: CommentRow }
+    expect(reply.data.parent_id).toBe(parent.data.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — @mention triggers
+// ---------------------------------------------------------------------------
+
+describe('comments routes — @mention triggers', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let issueId: string
+  let mockScheduler: Scheduler
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+
+    mockScheduler = {
+      triggerNow: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Scheduler
+
+    app = createApp(db, { scheduler: mockScheduler })
+    const company = await createCompany(app, 'MENT')
+    companyId = company.id
+
+    // Create an agent that can be mentioned
+    await createAgent(db, companyId, 'backend-bot')
+
+    const issue = await createIssue(app, companyId, { title: 'Mention Target' })
+    issueId = issue.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('fires trigger when comment contains @mention of existing agent', async () => {
+    const triggerNow = mockScheduler.triggerNow as ReturnType<typeof vi.fn>
+    triggerNow.mockClear()
+
+    const res = await postComment(app, companyId, issueId, {
+      content: 'Hey @backend-bot please review this',
+    })
+    expect(res.status).toBe(201)
+
+    expect(triggerNow).toHaveBeenCalled()
+  })
+
+  it('does not fire trigger for non-existent agent mention', async () => {
+    const triggerNow = vi.fn().mockResolvedValue(undefined)
+    const scheduler = { triggerNow } as unknown as Scheduler
+    const localApp = createApp(db, { scheduler })
+
+    const res = await localApp.request(
+      `/api/companies/${companyId}/issues/${issueId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Hey @nonexistent-agent check this' }),
+      },
+    )
+    expect(res.status).toBe(201)
+
+    expect(triggerNow).not.toHaveBeenCalled()
+  })
+})

--- a/apps/cli/src/commands/comment.ts
+++ b/apps/cli/src/commands/comment.ts
@@ -1,0 +1,84 @@
+/**
+ * `shackleai comment` — List and add threaded comments on issues
+ */
+
+import type { Command } from 'commander'
+import type { IssueComment } from '@shackleai/shared'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+function formatCommentTable(comments: IssueComment[]): void {
+  if (comments.length === 0) {
+    console.log('No comments found.')
+    return
+  }
+
+  const rows = comments.map((c) => ({
+    ID: c.id.slice(0, 8),
+    Author: c.author_agent_id ? c.author_agent_id.slice(0, 8) : 'system',
+    Content: c.content.length > 60 ? c.content.slice(0, 57) + '...' : c.content,
+    Thread: c.parent_id ? c.parent_id.slice(0, 8) : '-',
+    Resolved: c.is_resolved ? 'yes' : 'no',
+    Created: new Date(c.created_at).toLocaleString(),
+  }))
+
+  console.table(rows)
+}
+
+async function listComments(issueId: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/issues/${issueId}/comments`)
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<IssueComment[]>
+  formatCommentTable(body.data)
+}
+
+async function addComment(issueId: string, message: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ content: message }),
+  })
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<IssueComment>
+  console.log(`Comment added (${body.data.id.slice(0, 8)}) on issue ${issueId.slice(0, 8)}`)
+}
+
+export function registerCommentCommand(program: Command): void {
+  const comment = program
+    .command('comment')
+    .description('Manage comments on issues')
+
+  comment
+    .command('list')
+    .argument('<issueId>', 'Issue ID')
+    .description('List comments on an issue')
+    .action(async (issueId: string) => {
+      await listComments(issueId)
+    })
+
+  comment
+    .command('add')
+    .argument('<issueId>', 'Issue ID')
+    .argument('<message>', 'Comment message')
+    .description('Add a comment to an issue')
+    .action(async (issueId: string, message: string) => {
+      await addComment(issueId, message)
+    })
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,7 @@ import { registerRunCommand } from './commands/run.js'
 import { registerDoctorCommand } from './commands/doctor.js'
 import { registerUpgradeCommand } from './commands/upgrade.js'
 import { registerWorktreeCommand } from './commands/worktree.js'
+import { registerCommentCommand } from './commands/comment.js'
 
 export const VERSION = '0.1.0'
 
@@ -45,6 +46,7 @@ registerRunCommand(program)
 registerDoctorCommand(program)
 registerUpgradeCommand(program)
 registerWorktreeCommand(program)
+registerCommentCommand(program)
 
 // Only parse when run as CLI entrypoint — not when imported for VERSION etc.
 const isDirectRun =

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -21,6 +21,7 @@ import { goalsRouter } from './routes/goals.js'
 import { projectsRouter } from './routes/projects.js'
 import { worktreesRouter } from './routes/worktrees.js'
 import { toolCallsRouter } from './routes/tool-calls.js'
+import { commentsRouter } from './routes/comments.js'
 
 import { VERSION } from '../index.js'
 
@@ -47,6 +48,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', projectsRouter(db))
   app.route('/api/companies', worktreesRouter(db))
   app.route('/api/companies', toolCallsRouter(db))
+  app.route('/api/companies', commentsRouter(db, options?.scheduler))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/comments.ts
+++ b/apps/cli/src/server/routes/comments.ts
@@ -1,0 +1,158 @@
+/**
+ * Comment CRUD routes — /api/companies/:id/issues/:issueId/comments
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Issue, IssueComment } from '@shackleai/shared'
+import { CreateIssueCommentInput, TriggerType } from '@shackleai/shared'
+import type { Scheduler } from '@shackleai/core'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+/**
+ * Verify the issue exists and belongs to the company.
+ * Returns null if not found, otherwise the issue id.
+ */
+async function verifyIssueOwnership(
+  db: DatabaseProvider,
+  issueId: string,
+  companyId: string,
+): Promise<string | null> {
+  const result = await db.query<Pick<Issue, 'id'>>(
+    `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+    [issueId, companyId],
+  )
+  return result.rows.length > 0 ? result.rows[0].id : null
+}
+
+export function commentsRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/issues/:issueId/comments — list comments (paginated)
+  app.get('/:id/issues/:issueId/comments', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const { limit, offset } = parsePagination(c)
+    const result = await db.query<IssueComment>(
+      `SELECT * FROM issue_comments WHERE issue_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3`,
+      [issueId, limit, offset],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/comments — create comment
+  app.post('/:id/issues/:issueId/comments', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateIssueCommentInput.safeParse({ issue_id: issueId, ...(body as object) })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { content, author_agent_id, parent_id, is_resolved } = parsed.data
+
+    const result = await db.query<IssueComment>(
+      `INSERT INTO issue_comments (issue_id, author_agent_id, content, parent_id, is_resolved)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [issueId, author_agent_id ?? null, content, parent_id ?? null, is_resolved],
+    )
+
+    // Trigger mentioned agents — scan for @agent-name patterns
+    if (scheduler) {
+      const mentions = content.match(/@([\w-]+)/g)
+      if (mentions) {
+        const uniqueNames = [...new Set(mentions.map((m) => m.slice(1)))]
+        for (const agentName of uniqueNames) {
+          const agentResult = await db.query<{ id: string }>(
+            `SELECT id FROM agents WHERE company_id = $1 AND name = $2`,
+            [companyId, agentName],
+          )
+          if (agentResult.rows.length > 0) {
+            void scheduler.triggerNow(agentResult.rows[0].id, TriggerType.Mentioned)
+          }
+        }
+      }
+    }
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/issues/:issueId/comments/:cid — get single comment
+  app.get('/:id/issues/:issueId/comments/:cid', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+    const commentId = c.req.param('cid')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const result = await db.query<IssueComment>(
+      `SELECT * FROM issue_comments WHERE id = $1 AND issue_id = $2`,
+      [commentId, issueId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Comment not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // DELETE /api/companies/:id/issues/:issueId/comments/:cid — delete comment
+  app.delete('/:id/issues/:issueId/comments/:cid', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+    const commentId = c.req.param('cid')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const result = await db.query<IssueComment>(
+      `DELETE FROM issue_comments WHERE id = $1 AND issue_id = $2 RETURNING *`,
+      [commentId, issueId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Comment not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  return app
+}

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -1,11 +1,11 @@
 /**
- * Issue CRUD + checkout + comments routes — /api/companies/:id/issues
+ * Issue CRUD + checkout + delegate routes — /api/companies/:id/issues
  */
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
-import type { Issue, IssueComment } from '@shackleai/shared'
-import { CreateIssueInput, UpdateIssueInput, CreateIssueCommentInput, DelegateIssueInput } from '@shackleai/shared'
+import type { Issue } from '@shackleai/shared'
+import { CreateIssueInput, UpdateIssueInput, DelegateIssueInput } from '@shackleai/shared'
 import { IssueStatus, TriggerType } from '@shackleai/shared'
 import type { Scheduler } from '@shackleai/core'
 import { DelegationService, DelegationError, rollUpParentStatus } from '@shackleai/core'
@@ -297,84 +297,6 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
     }
 
     return c.json({ data: result.rows[0] })
-  })
-
-  // POST /api/companies/:id/issues/:issueId/comments — add comment
-  app.post('/:id/issues/:issueId/comments', companyScope, async (c) => {
-    const companyId = c.req.param('id')
-    const issueId = c.req.param('issueId')
-
-    // Verify issue belongs to company
-    const existing = await db.query<Issue>(
-      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
-      [issueId, companyId],
-    )
-    if (existing.rows.length === 0) {
-      return c.json({ error: 'Issue not found' }, 404)
-    }
-
-    let body: unknown
-    try {
-      body = await c.req.json()
-    } catch {
-      return c.json({ error: 'Invalid JSON body' }, 400)
-    }
-
-    const parsed = CreateIssueCommentInput.safeParse({ issue_id: issueId, ...(body as object) })
-    if (!parsed.success) {
-      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
-    }
-
-    const { content, author_agent_id, parent_id, is_resolved } = parsed.data
-
-    const result = await db.query<IssueComment>(
-      `INSERT INTO issue_comments (issue_id, author_agent_id, content, parent_id, is_resolved)
-       VALUES ($1, $2, $3, $4, $5)
-       RETURNING *`,
-      [issueId, author_agent_id ?? null, content, parent_id ?? null, is_resolved],
-    )
-
-    // Trigger mentioned agents — scan for @agent-name patterns
-    if (scheduler) {
-      const mentions = content.match(/@([\w-]+)/g)
-      if (mentions) {
-        const uniqueNames = [...new Set(mentions.map((m) => m.slice(1)))]
-        for (const agentName of uniqueNames) {
-          const agentResult = await db.query<{ id: string }>(
-            `SELECT id FROM agents WHERE company_id = $1 AND name = $2`,
-            [companyId, agentName],
-          )
-          if (agentResult.rows.length > 0) {
-            void scheduler.triggerNow(agentResult.rows[0].id, TriggerType.Mentioned)
-          }
-        }
-      }
-    }
-
-    return c.json({ data: result.rows[0] }, 201)
-  })
-
-  // GET /api/companies/:id/issues/:issueId/comments — list comments ordered by created_at
-  app.get('/:id/issues/:issueId/comments', companyScope, async (c) => {
-    const companyId = c.req.param('id')
-    const issueId = c.req.param('issueId')
-
-    // Verify issue belongs to company
-    const existing = await db.query<Issue>(
-      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
-      [issueId, companyId],
-    )
-    if (existing.rows.length === 0) {
-      return c.json({ error: 'Issue not found' }, 404)
-    }
-
-    const { limit, offset } = parsePagination(c)
-    const result = await db.query<IssueComment>(
-      `SELECT * FROM issue_comments WHERE issue_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3`,
-      [issueId, limit, offset],
-    )
-
-    return c.json({ data: result.rows })
   })
 
   // POST /api/companies/:id/issues/:issueId/delegate — delegate to a direct report


### PR DESCRIPTION
## Summary

- **Extracted** comment routes from `issues.ts` into a dedicated `comments.ts` router with full CRUD: GET list (paginated), POST create, GET single, DELETE
- **Added** CLI commands: `shackleai comment list <issueId>` and `shackleai comment add <issueId> "message"`
- **13 new tests** covering CRUD operations, threading via `parent_id`, validation errors, 404 cases, and @mention trigger firing

## Details

The `issue_comments` table (migration 006) and `CreateIssueCommentInput` validator already existed. POST/GET comment routes were embedded in the issues router. This PR:

1. Moves comment routes to `apps/cli/src/server/routes/comments.ts` with a `verifyIssueOwnership` helper
2. Adds GET single (`/:cid`) and DELETE (`/:cid`) endpoints that were missing
3. Preserves @mention trigger behavior (scan for `@agent-name`, look up agent, fire `TriggerType.Mentioned`)
4. Registers the new router in `server/index.ts`
5. Adds `comment` CLI command in `apps/cli/src/commands/comment.ts`
6. All 291 CLI tests pass (including 13 new + all existing event-trigger tests)

Closes #27

## Test plan

- [x] `pnpm build` passes (TypeScript strict mode, zero errors)
- [x] `pnpm test` — 291/291 CLI tests pass
- [x] New `comments.test.ts` covers: create 201, list ASC order, get single, delete + verify gone, empty body 400, invalid JSON 400, non-existent issue 404, non-existent comment 404, threading via parent_id, @mention trigger fires, non-existent agent mention does not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)