### PR TITLE
feat: add Codex, Cursor, Gemini, and Kiro adapters

### DIFF
--- a/packages/core/__tests__/adapter-registry.test.ts
+++ b/packages/core/__tests__/adapter-registry.test.ts
@@ -16,6 +16,10 @@ describe('AdapterRegistry', () => {
     expect(registry.has('mcp')).toBe(true)
     expect(registry.has('openclaw')).toBe(true)
     expect(registry.has('crewai')).toBe(true)
+    expect(registry.has('codex')).toBe(true)
+    expect(registry.has('cursor')).toBe(true)
+    expect(registry.has('gemini')).toBe(true)
+    expect(registry.has('kiro')).toBe(true)
 
     expect(registry.get('process')).toBeInstanceOf(ProcessAdapter)
     expect(registry.get('http')).toBeInstanceOf(HttpAdapter)
@@ -74,12 +78,16 @@ describe('AdapterRegistry', () => {
     registry.register(mockAdapter)
 
     const all = registry.list()
-    expect(all).toHaveLength(7) // process + http + claude + mcp + openclaw + crewai + custom
+    expect(all).toHaveLength(11) // 10 built-in + 1 custom
     expect(all.map((a) => a.type).sort()).toEqual([
       'claude',
+      'codex',
       'crewai',
+      'cursor',
       'custom',
+      'gemini',
       'http',
+      'kiro',
       'mcp',
       'openclaw',
       'process',

--- a/packages/core/src/adapters/codex.ts
+++ b/packages/core/src/adapters/codex.ts
@@ -1,0 +1,139 @@
+/**
+ * CodexAdapter — invokes the OpenAI Codex CLI to execute a heartbeat.
+ *
+ * Spawns `codex` with the prompt via `--prompt` argument.
+ * Follows the same patterns as ClaudeAdapter: graceful kill,
+ * timeout handling, __shackleai_result__ parsing, and safe env.
+ */
+
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
+import { gracefulKill, KILL_GRACE_MS } from './kill.js'
+import { buildFullPrompt, parseShackleResult } from './util.js'
+
+const IS_WIN = process.platform === 'win32'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export class CodexAdapter implements AdapterModule {
+  readonly type = 'codex'
+  readonly label = 'OpenAI Codex CLI'
+
+  private activeChild: ChildProcess | null = null
+  private abortKillTimer: ReturnType<typeof setTimeout> | null = null
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const prompt = ctx.adapterConfig.prompt as string | undefined
+    if (!prompt) {
+      return { exitCode: 1, stdout: '', stderr: 'adapterConfig.prompt is required for codex adapter' }
+    }
+
+    const fullPrompt = buildFullPrompt(prompt, ctx)
+    const timeoutMs = typeof ctx.adapterConfig.timeout === 'number'
+      ? ctx.adapterConfig.timeout * 1000
+      : DEFAULT_TIMEOUT_MS
+    const env = this.buildEnv(ctx)
+    const args = ['--quiet', '--prompt', fullPrompt]
+    const model = ctx.adapterConfig.model as string | undefined
+    if (model) args.unshift('--model', model)
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn('codex', args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+        detached: !IS_WIN,
+      })
+      this.activeChild = child
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        killTimer = gracefulKill(child, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+        const parsed = parseShackleResult(stdout)
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed ? `Codex CLI killed after ${timeoutMs}ms timeout\n${stderr}` : stderr,
+          sessionState: parsed?.sessionState ?? null,
+          usage: parsed?.usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        resolve({ exitCode: 127, stdout: '', stderr: `Failed to spawn codex CLI: ${err.message}` })
+      })
+    })
+  }
+
+  abort(): void {
+    const child = this.activeChild
+    if (!child) return
+    if (this.abortKillTimer) clearTimeout(this.abortKillTimer)
+    this.abortKillTimer = gracefulKill(child, KILL_GRACE_MS)
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = spawn('codex', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+      })
+      child.stdout.on('data', () => { /* drain */ })
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        resolve({ ok: false, error: 'codex --version timed out' })
+      }, 10_000)
+      child.on('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code === 0
+          ? { ok: true }
+          : { ok: false, error: `codex --version exited with code ${code}` })
+      })
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        resolve({ ok: false, error: `codex CLI not found: ${err.message}` })
+      })
+    })
+  }
+
+  private buildEnv(ctx: AdapterContext): Record<string, string> {
+    const shackleEnv: Record<string, string> = {
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+    }
+    const env = getSafeEnv(shackleEnv)
+    if (ctx.task) env.SHACKLEAI_TASK_ID = ctx.task
+    if (ctx.ancestry?.mission) env.SHACKLEAI_MISSION = ctx.ancestry.mission
+    if (ctx.ancestry?.project) env.SHACKLEAI_PROJECT = ctx.ancestry.project.name
+    if (ctx.ancestry?.goal) env.SHACKLEAI_GOAL = ctx.ancestry.goal.name
+    if (ctx.env.SHACKLEAI_API_KEY) env.SHACKLEAI_API_KEY = ctx.env.SHACKLEAI_API_KEY
+    if (ctx.sessionState) env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    return env
+  }
+
+  private clearActiveChild(child: ChildProcess): void {
+    if (this.activeChild === child) this.activeChild = null
+    if (this.abortKillTimer) { clearTimeout(this.abortKillTimer); this.abortKillTimer = null }
+  }
+}

--- a/packages/core/src/adapters/cursor.ts
+++ b/packages/core/src/adapters/cursor.ts
@@ -1,0 +1,139 @@
+/**
+ * CursorAdapter — invokes the Cursor CLI to execute a heartbeat.
+ *
+ * Spawns `cursor --cli` as a child process.
+ * Follows the same patterns as ClaudeAdapter: graceful kill,
+ * timeout handling, __shackleai_result__ parsing, and safe env.
+ */
+
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
+import { gracefulKill, KILL_GRACE_MS } from './kill.js'
+import { buildFullPrompt, parseShackleResult } from './util.js'
+
+const IS_WIN = process.platform === 'win32'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export class CursorAdapter implements AdapterModule {
+  readonly type = 'cursor'
+  readonly label = 'Cursor CLI'
+
+  private activeChild: ChildProcess | null = null
+  private abortKillTimer: ReturnType<typeof setTimeout> | null = null
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const prompt = ctx.adapterConfig.prompt as string | undefined
+    if (!prompt) {
+      return { exitCode: 1, stdout: '', stderr: 'adapterConfig.prompt is required for cursor adapter' }
+    }
+
+    const fullPrompt = buildFullPrompt(prompt, ctx)
+    const timeoutMs = typeof ctx.adapterConfig.timeout === 'number'
+      ? ctx.adapterConfig.timeout * 1000
+      : DEFAULT_TIMEOUT_MS
+    const env = this.buildEnv(ctx)
+    const args = ['--cli', '--prompt', fullPrompt]
+    const model = ctx.adapterConfig.model as string | undefined
+    if (model) args.push('--model', model)
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn('cursor', args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+        detached: !IS_WIN,
+      })
+      this.activeChild = child
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        killTimer = gracefulKill(child, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+        const parsed = parseShackleResult(stdout)
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed ? `Cursor CLI killed after ${timeoutMs}ms timeout\n${stderr}` : stderr,
+          sessionState: parsed?.sessionState ?? null,
+          usage: parsed?.usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        resolve({ exitCode: 127, stdout: '', stderr: `Failed to spawn cursor CLI: ${err.message}` })
+      })
+    })
+  }
+
+  abort(): void {
+    const child = this.activeChild
+    if (!child) return
+    if (this.abortKillTimer) clearTimeout(this.abortKillTimer)
+    this.abortKillTimer = gracefulKill(child, KILL_GRACE_MS)
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = spawn('cursor', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+      })
+      child.stdout.on('data', () => { /* drain */ })
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        resolve({ ok: false, error: 'cursor --version timed out' })
+      }, 10_000)
+      child.on('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code === 0
+          ? { ok: true }
+          : { ok: false, error: `cursor --version exited with code ${code}` })
+      })
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        resolve({ ok: false, error: `cursor CLI not found: ${err.message}` })
+      })
+    })
+  }
+
+  private buildEnv(ctx: AdapterContext): Record<string, string> {
+    const shackleEnv: Record<string, string> = {
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+    }
+    const env = getSafeEnv(shackleEnv)
+    if (ctx.task) env.SHACKLEAI_TASK_ID = ctx.task
+    if (ctx.ancestry?.mission) env.SHACKLEAI_MISSION = ctx.ancestry.mission
+    if (ctx.ancestry?.project) env.SHACKLEAI_PROJECT = ctx.ancestry.project.name
+    if (ctx.ancestry?.goal) env.SHACKLEAI_GOAL = ctx.ancestry.goal.name
+    if (ctx.env.SHACKLEAI_API_KEY) env.SHACKLEAI_API_KEY = ctx.env.SHACKLEAI_API_KEY
+    if (ctx.sessionState) env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    return env
+  }
+
+  private clearActiveChild(child: ChildProcess): void {
+    if (this.activeChild === child) this.activeChild = null
+    if (this.abortKillTimer) { clearTimeout(this.abortKillTimer); this.abortKillTimer = null }
+  }
+}

--- a/packages/core/src/adapters/gemini.ts
+++ b/packages/core/src/adapters/gemini.ts
@@ -1,0 +1,139 @@
+/**
+ * GeminiAdapter — invokes the Gemini CLI to execute a heartbeat.
+ *
+ * Spawns `gemini` as a child process with `--prompt` argument.
+ * Follows the same patterns as ClaudeAdapter: graceful kill,
+ * timeout handling, __shackleai_result__ parsing, and safe env.
+ */
+
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
+import { gracefulKill, KILL_GRACE_MS } from './kill.js'
+import { buildFullPrompt, parseShackleResult } from './util.js'
+
+const IS_WIN = process.platform === 'win32'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export class GeminiAdapter implements AdapterModule {
+  readonly type = 'gemini'
+  readonly label = 'Gemini CLI'
+
+  private activeChild: ChildProcess | null = null
+  private abortKillTimer: ReturnType<typeof setTimeout> | null = null
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const prompt = ctx.adapterConfig.prompt as string | undefined
+    if (!prompt) {
+      return { exitCode: 1, stdout: '', stderr: 'adapterConfig.prompt is required for gemini adapter' }
+    }
+
+    const fullPrompt = buildFullPrompt(prompt, ctx)
+    const timeoutMs = typeof ctx.adapterConfig.timeout === 'number'
+      ? ctx.adapterConfig.timeout * 1000
+      : DEFAULT_TIMEOUT_MS
+    const env = this.buildEnv(ctx)
+    const args = ['--prompt', fullPrompt]
+    const model = ctx.adapterConfig.model as string | undefined
+    if (model) args.unshift('--model', model)
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn('gemini', args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+        detached: !IS_WIN,
+      })
+      this.activeChild = child
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        killTimer = gracefulKill(child, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+        const parsed = parseShackleResult(stdout)
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed ? `Gemini CLI killed after ${timeoutMs}ms timeout\n${stderr}` : stderr,
+          sessionState: parsed?.sessionState ?? null,
+          usage: parsed?.usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        resolve({ exitCode: 127, stdout: '', stderr: `Failed to spawn gemini CLI: ${err.message}` })
+      })
+    })
+  }
+
+  abort(): void {
+    const child = this.activeChild
+    if (!child) return
+    if (this.abortKillTimer) clearTimeout(this.abortKillTimer)
+    this.abortKillTimer = gracefulKill(child, KILL_GRACE_MS)
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = spawn('gemini', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+      })
+      child.stdout.on('data', () => { /* drain */ })
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        resolve({ ok: false, error: 'gemini --version timed out' })
+      }, 10_000)
+      child.on('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code === 0
+          ? { ok: true }
+          : { ok: false, error: `gemini --version exited with code ${code}` })
+      })
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        resolve({ ok: false, error: `gemini CLI not found: ${err.message}` })
+      })
+    })
+  }
+
+  private buildEnv(ctx: AdapterContext): Record<string, string> {
+    const shackleEnv: Record<string, string> = {
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+    }
+    const env = getSafeEnv(shackleEnv)
+    if (ctx.task) env.SHACKLEAI_TASK_ID = ctx.task
+    if (ctx.ancestry?.mission) env.SHACKLEAI_MISSION = ctx.ancestry.mission
+    if (ctx.ancestry?.project) env.SHACKLEAI_PROJECT = ctx.ancestry.project.name
+    if (ctx.ancestry?.goal) env.SHACKLEAI_GOAL = ctx.ancestry.goal.name
+    if (ctx.env.SHACKLEAI_API_KEY) env.SHACKLEAI_API_KEY = ctx.env.SHACKLEAI_API_KEY
+    if (ctx.sessionState) env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    return env
+  }
+
+  private clearActiveChild(child: ChildProcess): void {
+    if (this.activeChild === child) this.activeChild = null
+    if (this.abortKillTimer) { clearTimeout(this.abortKillTimer); this.abortKillTimer = null }
+  }
+}

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -9,6 +9,10 @@ export { ClaudeAdapter } from './claude.js'
 export { McpAdapter } from './mcp.js'
 export { OpenClawAdapter } from './openclaw.js'
 export { CrewAIAdapter } from './crewai.js'
+export { CodexAdapter } from './codex.js'
+export { CursorAdapter } from './cursor.js'
+export { GeminiAdapter } from './gemini.js'
+export { KiroAdapter } from './kiro.js'
 export { getLastSessionState, saveSessionState } from './session.js'
 
 import type { AdapterModule } from './adapter.js'
@@ -18,6 +22,10 @@ import { ClaudeAdapter } from './claude.js'
 import { McpAdapter } from './mcp.js'
 import { OpenClawAdapter } from './openclaw.js'
 import { CrewAIAdapter } from './crewai.js'
+import { CodexAdapter } from './codex.js'
+import { CursorAdapter } from './cursor.js'
+import { GeminiAdapter } from './gemini.js'
+import { KiroAdapter } from './kiro.js'
 
 /**
  * AdapterRegistry — maps adapter_type strings to AdapterModule instances.
@@ -34,6 +42,10 @@ export class AdapterRegistry {
     this.register(new McpAdapter())
     this.register(new OpenClawAdapter())
     this.register(new CrewAIAdapter())
+    this.register(new CodexAdapter())
+    this.register(new CursorAdapter())
+    this.register(new GeminiAdapter())
+    this.register(new KiroAdapter())
   }
 
   /** Register an adapter module. Overwrites any existing adapter with the same type. */

--- a/packages/core/src/adapters/kiro.ts
+++ b/packages/core/src/adapters/kiro.ts
@@ -1,0 +1,139 @@
+/**
+ * KiroAdapter — invokes the Kiro CLI to execute a heartbeat.
+ *
+ * Spawns `kiro` as a child process with `--prompt` argument.
+ * Follows the same patterns as ClaudeAdapter: graceful kill,
+ * timeout handling, __shackleai_result__ parsing, and safe env.
+ */
+
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
+import { gracefulKill, KILL_GRACE_MS } from './kill.js'
+import { buildFullPrompt, parseShackleResult } from './util.js'
+
+const IS_WIN = process.platform === 'win32'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export class KiroAdapter implements AdapterModule {
+  readonly type = 'kiro'
+  readonly label = 'Kiro CLI'
+
+  private activeChild: ChildProcess | null = null
+  private abortKillTimer: ReturnType<typeof setTimeout> | null = null
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const prompt = ctx.adapterConfig.prompt as string | undefined
+    if (!prompt) {
+      return { exitCode: 1, stdout: '', stderr: 'adapterConfig.prompt is required for kiro adapter' }
+    }
+
+    const fullPrompt = buildFullPrompt(prompt, ctx)
+    const timeoutMs = typeof ctx.adapterConfig.timeout === 'number'
+      ? ctx.adapterConfig.timeout * 1000
+      : DEFAULT_TIMEOUT_MS
+    const env = this.buildEnv(ctx)
+    const args = ['--prompt', fullPrompt]
+    const model = ctx.adapterConfig.model as string | undefined
+    if (model) args.unshift('--model', model)
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn('kiro', args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+        detached: !IS_WIN,
+      })
+      this.activeChild = child
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        killTimer = gracefulKill(child, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+        const parsed = parseShackleResult(stdout)
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed ? `Kiro CLI killed after ${timeoutMs}ms timeout\n${stderr}` : stderr,
+          sessionState: parsed?.sessionState ?? null,
+          usage: parsed?.usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        resolve({ exitCode: 127, stdout: '', stderr: `Failed to spawn kiro CLI: ${err.message}` })
+      })
+    })
+  }
+
+  abort(): void {
+    const child = this.activeChild
+    if (!child) return
+    if (this.abortKillTimer) clearTimeout(this.abortKillTimer)
+    this.abortKillTimer = gracefulKill(child, KILL_GRACE_MS)
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = spawn('kiro', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: IS_WIN,
+      })
+      child.stdout.on('data', () => { /* drain */ })
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        resolve({ ok: false, error: 'kiro --version timed out' })
+      }, 10_000)
+      child.on('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code === 0
+          ? { ok: true }
+          : { ok: false, error: `kiro --version exited with code ${code}` })
+      })
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        resolve({ ok: false, error: `kiro CLI not found: ${err.message}` })
+      })
+    })
+  }
+
+  private buildEnv(ctx: AdapterContext): Record<string, string> {
+    const shackleEnv: Record<string, string> = {
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+    }
+    const env = getSafeEnv(shackleEnv)
+    if (ctx.task) env.SHACKLEAI_TASK_ID = ctx.task
+    if (ctx.ancestry?.mission) env.SHACKLEAI_MISSION = ctx.ancestry.mission
+    if (ctx.ancestry?.project) env.SHACKLEAI_PROJECT = ctx.ancestry.project.name
+    if (ctx.ancestry?.goal) env.SHACKLEAI_GOAL = ctx.ancestry.goal.name
+    if (ctx.env.SHACKLEAI_API_KEY) env.SHACKLEAI_API_KEY = ctx.env.SHACKLEAI_API_KEY
+    if (ctx.sessionState) env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    return env
+  }
+
+  private clearActiveChild(child: ChildProcess): void {
+    if (this.activeChild === child) this.activeChild = null
+    if (this.abortKillTimer) { clearTimeout(this.abortKillTimer); this.abortKillTimer = null }
+  }
+}

--- a/packages/core/src/adapters/util.ts
+++ b/packages/core/src/adapters/util.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared utilities for CLI-based adapters.
+ *
+ * Extracted to avoid duplication across CLI adapters (Claude, Codex,
+ * Cursor, Gemini, Kiro, and future CLI-based adapters).
+ */
+
+import type { AdapterContext, AdapterResult } from './adapter.js'
+
+/**
+ * Try to extract a __shackleai_result__ JSON block from output text.
+ * Looks for `{"__shackleai_result__": ...}` anywhere in the output.
+ */
+export function parseShackleResult(
+  text: string,
+): { sessionState?: string; usage?: AdapterResult['usage'] } | null {
+  const marker = '__shackleai_result__'
+  const idx = text.indexOf(marker)
+  if (idx === -1) return null
+
+  const braceStart = text.lastIndexOf('{', idx)
+  if (braceStart === -1) return null
+
+  let depth = 0
+  for (let i = braceStart; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    else if (text[i] === '}') depth--
+    if (depth === 0) {
+      try {
+        const json = JSON.parse(text.slice(braceStart, i + 1)) as Record<string, unknown>
+        const result = json[marker] as Record<string, unknown> | undefined
+        if (!result) return null
+
+        const parsed: { sessionState?: string; usage?: AdapterResult['usage'] } = {}
+
+        if (typeof result.sessionState === 'string') {
+          parsed.sessionState = result.sessionState
+        }
+
+        if (result.usage && typeof result.usage === 'object') {
+          const u = result.usage as Record<string, unknown>
+          parsed.usage = {
+            inputTokens: (u.inputTokens as number) ?? 0,
+            outputTokens: (u.outputTokens as number) ?? 0,
+            costCents: (u.costCents as number) ?? 0,
+            model: (u.model as string) ?? 'unknown',
+            provider: (u.provider as string) ?? 'unknown',
+          }
+        }
+
+        return parsed
+      } catch {
+        return null
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Build the full prompt string by prepending system context and ancestry.
+ */
+export function buildFullPrompt(prompt: string, ctx: AdapterContext): string {
+  let fullPrompt = prompt
+
+  if (ctx.systemContext) {
+    fullPrompt = `${ctx.systemContext}\n\n${fullPrompt}`
+  }
+
+  if (ctx.ancestry) {
+    const parts: string[] = []
+    if (ctx.ancestry.mission) parts.push(`Mission: ${ctx.ancestry.mission}`)
+    if (ctx.ancestry.project) parts.push(`Project: ${ctx.ancestry.project.name}`)
+    if (ctx.ancestry.goal) parts.push(`Goal: ${ctx.ancestry.goal.name}`)
+    if (parts.length > 0) {
+      fullPrompt = `Context: ${parts.join(' | ')}\n\n${fullPrompt}`
+    }
+  }
+
+  return fullPrompt
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -39,6 +39,10 @@ export const AdapterType = {
   Mcp: 'mcp',
   OpenClaw: 'openclaw',
   CrewAI: 'crewai',
+  Codex: 'codex',
+  Cursor: 'cursor',
+  Gemini: 'gemini',
+  Kiro: 'kiro',
 } as const
 export type AdapterType = (typeof AdapterType)[keyof typeof AdapterType]
 


### PR DESCRIPTION
## Summary

- Adds 4 new CLI-based adapters (Codex, Cursor, Gemini, Kiro) to match Paperclip adapter coverage
- Extracts shared `parseShackleResult` and `buildFullPrompt` into `adapters/util.ts` to reduce duplication
- Registers all 4 in `AdapterRegistry` and adds types to `AdapterType` enum
- Updates adapter-registry test to verify all 10 built-in adapters

## Details

| Adapter | CLI Command | Prompt Flag | Special Flags |
|---------|-------------|-------------|---------------|
| CodexAdapter | `codex` | `--prompt` | `--quiet` |
| CursorAdapter | `cursor` | `--prompt` | `--cli` |
| GeminiAdapter | `gemini` | `--prompt` | -- |
| KiroAdapter | `kiro` | `--prompt` | -- |

All adapters follow the ClaudeAdapter pattern:
- `AdapterModule` interface implementation
- `gracefulKill` from `kill.ts` for `abort()`
- `activeChild` tracking for process management
- Timeout handling (default 300s, exit code 124 on timeout)
- `__shackleai_result__` JSON parsing for usage/session data
- Safe env var whitelisting via `getSafeEnv`
- `testEnvironment()` via `--version` check

## Files Changed

- `packages/core/src/adapters/codex.ts` — new
- `packages/core/src/adapters/cursor.ts` — new
- `packages/core/src/adapters/gemini.ts` — new
- `packages/core/src/adapters/kiro.ts` — new
- `packages/core/src/adapters/util.ts` — new (shared utilities)
- `packages/core/src/adapters/index.ts` — exports + registry
- `packages/shared/src/constants.ts` — AdapterType enum
- `packages/core/__tests__/adapter-registry.test.ts` — updated assertions

## Test plan

- [x] `pnpm --filter @shackleai/core build` passes
- [x] Adapter registry test passes (5/5 tests, including new adapter checks)
- [ ] Verify validators auto-accept new adapter types (derived from `Object.values(AdapterType)`)

Closes #155

Generated with [Claude Code](https://claude.com/claude-code)