### PR TITLE
feat: encrypted secrets management with API redaction

### DIFF
--- a/apps/cli/src/commands/secret.ts
+++ b/apps/cli/src/commands/secret.ts
@@ -1,0 +1,121 @@
+/**
+ * `shackleai secret` — Manage encrypted secrets
+ */
+
+import type { Command } from 'commander'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface SecretListItem {
+  id: string
+  name: string
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+interface SecretValue {
+  name: string
+  value: string
+}
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+async function secretSet(name: string, value: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient('/api/companies/' + companyId + '/secrets', {
+    method: 'POST',
+    body: JSON.stringify({ name, value }),
+  })
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error('Error: ' + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<SecretListItem>
+  console.log("Secret '" + body.data.name + "' stored successfully.")
+}
+
+async function secretList(): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient('/api/companies/' + companyId + '/secrets')
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error('Error: ' + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<SecretListItem[]>
+
+  if (body.data.length === 0) {
+    console.log('No secrets found.')
+    return
+  }
+
+  console.log('Secrets:')
+  for (const secret of body.data) {
+    const by = secret.created_by ? ' (by ' + secret.created_by + ')' : ''
+    console.log('  ' + secret.name + by + '  — updated ' + secret.updated_at)
+  }
+}
+
+async function secretGet(name: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient('/api/companies/' + companyId + '/secrets/' + encodeURIComponent(name))
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error('Error: ' + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<SecretValue>
+  console.log(body.data.value)
+}
+
+async function secretDelete(name: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(
+    '/api/companies/' + companyId + '/secrets/' + encodeURIComponent(name),
+    { method: 'DELETE' },
+  )
+
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error('Error: ' + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  console.log("Secret '" + name + "' deleted.")
+}
+
+export function registerSecretCommand(program: Command): void {
+  const secretCmd = program
+    .command('secret')
+    .description('Manage encrypted secrets')
+
+  secretCmd
+    .command('set <name> <value>')
+    .description('Store an encrypted secret')
+    .action(secretSet)
+
+  secretCmd
+    .command('list')
+    .description('List secret names (values hidden)')
+    .action(secretList)
+
+  secretCmd
+    .command('get <name>')
+    .description('Decrypt and display a secret value')
+    .action(secretGet)
+
+  secretCmd
+    .command('delete <name>')
+    .description('Delete a secret')
+    .action(secretDelete)
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerCompanyCommand } from './commands/company.js'
 import { registerCommentCommand } from './commands/comment.js'
 import { registerConfigCommand } from './commands/config-cmd.js'
 import { registerApprovalCommand } from './commands/approval.js'
+import { registerSecretCommand } from './commands/secret.js'
 
 export const VERSION = '0.1.0'
 
@@ -59,6 +60,7 @@ registerCompanyCommand(program)
 registerCommentCommand(program)
 registerConfigCommand(program)
 registerApprovalCommand(program)
+registerSecretCommand(program)
 
 // Only parse when run as CLI entrypoint — not when imported for VERSION etc.
 const isDirectRun =

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -23,25 +23,26 @@ import { worktreesRouter } from './routes/worktrees.js'
 import { toolCallsRouter } from './routes/tool-calls.js'
 import { commentsRouter } from './routes/comments.js'
 import { approvalsRouter } from './routes/approvals.js'
+import { secretsRouter } from './routes/secrets.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
 
 export interface CreateAppOptions {
   scheduler?: Scheduler
-  /** Skip API authentication — for testing only. NEVER set in production. */
+  /** Skip API authentication ï¿½ for testing only. NEVER set in production. */
   skipAuth?: boolean
 }
 
 export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hono {
   const app = new Hono()
 
-  // --- Health check — unauthenticated ---
+  // --- Health check ï¿½ unauthenticated ---
   app.get('/api/health', (c) => {
     return c.json({ status: 'ok', version: VERSION })
   })
 
-  // --- Global API authentication — protects all /api/* routes except /api/health ---
+  // --- Global API authentication ï¿½ protects all /api/* routes except /api/health ---
   if (!options?.skipAuth) {
     const apiAuthMiddleware = createApiAuth(db)
     app.use('/api/*', async (c, next) => {
@@ -66,6 +67,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', toolCallsRouter(db))
   app.route('/api/companies', commentsRouter(db, options?.scheduler))
   app.route('/api/companies', approvalsRouter(db))
+  app.route('/api/companies', secretsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/secrets.ts
+++ b/apps/cli/src/server/routes/secrets.ts
@@ -1,0 +1,88 @@
+/**
+ * Secrets CRUD routes — /api/companies/:id/secrets
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import { CreateSecretInput } from '@shackleai/shared'
+import { SecretsManager } from '@shackleai/core'
+import type { SecretListItem } from '@shackleai/core'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function secretsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+  const secrets = new SecretsManager(db)
+
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/secrets — list secrets (names only, values redacted)
+  app.get('/:id/secrets', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const items: SecretListItem[] = await secrets.list(companyId)
+    return c.json({ data: items })
+  })
+
+  // POST /api/companies/:id/secrets — store a secret (encrypt before saving)
+  app.post('/:id/secrets', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateSecretInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { name, value, created_by } = parsed.data
+    const row = await secrets.store(companyId, name, value, created_by)
+
+    return c.json({
+      data: {
+        id: row.id,
+        name: row.name,
+        created_by: row.created_by,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      },
+    }, 201)
+  })
+
+  // GET /api/companies/:id/secrets/:name — get decrypted value
+  app.get('/:id/secrets/:name', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const name = c.req.param('name')!
+
+    const value = await secrets.get(companyId, name)
+    if (value === null) {
+      return c.json({ error: 'Secret not found: ' + name }, 404)
+    }
+
+    return c.json({ data: { name, value } })
+  })
+
+  // DELETE /api/companies/:id/secrets/:name — delete a secret
+  app.delete('/:id/secrets/:name', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const name = c.req.param('name')!
+
+    const deleted = await secrets.delete(companyId, name)
+    if (!deleted) {
+      return c.json({ error: 'Secret not found: ' + name }, 404)
+    }
+
+    return c.json({ data: { deleted: true } })
+  })
+
+  return app
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,3 +50,6 @@ export type { LicenseStatus, ActivationResult } from './license.js'
 export { WorktreeManager } from './worktree/index.js'
 
 export { DelegationService, DelegationError, rollUpParentStatus } from './delegation.js'
+
+export { SecretsManager, LogRedactor } from './secrets/index.js'
+export type { SecretRow, SecretListItem } from './secrets/index.js'

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -38,6 +38,8 @@ import type { AdapterContext, AdapterModule, AdapterResult, GoalAncestry } from 
 import { getLastSessionState, saveSessionState } from '../adapters/index.js'
 import type { RunnerResult } from '../scheduler.js'
 import type { GovernanceEngine } from '../governance/index.js'
+import { SecretsManager } from '../secrets/index.js'
+import { LogRedactor } from '../secrets/index.js'
 
 /** Default timeout in seconds. */
 const DEFAULT_TIMEOUT_S = 300
@@ -83,6 +85,8 @@ export class HeartbeatExecutor {
   private adapterRegistry: AdapterRegistry
   private contextBuilder: ContextBuilder
   private governance: GovernanceEngine | null
+  private secretsManager: SecretsManager
+  private logRedactor: LogRedactor
 
   constructor(
     db: DatabaseProvider,
@@ -97,6 +101,8 @@ export class HeartbeatExecutor {
     this.adapterRegistry = adapterRegistry
     this.contextBuilder = new ContextBuilder(db)
     this.governance = governance ?? null
+    this.secretsManager = new SecretsManager(db)
+    this.logRedactor = new LogRedactor()
   }
 
   /**
@@ -222,13 +228,23 @@ export class HeartbeatExecutor {
           this.contextBuilder.build(agentId, companyId),
         ])
 
+      // -- Step 5b: Load secrets as env vars --
+      let secretEnv: Record<string, string> = {}
+      try {
+        secretEnv = await this.secretsManager.getAllDecrypted(companyId)
+        const secretValues = Object.values(secretEnv)
+        this.logRedactor.addSecrets(secretValues)
+      } catch {
+        // Non-fatal -- continue without secrets
+      }
+
       const ctx: AdapterContext = {
         agentId,
         companyId,
         task: task?.title ?? undefined,
         heartbeatRunId: runId,
         adapterConfig,
-        env: {},
+        env: { ...secretEnv },
         sessionState,
         recentActivity,
         assignedTasks,
@@ -273,6 +289,14 @@ export class HeartbeatExecutor {
         } else {
           throw err
         }
+      }
+
+      // -- Step 6b: Redact secrets from adapter output --
+      if (adapterResult.stdout) {
+        adapterResult = { ...adapterResult, stdout: this.logRedactor.redact(adapterResult.stdout) }
+      }
+      if (adapterResult.stderr) {
+        adapterResult = { ...adapterResult, stderr: this.logRedactor.redact(adapterResult.stderr) }
       }
 
       // ── Step 7: Log event to Observatory ────────────────────────────

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -1,0 +1,3 @@
+export { SecretsManager } from './manager.js'
+export type { SecretRow, SecretListItem } from './manager.js'
+export { LogRedactor } from './redactor.js'

--- a/packages/core/src/secrets/manager.ts
+++ b/packages/core/src/secrets/manager.ts
@@ -1,0 +1,186 @@
+/**
+ * SecretsManager — AES-256-GCM encrypted secret storage.
+ *
+ * Derives an encryption key from a master secret (env var SHACKLEAI_SECRET_KEY
+ * or auto-generated file at ~/.shackleai/orchestrator/.secret-key).
+ *
+ * Encrypted format: iv:authTag:ciphertext (all hex-encoded).
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv, scryptSync } from 'node:crypto'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import type { DatabaseProvider } from '@shackleai/db'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 16
+const AUTH_TAG_LENGTH = 16
+const KEY_LENGTH = 32
+const SALT = 'shackleai-secrets-v1'
+
+/** Path to auto-generated secret key file. */
+function secretKeyPath(): string {
+  return join(homedir(), '.shackleai', 'orchestrator', '.secret-key')
+}
+
+/** Load or generate the master secret key. */
+function loadMasterSecret(): string {
+  const envKey = process.env.SHACKLEAI_SECRET_KEY
+  if (envKey && envKey.length > 0) {
+    return envKey
+  }
+
+  const keyPath = secretKeyPath()
+  if (existsSync(keyPath)) {
+    return readFileSync(keyPath, 'utf-8').trim()
+  }
+
+  const generated = randomBytes(32).toString('hex')
+  const dir = join(homedir(), '.shackleai', 'orchestrator')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(keyPath, generated, { mode: 0o600 })
+  return generated
+}
+
+/** Derive a 256-bit key from the master secret using scrypt. */
+function deriveKey(masterSecret: string): Buffer {
+  return scryptSync(masterSecret, SALT, KEY_LENGTH)
+}
+
+export interface SecretRow {
+  id: string
+  company_id: string
+  name: string
+  encrypted_value: string
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface SecretListItem {
+  id: string
+  name: string
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export class SecretsManager {
+  private db: DatabaseProvider
+  private key: Buffer
+
+  constructor(db: DatabaseProvider, masterSecret?: string) {
+    this.db = db
+    const secret = masterSecret ?? loadMasterSecret()
+    this.key = deriveKey(secret)
+  }
+
+  /** Encrypt a plaintext value. Returns iv:authTag:ciphertext (hex). */
+  encrypt(plaintext: string): string {
+    const iv = randomBytes(IV_LENGTH)
+    const cipher = createCipheriv(ALGORITHM, this.key, iv, { authTagLength: AUTH_TAG_LENGTH })
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+    const authTag = cipher.getAuthTag()
+    return iv.toString('hex') + ':' + authTag.toString('hex') + ':' + encrypted.toString('hex')
+  }
+
+  /** Decrypt a value in iv:authTag:ciphertext format. */
+  decrypt(ciphertext: string): string {
+    const parts = ciphertext.split(':')
+    if (parts.length !== 3) {
+      throw new Error('Invalid encrypted value format')
+    }
+
+    const iv = Buffer.from(parts[0], 'hex')
+    const authTag = Buffer.from(parts[1], 'hex')
+    const encrypted = Buffer.from(parts[2], 'hex')
+
+    const decipher = createDecipheriv(ALGORITHM, this.key, iv, { authTagLength: AUTH_TAG_LENGTH })
+    decipher.setAuthTag(authTag)
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()])
+    return decrypted.toString('utf8')
+  }
+
+  /** Store an encrypted secret. Upserts on (company_id, name). */
+  async store(
+    companyId: string,
+    name: string,
+    value: string,
+    createdBy?: string,
+  ): Promise<SecretRow> {
+    const encryptedValue = this.encrypt(value)
+
+    const sql = [
+      'INSERT INTO secrets (company_id, name, encrypted_value, created_by)',
+      'VALUES ($1, $2, $3, $4)',
+      'ON CONFLICT (company_id, name)',
+      'DO UPDATE SET encrypted_value = $3, updated_at = NOW()',
+      'RETURNING *',
+    ].join(' ')
+
+    const result = await this.db.query<SecretRow>(sql, [
+      companyId,
+      name,
+      encryptedValue,
+      createdBy ?? null,
+    ])
+
+    return result.rows[0]
+  }
+
+  /** Get a decrypted secret by name. Returns null if not found. */
+  async get(companyId: string, name: string): Promise<string | null> {
+    const result = await this.db.query<SecretRow>(
+      'SELECT * FROM secrets WHERE company_id = $1 AND name = $2',
+      [companyId, name],
+    )
+
+    if (result.rows.length === 0) {
+      return null
+    }
+
+    return this.decrypt(result.rows[0].encrypted_value)
+  }
+
+  /** List secrets for a company (names only). */
+  async list(companyId: string): Promise<SecretListItem[]> {
+    const sql = [
+      'SELECT id, name, created_by, created_at, updated_at',
+      'FROM secrets WHERE company_id = $1 ORDER BY name',
+    ].join(' ')
+
+    const result = await this.db.query<SecretListItem>(sql, [companyId])
+
+    return result.rows
+  }
+
+  /** Delete a secret by name. Returns true if deleted, false if not found. */
+  async delete(companyId: string, name: string): Promise<boolean> {
+    const result = await this.db.query<{ id: string }>(
+      'DELETE FROM secrets WHERE company_id = $1 AND name = $2 RETURNING id',
+      [companyId, name],
+    )
+
+    return result.rows.length > 0
+  }
+
+  /** Get all secret names and their decrypted values for a company (env injection). */
+  async getAllDecrypted(companyId: string): Promise<Record<string, string>> {
+    const result = await this.db.query<SecretRow>(
+      'SELECT name, encrypted_value FROM secrets WHERE company_id = $1',
+      [companyId],
+    )
+
+    const secrets: Record<string, string> = {}
+    for (const row of result.rows) {
+      try {
+        secrets[row.name] = this.decrypt(row.encrypted_value)
+      } catch {
+        // Skip secrets that fail to decrypt (e.g., key rotation)
+      }
+    }
+
+    return secrets
+  }
+}

--- a/packages/core/src/secrets/redactor.ts
+++ b/packages/core/src/secrets/redactor.ts
@@ -1,0 +1,38 @@
+/**
+ * LogRedactor — scans strings for known secret values and replaces them with [REDACTED].
+ *
+ * Used to sanitize adapter stdout/stderr before storage/display.
+ */
+
+export class LogRedactor {
+  private secrets: Set<string> = new Set()
+
+  /** Register secret values that should be redacted from output. */
+  addSecrets(values: string[]): void {
+    for (const v of values) {
+      // Only redact non-trivial values (>= 4 chars) to avoid false positives
+      if (v.length >= 4) {
+        this.secrets.add(v)
+      }
+    }
+  }
+
+  /** Clear all registered secrets. */
+  clear(): void {
+    this.secrets.clear()
+  }
+
+  /** Redact all known secret values from the given text. */
+  redact(text: string): string {
+    if (this.secrets.size === 0) return text
+
+    let result = text
+    for (const secret of this.secrets) {
+      while (result.includes(secret)) {
+        result = result.split(secret).join('[REDACTED]')
+      }
+    }
+
+    return result
+  }
+}

--- a/packages/db/src/migrations/017_secrets.ts
+++ b/packages/db/src/migrations/017_secrets.ts
@@ -1,0 +1,14 @@
+export const name = '017_secrets'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS secrets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id),
+  name TEXT NOT NULL,
+  encrypted_value TEXT NOT NULL,
+  created_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(company_id, name)
+);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -15,6 +15,7 @@ import * as m013 from './013_agent_worktrees.js'
 import * as m014 from './014_tool_calls.js'
 import * as m015 from './015_indexes.js'
 import * as m016 from './016_approvals.js'
+import * as m017 from './017_secrets.js'
 
 export interface Migration {
   name: string
@@ -38,6 +39,7 @@ const migrations: Migration[] = [
   m014,
   m015,
   m016,
+  m017,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -242,3 +242,13 @@ export interface Approval {
   decided_at: string | null
   created_at: string
 }
+
+export interface Secret {
+  id: string
+  company_id: string
+  name: string
+  encrypted_value: string
+  created_by: string | null
+  created_at: Date
+  updated_at: Date
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -336,3 +336,17 @@ export const WorktreeCleanupInput = z.object({
 })
 export type WorktreeCleanupInput = z.infer<typeof WorktreeCleanupInput>
 
+
+// ---------------------------------------------------------------------------
+// Secret
+// ---------------------------------------------------------------------------
+
+export const CreateSecretInput = z.object({
+  name: nonEmpty.regex(
+    /^[A-Za-z_][A-Za-z0-9_]*$/,
+    'Secret name must be a valid env-var style identifier (letters, digits, underscores)',
+  ),
+  value: nonEmpty,
+  created_by: z.string().optional(),
+})
+export type CreateSecretInput = z.infer<typeof CreateSecretInput>


### PR DESCRIPTION
## Summary
- **SecretsManager**: AES-256-GCM encryption with scrypt key derivation from `SHACKLEAI_SECRET_KEY` env var or auto-generated `~/.shackleai/orchestrator/.secret-key`
- **LogRedactor**: Scans adapter stdout/stderr for known secret values, replaces with `[REDACTED]`
- **API routes**: Full CRUD at `/api/companies/:id/secrets` (list returns names only, GET decrypts)
- **CLI commands**: `shackleai secret set/list/get/delete`
- **Env injection**: Decrypted secrets injected as env vars into adapter execution context
- **Migration**: `017_secrets.sql` with `UNIQUE(company_id, name)` constraint

## Test plan
- [ ] Verify `encrypt()` and `decrypt()` round-trip correctly
- [ ] Verify upsert behavior on duplicate secret names
- [ ] Test API routes (create, list, get, delete) with auth
- [ ] Verify LogRedactor replaces secrets in sample output
- [ ] Verify secrets are injected into adapter env during heartbeat
- [ ] Verify `SHACKLEAI_SECRET_KEY` env var takes precedence over file

Closes #121

Generated with [Claude Code](https://claude.com/claude-code)