### PR TITLE
feat: add time-windowed quota enforcement

### DIFF
--- a/apps/cli/src/commands/quota.ts
+++ b/apps/cli/src/commands/quota.ts
@@ -1,0 +1,148 @@
+/**
+ * `shackleai quota` -- Manage time-windowed provider quotas
+ */
+
+import type { Command } from 'commander'
+import * as p from '@clack/prompts'
+import type { QuotaWindow, QuotaStatus } from '@shackleai/shared'
+import { apiClient, getCompanyId } from '../api-client.js'
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+function formatQuotaTable(quotas: QuotaWindow[]): void {
+  if (quotas.length === 0) {
+    console.log('No quota windows configured.')
+    return
+  }
+  const rows = quotas.map((q) => ({
+    ID: q.id.slice(0, 8),
+    Agent: q.agent_id?.slice(0, 8) ?? '(all)',
+    Provider: q.provider ?? '(all)',
+    Window: q.window_duration,
+    'Max Requests': q.max_requests ?? '-',
+    'Max Tokens': q.max_tokens ?? '-',
+    Created: new Date(q.created_at).toLocaleString(),
+  }))
+  console.table(rows)
+}
+
+async function listQuotas(): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/quotas`)
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+  const body = (await res.json()) as ApiResponse<QuotaWindow[]>
+  formatQuotaTable(body.data)
+}
+
+async function createQuotaInteractive(): Promise<void> {
+  p.intro('Create a quota window')
+
+  const provider = await p.text({
+    message: 'Provider (leave empty for all providers)',
+    placeholder: 'anthropic',
+  })
+  if (p.isCancel(provider)) { p.cancel('Cancelled.'); return }
+
+  const windowDuration = await p.select({
+    message: 'Window duration',
+    options: [
+      { value: '1m', label: '1 minute' },
+      { value: '5m', label: '5 minutes' },
+      { value: '15m', label: '15 minutes' },
+      { value: '1h', label: '1 hour' },
+      { value: '6h', label: '6 hours' },
+      { value: '1d', label: '1 day' },
+    ],
+  })
+  if (p.isCancel(windowDuration)) { p.cancel('Cancelled.'); return }
+
+  const maxRequests = await p.text({
+    message: 'Max requests (leave empty for no limit)',
+    placeholder: '100',
+  })
+  if (p.isCancel(maxRequests)) { p.cancel('Cancelled.'); return }
+
+  const maxTokens = await p.text({
+    message: 'Max tokens (leave empty for no limit)',
+    placeholder: '1000000',
+  })
+  if (p.isCancel(maxTokens)) { p.cancel('Cancelled.'); return }
+
+  const parsedRequests = maxRequests?.trim() ? parseInt(maxRequests.trim(), 10) : undefined
+  const parsedTokens = maxTokens?.trim() ? parseInt(maxTokens.trim(), 10) : undefined
+
+  if (parsedRequests === undefined && parsedTokens === undefined) {
+    p.cancel('At least one of max requests or max tokens must be set.')
+    return
+  }
+
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/quotas`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      provider: provider?.trim() || null,
+      window_duration: windowDuration,
+      max_requests: parsedRequests ?? null,
+      max_tokens: parsedTokens ?? null,
+    }),
+  })
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+  const body = (await res.json()) as ApiResponse<QuotaWindow>
+  p.outro(`Quota window created: ${body.data.id.slice(0, 8)}`)
+}
+
+async function deleteQuota(quotaId: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/quotas/${quotaId}`, { method: 'DELETE' })
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+  console.log(`Quota window ${quotaId} deleted.`)
+}
+
+async function showStatus(agentId: string): Promise<void> {
+  const companyId = await getCompanyId()
+  const res = await apiClient(`/api/companies/${companyId}/agents/${agentId}/quota-status`)
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
+    process.exit(1)
+  }
+  const body = (await res.json()) as ApiResponse<QuotaStatus[]>
+  if (body.data.length === 0) {
+    console.log('No quota windows apply to this agent.')
+    return
+  }
+  const rows = body.data.map((s) => ({
+    'Quota ID': s.quota.id.slice(0, 8),
+    Provider: s.quota.provider ?? '(all)',
+    Window: s.quota.window_duration,
+    Requests: `${s.current_requests}/${s.quota.max_requests ?? '-'}`,
+    Tokens: `${s.current_tokens}/${s.quota.max_tokens ?? '-'}`,
+    Exceeded: s.exceeded ? 'YES' : 'no',
+  }))
+  console.table(rows)
+}
+
+export function registerQuotaCommand(program: Command): void {
+  const cmd = program.command('quota').description('Manage time-windowed provider quotas')
+
+  cmd.command('list').description('List quota windows').action(async () => { await listQuotas() })
+  cmd.command('create').description('Create a quota window (interactive)').action(async () => { await createQuotaInteractive() })
+  cmd.command('delete <id>').description('Delete a quota window').action(async (id: string) => { await deleteQuota(id) })
+  cmd.command('status <agentId>').description('Show quota usage for an agent').action(async (agentId: string) => { await showStatus(agentId) })
+}

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -20,6 +20,7 @@ import {
   OpenClawAdapter,
   CrewAIAdapter,
   GovernanceEngine,
+  QuotaManager,
 } from '@shackleai/core'
 import { AgentApiKeyStatus } from '@shackleai/shared'
 import { readConfig, writeConfig } from '../config.js'
@@ -74,7 +75,7 @@ export async function startCommand(options: { port: number }): Promise<void> {
   // runMigrations has a WeakSet guard â€” safe even if autoInitFromEnv already ran it
   await runMigrations(db)
 
-  // Ensure at least one API key exists — generate a default admin key on first start
+  // Ensure at least one API key exists ï¿½ generate a default admin key on first start
   await ensureDefaultApiKey(db, config.companyId)
 
   // Initialize core services
@@ -91,8 +92,11 @@ export async function startCommand(options: { port: number }): Promise<void> {
   // GovernanceEngine enforces policies before adapter execution
   const governance = new GovernanceEngine(db)
 
+  // QuotaManager enforces time-windowed provider-level quotas
+  const quotaManager = new QuotaManager(db)
+
   // HeartbeatExecutor is the single source of truth for heartbeat_run records
-  const executor = new HeartbeatExecutor(db, costTracker, observatory, adapterRegistry, governance)
+  const executor = new HeartbeatExecutor(db, costTracker, observatory, adapterRegistry, governance, quotaManager)
 
   // Scheduler wraps executor with coalescing and cron scheduling
   const scheduler = new Scheduler(db, (agentId, trigger) =>
@@ -281,7 +285,7 @@ async function ensureDefaultApiKey(db: DatabaseProvider, companyId: string): Pro
 
     Authorization: Bearer ${plainKey}
 
-  Save this key — it will NOT be shown again.
+  Save this key ï¿½ it will NOT be shown again.
   =====================================================================
   `)
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -20,6 +20,7 @@ import { registerCommentCommand } from './commands/comment.js'
 import { registerConfigCommand } from './commands/config-cmd.js'
 import { registerApprovalCommand } from './commands/approval.js'
 import { registerSecretCommand } from './commands/secret.js'
+import { registerQuotaCommand } from './commands/quota.js'
 
 export const VERSION = '0.1.0'
 
@@ -61,6 +62,7 @@ registerCommentCommand(program)
 registerConfigCommand(program)
 registerApprovalCommand(program)
 registerSecretCommand(program)
+registerQuotaCommand(program)
 
 // Only parse when run as CLI entrypoint — not when imported for VERSION etc.
 const isDirectRun =

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -24,6 +24,7 @@ import { toolCallsRouter } from './routes/tool-calls.js'
 import { commentsRouter } from './routes/comments.js'
 import { approvalsRouter } from './routes/approvals.js'
 import { secretsRouter } from './routes/secrets.js'
+import { quotasRouter } from './routes/quotas.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
@@ -68,6 +69,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', commentsRouter(db, options?.scheduler))
   app.route('/api/companies', approvalsRouter(db))
   app.route('/api/companies', secretsRouter(db))
+  app.route('/api/companies', quotasRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/quotas.ts
+++ b/apps/cli/src/server/routes/quotas.ts
@@ -1,0 +1,85 @@
+/**
+ * Quota window routes -- /api/companies/:id/quotas
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { QuotaWindow } from '@shackleai/shared'
+import { CreateQuotaWindowInput } from '@shackleai/shared'
+import { QuotaManager } from '@shackleai/core'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function quotasRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+  const quotaManager = new QuotaManager(db)
+
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  app.get('/:id/quotas', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const result = await db.query<QuotaWindow>(
+      `SELECT * FROM quota_windows WHERE company_id = $1 ORDER BY created_at ASC`,
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  app.post('/:id/quotas', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateQuotaWindowInput.safeParse({
+      company_id: companyId,
+      ...(body as object),
+    })
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { agent_id, provider, window_duration, max_requests, max_tokens } = parsed.data
+
+    if (max_requests == null && max_tokens == null) {
+      return c.json({ error: 'At least one of max_requests or max_tokens must be set' }, 400)
+    }
+
+    const result = await db.query<QuotaWindow>(
+      `INSERT INTO quota_windows (company_id, agent_id, provider, window_duration, max_requests, max_tokens)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [companyId, agent_id ?? null, provider ?? null, window_duration, max_requests ?? null, max_tokens ?? null],
+    )
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  app.delete('/:id/quotas/:quotaId', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const quotaId = c.req.param('quotaId')
+    const result = await db.query(
+      `DELETE FROM quota_windows WHERE id = $1 AND company_id = $2 RETURNING id`,
+      [quotaId, companyId],
+    )
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Quota window not found' }, 404)
+    }
+    return c.json({ data: { deleted: true } })
+  })
+
+  app.get('/:id/agents/:agentId/quota-status', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const agentId = c.req.param('agentId')!
+    const statuses = await quotaManager.getQuotaStatus(companyId, agentId)
+    return c.json({ data: statuses })
+  })
+
+  return app
+}

--- a/packages/core/__tests__/engine.test.ts
+++ b/packages/core/__tests__/engine.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { PGliteProvider, runMigrations } from '@shackleai/db'
 import { PolicyAction } from '@shackleai/shared'
-import { GovernanceEngine, RateLimiter } from '../src/governance/index.js'
+import { GovernanceEngine } from '../src/governance/index.js'
+import { QuotaManager } from '../src/quota/index.js'
 
 // ---------------------------------------------------------------------------
 // Shared test fixtures
@@ -242,54 +243,119 @@ describe('GovernanceEngine', () => {
 })
 
 // ---------------------------------------------------------------------------
-// RateLimiter
+// QuotaManager
 // ---------------------------------------------------------------------------
 
-describe('RateLimiter', () => {
-  let limiter: RateLimiter
+describe('QuotaManager', () => {
+  let db: PGliteProvider
+  let quotaManager: QuotaManager
 
-  const POLICY_ID = '00000000-0000-0000-0000-000000000099'
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
 
-  beforeEach(() => {
-    limiter = new RateLimiter()
+    await db.exec(`
+      INSERT INTO companies (id, name, issue_prefix)
+      VALUES ('00000000-0000-0000-0000-000000000001', 'Quota Corp', 'QC');
+    `)
+    await db.exec(`
+      INSERT INTO agents (id, company_id, name, role, adapter_type, adapter_config)
+      VALUES ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'Agent Q', 'worker', 'process', '{}');
+    `)
+
+    quotaManager = new QuotaManager(db)
   })
 
-  it('should allow calls within the rate limit', () => {
-    // 10 calls per hour
-    for (let i = 0; i < 10; i++) {
-      expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 10)).toBe(true)
+  afterAll(async () => {
+    await db.close()
+  })
+
+  beforeEach(async () => {
+    await db.exec('DELETE FROM quota_windows')
+    await db.exec('DELETE FROM cost_events')
+  })
+
+  it('should allow when no quotas exist', async () => {
+    const result = await quotaManager.checkQuota(COMPANY_ID, AGENT_ID, 'anthropic')
+    expect(result.allowed).toBe(true)
+  })
+
+  it('should deny when request quota is exceeded', async () => {
+    await db.query(
+      `INSERT INTO quota_windows (company_id, agent_id, provider, window_duration, max_requests)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [COMPANY_ID, AGENT_ID, 'anthropic', '1h', 3],
+    )
+
+    for (let i = 0; i < 3; i++) {
+      await db.query(
+        `INSERT INTO cost_events (company_id, agent_id, provider, input_tokens, output_tokens, cost_cents)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [COMPANY_ID, AGENT_ID, 'anthropic', 100, 50, 1],
+      )
     }
+
+    const result = await quotaManager.checkQuota(COMPANY_ID, AGENT_ID, 'anthropic')
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Request quota exceeded')
+    expect(result.quotaId).toBeDefined()
   })
 
-  it('should deny when rate limit is exceeded', () => {
-    // 3 calls per hour — consume all tokens
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 3)).toBe(true)
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 3)).toBe(true)
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 3)).toBe(true)
+  it('should deny when token quota is exceeded', async () => {
+    await db.query(
+      `INSERT INTO quota_windows (company_id, agent_id, provider, window_duration, max_tokens)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [COMPANY_ID, AGENT_ID, 'anthropic', '1h', 500],
+    )
 
-    // 4th call should be denied
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 3)).toBe(false)
+    await db.query(
+      `INSERT INTO cost_events (company_id, agent_id, provider, input_tokens, output_tokens, cost_cents)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [COMPANY_ID, AGENT_ID, 'anthropic', 100, 500, 10],
+    )
+
+    const result = await quotaManager.checkQuota(COMPANY_ID, AGENT_ID, 'anthropic')
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Token quota exceeded')
   })
 
-  it('should track separate buckets per policy+agent pair', () => {
-    // Exhaust AGENT_ID's bucket
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 1)).toBe(true)
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 1)).toBe(false)
+  it('should apply company-wide quotas', async () => {
+    await db.query(
+      `INSERT INTO quota_windows (company_id, agent_id, provider, window_duration, max_requests)
+       VALUES ($1, NULL, $2, $3, $4)`,
+      [COMPANY_ID, 'anthropic', '1h', 2],
+    )
 
-    // OTHER_AGENT_ID should still have tokens
-    expect(limiter.checkRateLimit(POLICY_ID, OTHER_AGENT_ID, 1)).toBe(true)
+    for (let i = 0; i < 2; i++) {
+      await db.query(
+        `INSERT INTO cost_events (company_id, agent_id, provider, input_tokens, output_tokens, cost_cents)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [COMPANY_ID, AGENT_ID, 'anthropic', 100, 50, 1],
+      )
+    }
+
+    const result = await quotaManager.checkQuota(COMPANY_ID, AGENT_ID, 'anthropic')
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('company')
   })
 
-  it('should deny when maxCallsPerHour is 0', () => {
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 0)).toBe(false)
-  })
+  it('should return quota status with current usage', async () => {
+    await db.query(
+      `INSERT INTO quota_windows (company_id, agent_id, provider, window_duration, max_requests, max_tokens)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [COMPANY_ID, AGENT_ID, 'anthropic', '1h', 10, 10000],
+    )
 
-  it('should reset all buckets', () => {
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 1)).toBe(true)
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 1)).toBe(false)
+    await db.query(
+      `INSERT INTO cost_events (company_id, agent_id, provider, input_tokens, output_tokens, cost_cents)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [COMPANY_ID, AGENT_ID, 'anthropic', 200, 300, 5],
+    )
 
-    limiter.reset()
-
-    expect(limiter.checkRateLimit(POLICY_ID, AGENT_ID, 1)).toBe(true)
+    const statuses = await quotaManager.getQuotaStatus(COMPANY_ID, AGENT_ID)
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0].current_requests).toBe(1)
+    expect(statuses[0].current_tokens).toBe(500)
+    expect(statuses[0].exceeded).toBe(false)
   })
 })

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -1,7 +1,6 @@
 /**
- * Governance module — policy evaluation and rate limiting for tool access control.
+ * Governance module — policy evaluation for tool access control.
  */
 
 export { GovernanceEngine } from './engine.js'
 export type { PolicyCheckResult } from './engine.js'
-export { RateLimiter } from './rate-limiter.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,8 +3,11 @@
  */
 export const VERSION = '0.1.0'
 
-export { GovernanceEngine, RateLimiter } from './governance/index.js'
+export { GovernanceEngine } from './governance/index.js'
 export type { PolicyCheckResult } from './governance/index.js'
+
+export { QuotaManager } from './quota/index.js'
+export type { QuotaCheckResult } from './quota/index.js'
 
 export { ContextBuilder } from './context-builder.js'
 

--- a/packages/core/src/quota/index.ts
+++ b/packages/core/src/quota/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Quota module -- time-windowed provider-level quota enforcement.
+ */
+
+export { QuotaManager } from './manager.js'
+export type { QuotaCheckResult } from './manager.js'

--- a/packages/core/src/quota/manager.ts
+++ b/packages/core/src/quota/manager.ts
@@ -1,0 +1,168 @@
+/**
+ * QuotaManager -- time-windowed provider-level quota enforcement.
+ *
+ * Enforces per-provider, per-agent (or company-wide) request and token limits
+ * using a sliding window over cost_events. Replaces the dead in-memory
+ * RateLimiter with database-backed enforcement.
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+import type { QuotaWindow, QuotaStatus } from '@shackleai/shared'
+
+export interface QuotaCheckResult {
+  allowed: boolean
+  quotaId?: string
+  reason?: string
+}
+
+const DURATION_MS: Record<string, number> = {
+  '1m': 60_000,
+  '5m': 5 * 60_000,
+  '15m': 15 * 60_000,
+  '1h': 60 * 60_000,
+  '6h': 6 * 60 * 60_000,
+  '1d': 24 * 60 * 60_000,
+}
+
+export class QuotaManager {
+  private readonly db: DatabaseProvider
+
+  constructor(db: DatabaseProvider) {
+    this.db = db
+  }
+
+  async checkQuota(
+    companyId: string,
+    agentId: string,
+    provider?: string,
+  ): Promise<QuotaCheckResult> {
+    const conditions = ['company_id = $1', '(agent_id = $2 OR agent_id IS NULL)']
+    const params: unknown[] = [companyId, agentId]
+
+    if (provider) {
+      conditions.push('(provider = $3 OR provider IS NULL)')
+      params.push(provider)
+    } else {
+      conditions.push('provider IS NULL')
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await this.db.query<QuotaWindow>(
+      `SELECT * FROM quota_windows WHERE ${where}`,
+      params,
+    )
+
+    if (result.rows.length === 0) {
+      return { allowed: true }
+    }
+
+    for (const quota of result.rows) {
+      const durationMs = DURATION_MS[quota.window_duration]
+      if (!durationMs) continue
+
+      const windowStart = new Date(Date.now() - durationMs).toISOString()
+      const usage = await this.getUsageForQuota(quota, companyId, windowStart)
+
+      if (quota.max_requests !== null && usage.request_count >= quota.max_requests) {
+        const scope = quota.agent_id ? 'agent' : 'company'
+        const providerLabel = quota.provider ?? 'all providers'
+        return {
+          allowed: false,
+          quotaId: quota.id,
+          reason: `Request quota exceeded: ${usage.request_count}/${quota.max_requests} requests in ${quota.window_duration} window (${scope}, ${providerLabel})`,
+        }
+      }
+
+      if (quota.max_tokens !== null && usage.total_tokens >= quota.max_tokens) {
+        const scope = quota.agent_id ? 'agent' : 'company'
+        const providerLabel = quota.provider ?? 'all providers'
+        return {
+          allowed: false,
+          quotaId: quota.id,
+          reason: `Token quota exceeded: ${usage.total_tokens}/${quota.max_tokens} tokens in ${quota.window_duration} window (${scope}, ${providerLabel})`,
+        }
+      }
+    }
+
+    return { allowed: true }
+  }
+
+  async getQuotaStatus(
+    companyId: string,
+    agentId?: string,
+  ): Promise<QuotaStatus[]> {
+    const conditions = ['company_id = $1']
+    const params: unknown[] = [companyId]
+
+    if (agentId) {
+      conditions.push('(agent_id = $2 OR agent_id IS NULL)')
+      params.push(agentId)
+    }
+
+    const where = conditions.join(' AND ')
+    const quotas = await this.db.query<QuotaWindow>(
+      `SELECT * FROM quota_windows WHERE ${where} ORDER BY created_at ASC`,
+      params,
+    )
+
+    const statuses: QuotaStatus[] = []
+
+    for (const quota of quotas.rows) {
+      const durationMs = DURATION_MS[quota.window_duration]
+      if (!durationMs) continue
+
+      const windowStart = new Date(Date.now() - durationMs).toISOString()
+      const usage = await this.getUsageForQuota(quota, companyId, windowStart)
+
+      const requestExceeded =
+        quota.max_requests !== null && usage.request_count >= quota.max_requests
+      const tokenExceeded =
+        quota.max_tokens !== null && usage.total_tokens >= quota.max_tokens
+
+      statuses.push({
+        quota,
+        current_requests: usage.request_count,
+        current_tokens: usage.total_tokens,
+        exceeded: requestExceeded || tokenExceeded,
+      })
+    }
+
+    return statuses
+  }
+
+  private async getUsageForQuota(
+    quota: QuotaWindow,
+    companyId: string,
+    windowStart: string,
+  ): Promise<{ request_count: number; total_tokens: number }> {
+    const usageConditions = ['company_id = $1', 'occurred_at >= $2']
+    const usageParams: unknown[] = [companyId, windowStart]
+    let paramIdx = 3
+
+    if (quota.agent_id) {
+      usageConditions.push(`agent_id = $${paramIdx++}`)
+      usageParams.push(quota.agent_id)
+    }
+
+    if (quota.provider) {
+      usageConditions.push(`provider = $${paramIdx++}`)
+      usageParams.push(quota.provider)
+    }
+
+    const usageWhere = usageConditions.join(' AND ')
+
+    const usage = await this.db.query<{
+      request_count: number
+      total_tokens: number
+    }>(
+      `SELECT
+         COUNT(*)::int AS request_count,
+         COALESCE(SUM(input_tokens + output_tokens), 0)::int AS total_tokens
+       FROM cost_events
+       WHERE ${usageWhere}`,
+      usageParams,
+    )
+
+    return usage.rows[0] ?? { request_count: 0, total_tokens: 0 }
+  }
+}

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -41,6 +41,7 @@ import type { GovernanceEngine } from '../governance/index.js'
 import { SecretsManager } from '../secrets/index.js'
 import { LogRedactor } from '../secrets/index.js'
 import { HeartbeatEventLogger } from './event-logger.js'
+import type { QuotaManager } from '../quota/index.js'
 
 /** Default timeout in seconds. */
 const DEFAULT_TIMEOUT_S = 300
@@ -88,6 +89,7 @@ export class HeartbeatExecutor {
   private governance: GovernanceEngine | null
   private secretsManager: SecretsManager
   private logRedactor: LogRedactor
+  private quotaManager: QuotaManager | null
 
   constructor(
     db: DatabaseProvider,
@@ -95,6 +97,7 @@ export class HeartbeatExecutor {
     observatory: Observatory,
     adapterRegistry: AdapterRegistry,
     governance?: GovernanceEngine,
+    quotaManager?: QuotaManager,
   ) {
     this.db = db
     this.costTracker = costTracker
@@ -104,6 +107,7 @@ export class HeartbeatExecutor {
     this.governance = governance ?? null
     this.secretsManager = new SecretsManager(db)
     this.logRedactor = new LogRedactor()
+    this.quotaManager = quotaManager ?? null
   }
 
   /**
@@ -179,6 +183,32 @@ export class HeartbeatExecutor {
         events.emit('error', { message: errMsg })
 
         return { exitCode: 1, stderr: errMsg }
+      }
+
+      // -- Step 3b: Quota check -----------------------------------------------
+      if (this.quotaManager) {
+        const quotaResult = await this.quotaManager.checkQuota(companyId, agentId)
+        if (!quotaResult.allowed) {
+          const errMsg = `Quota exceeded: ${quotaResult.reason}`
+          await this.markRunFailed(runId, errMsg)
+          await this.markAgentIdle(agentId)
+
+          this.observatory.logEvent({
+            company_id: companyId,
+            entity_type: 'heartbeat_run',
+            entity_id: runId,
+            actor_type: 'agent',
+            actor_id: agentId,
+            action: 'quota_exceeded',
+            changes: {
+              trigger,
+              quotaId: quotaResult.quotaId ?? null,
+              reason: quotaResult.reason,
+            },
+          })
+
+          return { exitCode: 1, stderr: errMsg }
+        }
       }
 
       // ── Step 4: Load adapter ────────────────────────────────────────

--- a/packages/db/src/migrations/020_quota_windows.ts
+++ b/packages/db/src/migrations/020_quota_windows.ts
@@ -1,0 +1,17 @@
+export const name = '020_quota_windows'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS quota_windows (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id),
+  agent_id UUID REFERENCES agents(id),
+  provider TEXT,
+  window_duration TEXT NOT NULL DEFAULT '1h',
+  max_requests INTEGER,
+  max_tokens INTEGER,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quota_windows_company ON quota_windows (company_id);
+CREATE INDEX IF NOT EXISTS idx_quota_windows_agent ON quota_windows (company_id, agent_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -18,6 +18,7 @@ import * as m016 from './016_approvals.js'
 import * as m017 from './017_secrets.js'
 import * as m018 from './018_agent_config_revisions.js'
 import * as m019 from './019_heartbeat_run_events.js'
+import * as m020 from './020_quota_windows.js'
 
 export interface Migration {
   name: string
@@ -44,6 +45,7 @@ const migrations: Migration[] = [
   m017,
   m018,
   m019,
+  m020,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -281,3 +281,21 @@ export interface HeartbeatRunEvent {
   payload: Record<string, unknown> | null
   created_at: string
 }
+
+export interface QuotaWindow {
+  id: string
+  company_id: string
+  agent_id: string | null
+  provider: string | null
+  window_duration: string
+  max_requests: number | null
+  max_tokens: number | null
+  created_at: string
+}
+
+export interface QuotaStatus {
+  quota: QuotaWindow
+  current_requests: number
+  current_tokens: number
+  exceeded: boolean
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -350,3 +350,19 @@ export const CreateSecretInput = z.object({
   created_by: z.string().optional(),
 })
 export type CreateSecretInput = z.infer<typeof CreateSecretInput>
+
+// ---------------------------------------------------------------------------
+// QuotaWindow
+// ---------------------------------------------------------------------------
+
+const windowDurationValues = ['1m', '5m', '15m', '1h', '6h', '1d'] as const
+
+export const CreateQuotaWindowInput = z.object({
+  company_id: uuid,
+  agent_id: uuid.nullable().optional(),
+  provider: z.string().nullable().optional(),
+  window_duration: z.enum(windowDurationValues).default('1h'),
+  max_requests: z.number().int().min(1).nullable().optional(),
+  max_tokens: z.number().int().min(1).nullable().optional(),
+})
+export type CreateQuotaWindowInput = z.infer<typeof CreateQuotaWindowInput>


### PR DESCRIPTION
## Summary

- Add `QuotaManager` class with sliding-window quota enforcement over `cost_events`, replacing the dead in-memory `RateLimiter`
- Create `quota_windows` table (migration 017) with support for per-provider, per-agent, and company-wide quotas
- Wire quota checks into `HeartbeatExecutor` between budget check and adapter execution (Step 3b)
- Add CRUD API routes (`GET/POST/DELETE /quotas`, `GET /agents/:id/quota-status`) and CLI commands (`shackleai quota list/create/delete/status`)

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] QuotaManager unit tests pass (5 tests in engine.test.ts)
- [ ] E2E: Create quota via API, verify enforcement blocks heartbeat
- [ ] E2E: Verify CLI quota commands work against running server

Closes #177

Generated with [Claude Code](https://claude.com/claude-code)