### PR TITLE
fix: cache dashboard index.html at startup instead of readFileSync per request

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -90,10 +90,12 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
       serveStatic({ root: dashboardDist, rewriteRequestPath: () => '/favicon.svg' }),
     )
 
-    // SPA fallback — serve index.html for all non-API routes
+    // Cache index.html once at startup — avoids readFileSync blocking the event loop per request
+    const indexHtml = fs.readFileSync(path.join(dashboardDist, 'index.html'), 'utf-8')
+
+    // SPA fallback — serve cached index.html for all non-API routes
     app.get('*', (c) => {
-      const html = fs.readFileSync(path.join(dashboardDist, 'index.html'), 'utf-8')
-      return c.html(html)
+      return c.html(indexHtml)
     })
   }
 


### PR DESCRIPTION
## Summary
- Reads `index.html` once at startup and caches it in a variable
- SPA fallback handler serves the cached string instead of calling `fs.readFileSync` on every request
- Eliminates event loop blocking on every non-API route hit

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] `dashboard.test.ts` passes (3/3)
- [ ] Manual: verify dashboard loads at `/` after `shackleai start`

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)