### PR TITLE
feat: add granular heartbeat run events logging

### DIFF
--- a/apps/cli/__tests__/heartbeats.test.ts
+++ b/apps/cli/__tests__/heartbeats.test.ts
@@ -145,3 +145,92 @@ describe('heartbeats routes', () => {
     expect(res.status).toBe(404)
   })
 })
+
+describe('heartbeat run events routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+  let agentId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db, { skipAuth: true })
+    companyId = await createCompany(app, 'Events Corp')
+    agentId = await createAgent(app, companyId)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId/events returns empty array when no events', async () => {
+    const runId = await insertHeartbeatRun(db, companyId, agentId)
+
+    const res = await app.request(
+      `/api/companies/${companyId}/heartbeats/${runId}/events`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId/events returns events in chronological order', async () => {
+    const runId = await insertHeartbeatRun(db, companyId, agentId)
+
+    // Insert events directly
+    await db.query(
+      `INSERT INTO heartbeat_run_events (heartbeat_run_id, event_type, payload)
+       VALUES ($1, $2, $3)`,
+      [runId, 'adapter_loaded', JSON.stringify({ adapterType: 'process' })],
+    )
+    await db.query(
+      `INSERT INTO heartbeat_run_events (heartbeat_run_id, event_type, payload)
+       VALUES ($1, $2, $3)`,
+      [runId, 'budget_checked', JSON.stringify({ withinBudget: true })],
+    )
+    await db.query(
+      `INSERT INTO heartbeat_run_events (heartbeat_run_id, event_type)
+       VALUES ($1, $2)`,
+      [runId, 'adapter_started'],
+    )
+
+    const res = await app.request(
+      `/api/companies/${companyId}/heartbeats/${runId}/events`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: Array<{
+        id: string
+        heartbeat_run_id: string
+        event_type: string
+        payload: Record<string, unknown> | null
+        created_at: string
+      }>
+    }
+    expect(body.data).toHaveLength(3)
+    expect(body.data[0].event_type).toBe('adapter_loaded')
+    expect(body.data[0].heartbeat_run_id).toBe(runId)
+    expect(body.data[0].payload).toEqual({ adapterType: 'process' })
+    expect(body.data[1].event_type).toBe('budget_checked')
+    expect(body.data[2].event_type).toBe('adapter_started')
+    expect(body.data[2].payload).toBeNull()
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId/events returns 404 for non-existent run', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/heartbeats/00000000-0000-0000-0000-000000000000/events`,
+    )
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Heartbeat run not found')
+  })
+
+  it('GET /api/companies/:id/heartbeats/:runId/events returns 404 for non-existent company', async () => {
+    const res = await app.request(
+      `/api/companies/00000000-0000-0000-0000-000000000000/heartbeats/00000000-0000-0000-0000-000000000001/events`,
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/cli/src/server/routes/heartbeats.ts
+++ b/apps/cli/src/server/routes/heartbeats.ts
@@ -4,7 +4,7 @@
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
-import type { HeartbeatRun } from '@shackleai/shared'
+import type { HeartbeatRun, HeartbeatRunEvent } from '@shackleai/shared'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
 import { parsePagination } from '../pagination.js'
@@ -58,6 +58,33 @@ export function heartbeatsRouter(db: DatabaseProvider): Hono<{ Variables: Variab
     }
 
     return c.json({ data: result.rows[0] })
+  })
+
+
+  // GET /api/companies/:id/heartbeats/:runId/events - granular events for a heartbeat run
+  app.get('/:id/heartbeats/:runId/events', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const runId = c.req.param('runId')
+
+    // Verify the heartbeat run exists and belongs to this company
+    const runResult = await db.query<HeartbeatRun>(
+      `SELECT id FROM heartbeat_runs WHERE id = $1 AND company_id = $2`,
+      [runId, companyId],
+    )
+
+    if (runResult.rows.length === 0) {
+      return c.json({ error: 'Heartbeat run not found' }, 404)
+    }
+
+    const result = await db.query<HeartbeatRunEvent>(
+      `SELECT id, heartbeat_run_id, event_type, payload, created_at
+       FROM heartbeat_run_events
+       WHERE heartbeat_run_id = $1
+       ORDER BY created_at ASC`,
+      [runId],
+    )
+
+    return c.json({ data: result.rows })
   })
 
   return app

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export { Scheduler } from './scheduler.js'
 export type { RunnerExecutor, RunnerResult } from './scheduler.js'
 
 export { HeartbeatExecutor } from './runner/index.js'
+export { HeartbeatEventLogger, insertHeartbeatRunEvent, getHeartbeatRunEvents } from './runner/index.js'
 
 export { LicenseManager } from './license.js'
 export type { LicenseStatus, ActivationResult } from './license.js'

--- a/packages/core/src/runner/event-logger.ts
+++ b/packages/core/src/runner/event-logger.ts
@@ -1,0 +1,70 @@
+/**
+ * HeartbeatEventLogger — records granular events within a heartbeat run.
+ *
+ * Best-effort: errors are caught and logged to console, never thrown.
+ * This ensures event logging never fails the heartbeat pipeline.
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+import type { HeartbeatRunEventType, HeartbeatRunEvent } from '@shackleai/shared'
+
+export class HeartbeatEventLogger {
+  private db: DatabaseProvider
+  private runId: string
+
+  constructor(db: DatabaseProvider, runId: string) {
+    this.db = db
+    this.runId = runId
+  }
+
+  /**
+   * Record a granular event for this heartbeat run. Fire-and-forget.
+   */
+  emit(eventType: HeartbeatRunEventType, payload?: Record<string, unknown>): void {
+    this.insertEvent(eventType, payload).catch((err: unknown) => {
+      console.error(`[HeartbeatEventLogger] Failed to log ${eventType}:`, err)
+    })
+  }
+
+  private async insertEvent(
+    eventType: HeartbeatRunEventType,
+    payload?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.db.query(
+      `INSERT INTO heartbeat_run_events (heartbeat_run_id, event_type, payload)
+       VALUES ($1, $2, $3)`,
+      [this.runId, eventType, payload ? JSON.stringify(payload) : null],
+    )
+  }
+}
+
+/**
+ * Insert a heartbeat run event (for direct use outside the executor).
+ */
+export async function insertHeartbeatRunEvent(
+  db: DatabaseProvider,
+  event: { heartbeat_run_id: string; event_type: HeartbeatRunEventType; payload?: Record<string, unknown> },
+): Promise<void> {
+  await db.query(
+    `INSERT INTO heartbeat_run_events (heartbeat_run_id, event_type, payload)
+     VALUES ($1, $2, $3)`,
+    [event.heartbeat_run_id, event.event_type, event.payload ? JSON.stringify(event.payload) : null],
+  )
+}
+
+/**
+ * Retrieve all events for a heartbeat run, ordered by creation time.
+ */
+export async function getHeartbeatRunEvents(
+  db: DatabaseProvider,
+  runId: string,
+): Promise<HeartbeatRunEvent[]> {
+  const result = await db.query<HeartbeatRunEvent>(
+    `SELECT id, heartbeat_run_id, event_type, payload, created_at
+     FROM heartbeat_run_events
+     WHERE heartbeat_run_id = $1
+     ORDER BY created_at ASC`,
+    [runId],
+  )
+  return result.rows
+}

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -40,6 +40,7 @@ import type { RunnerResult } from '../scheduler.js'
 import type { GovernanceEngine } from '../governance/index.js'
 import { SecretsManager } from '../secrets/index.js'
 import { LogRedactor } from '../secrets/index.js'
+import { HeartbeatEventLogger } from './event-logger.js'
 
 /** Default timeout in seconds. */
 const DEFAULT_TIMEOUT_S = 300
@@ -111,6 +112,7 @@ export class HeartbeatExecutor {
    */
   async execute(agentId: string, trigger: TriggerType): Promise<RunnerResult> {
     const runId = randomUUID()
+    const events = new HeartbeatEventLogger(this.db, runId)
 
     // ── Step 0: Load agent ──────────────────────────────────────────
     const agentResult = await this.db.query<AgentRow>(
@@ -153,6 +155,12 @@ export class HeartbeatExecutor {
     try {
       // ── Step 3: Budget check ────────────────────────────────────────
       const budget = await this.costTracker.checkBudget(companyId, agentId)
+
+      events.emit('budget_checked', {
+        withinBudget: budget.withinBudget,
+        percentUsed: budget.percentUsed,
+      })
+
       if (!budget.withinBudget) {
         const errMsg = `Budget exceeded (${budget.percentUsed.toFixed(1)}% used)`
         await this.markRunFailed(runId, errMsg)
@@ -168,6 +176,8 @@ export class HeartbeatExecutor {
           changes: { trigger, percentUsed: budget.percentUsed },
         })
 
+        events.emit('error', { message: errMsg })
+
         return { exitCode: 1, stderr: errMsg }
       }
 
@@ -177,8 +187,12 @@ export class HeartbeatExecutor {
         const errMsg = `Unknown adapter type: ${agent.adapter_type}`
         await this.markRunFailed(runId, errMsg)
         await this.markAgentIdle(agentId)
+        events.emit('error', { message: errMsg })
         return { exitCode: 1, stderr: errMsg }
       }
+
+
+      events.emit('adapter_loaded', { adapterType: agent.adapter_type })
 
       // Step 4b: Governance check
       if (this.governance) {
@@ -187,6 +201,13 @@ export class HeartbeatExecutor {
           agentId,
           agent.adapter_type,
         )
+
+
+        events.emit('governance_checked', {
+          allowed: policyResult.allowed,
+          policyId: policyResult.policyId ?? null,
+          reason: policyResult.reason ?? null,
+        })
 
         if (!policyResult.allowed) {
           const errMsg = `Governance violation: ${policyResult.reason}`
@@ -207,6 +228,8 @@ export class HeartbeatExecutor {
               reason: policyResult.reason,
             },
           })
+
+          events.emit('error', { message: errMsg })
 
           return { exitCode: 1, stderr: errMsg }
         }
@@ -255,6 +278,13 @@ export class HeartbeatExecutor {
         systemContext,
       }
 
+      events.emit('context_built', {
+        hasTask: !!task,
+        hasSessionState: !!sessionState,
+        recentActivityCount: recentActivity.length,
+        unreadCommentsCount: unreadComments.length,
+      })
+
       // Mark run as running
       await this.db.query(
         `UPDATE heartbeat_runs SET status = $1, started_at = NOW(), session_id_before = $2
@@ -268,6 +298,8 @@ export class HeartbeatExecutor {
           ? adapterConfig.timeout
           : DEFAULT_TIMEOUT_S
       const timeoutMs = timeoutS * 1000
+
+      events.emit('adapter_started', { adapterType: agent.adapter_type, timeoutS })
 
       let adapterResult: AdapterResult
       let timedOut = false
@@ -298,6 +330,12 @@ export class HeartbeatExecutor {
       if (adapterResult.stderr) {
         adapterResult = { ...adapterResult, stderr: this.logRedactor.redact(adapterResult.stderr) }
       }
+
+      events.emit('adapter_finished', {
+        exitCode: adapterResult.exitCode,
+        timedOut,
+        adapterType: agent.adapter_type,
+      })
 
       // ── Step 7: Log event to Observatory ────────────────────────────
       const finalStatus = timedOut
@@ -334,9 +372,23 @@ export class HeartbeatExecutor {
         })
       }
 
+
+      if (adapterResult.usage) {
+        events.emit('cost_recorded', {
+          provider: adapterResult.usage.provider,
+          model: adapterResult.usage.model,
+          costCents: adapterResult.usage.costCents,
+        })
+      }
+
       // ── Step 9: Save session state ──────────────────────────────────
       if (adapterResult.sessionState) {
         await saveSessionState(runId, adapterResult.sessionState, this.db)
+      }
+
+
+      if (adapterResult.sessionState) {
+        events.emit('session_saved', { sessionState: adapterResult.sessionState })
       }
 
       // ── Step 9b: Record tool calls ─────────────────────────────────
@@ -423,6 +475,8 @@ export class HeartbeatExecutor {
         action: 'heartbeat_error',
         changes: { trigger, error: errMsg },
       })
+
+      events.emit('error', { message: errMsg })
 
       await this.markRunFailed(runId, errMsg)
       await this.markAgentIdle(agentId)

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -3,3 +3,8 @@
  */
 
 export { HeartbeatExecutor } from './executor.js'
+export {
+  HeartbeatEventLogger,
+  insertHeartbeatRunEvent,
+  getHeartbeatRunEvents,
+} from './event-logger.js'

--- a/packages/db/src/migrations/019_heartbeat_run_events.ts
+++ b/packages/db/src/migrations/019_heartbeat_run_events.ts
@@ -1,0 +1,11 @@
+export const name = '019_heartbeat_run_events'
+export const sql = `
+  CREATE TABLE IF NOT EXISTS heartbeat_run_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    heartbeat_run_id UUID NOT NULL REFERENCES heartbeat_runs(id),
+    event_type TEXT NOT NULL,
+    payload JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS idx_hb_events_run ON heartbeat_run_events(heartbeat_run_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -17,6 +17,7 @@ import * as m015 from './015_indexes.js'
 import * as m016 from './016_approvals.js'
 import * as m017 from './017_secrets.js'
 import * as m018 from './018_agent_config_revisions.js'
+import * as m019 from './019_heartbeat_run_events.js'
 
 export interface Migration {
   name: string
@@ -42,6 +43,7 @@ const migrations: Migration[] = [
   m016,
   m017,
   m018,
+  m019,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -262,3 +262,22 @@ export interface AgentConfigRevision {
   change_reason: string | null
   created_at: string
 }
+
+export type HeartbeatRunEventType =
+  | 'adapter_loaded'
+  | 'governance_checked'
+  | 'budget_checked'
+  | 'context_built'
+  | 'adapter_started'
+  | 'adapter_finished'
+  | 'cost_recorded'
+  | 'session_saved'
+  | 'error'
+
+export interface HeartbeatRunEvent {
+  id: string
+  heartbeat_run_id: string
+  event_type: HeartbeatRunEventType
+  payload: Record<string, unknown> | null
+  created_at: string
+}


### PR DESCRIPTION
## Summary

- Adds `heartbeat_run_events` table (migration 018) to store granular pipeline events within each heartbeat run
- Introduces `HeartbeatEventLogger` class that emits fire-and-forget events at each executor step: `adapter_loaded`, `governance_checked`, `budget_checked`, `context_built`, `adapter_started`, `adapter_finished`, `cost_recorded`, `session_saved`, `error`
- Adds `GET /api/companies/:id/heartbeats/:runId/events` API endpoint to retrieve events for a run

## Test plan

- [x] New heartbeat events API tests (4 tests, all passing)
- [x] Existing heartbeat route tests still pass
- [x] Build passes (`pnpm build` -- 5/5 tasks successful)
- [x] Pre-existing test failures confirmed unrelated (budget enforcement, process adapter on Windows)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)