### PR TITLE
fix: remove shell:true from adapters to fix env var injection on Windows (#147)

### DIFF
--- a/packages/core/src/adapters/claude.ts
+++ b/packages/core/src/adapters/claude.ts
@@ -159,7 +159,6 @@ export class ClaudeAdapter implements AdapterModule {
       const child = spawn('claude', args, {
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
 
@@ -218,7 +217,6 @@ export class ClaudeAdapter implements AdapterModule {
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       const child = spawn('claude', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
       })
 
       child.stdout.on('data', () => {

--- a/packages/core/src/adapters/codex.ts
+++ b/packages/core/src/adapters/codex.ts
@@ -47,7 +47,6 @@ export class CodexAdapter implements AdapterModule {
       const child = spawn('codex', args, {
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
       this.activeChild = child
@@ -96,7 +95,6 @@ export class CodexAdapter implements AdapterModule {
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       const child = spawn('codex', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
       })
       child.stdout.on('data', () => { /* drain */ })
       const timeout = setTimeout(() => {

--- a/packages/core/src/adapters/cursor.ts
+++ b/packages/core/src/adapters/cursor.ts
@@ -47,7 +47,6 @@ export class CursorAdapter implements AdapterModule {
       const child = spawn('cursor', args, {
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
       this.activeChild = child
@@ -96,7 +95,6 @@ export class CursorAdapter implements AdapterModule {
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       const child = spawn('cursor', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
       })
       child.stdout.on('data', () => { /* drain */ })
       const timeout = setTimeout(() => {

--- a/packages/core/src/adapters/gemini.ts
+++ b/packages/core/src/adapters/gemini.ts
@@ -47,7 +47,6 @@ export class GeminiAdapter implements AdapterModule {
       const child = spawn('gemini', args, {
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
       this.activeChild = child
@@ -96,7 +95,6 @@ export class GeminiAdapter implements AdapterModule {
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       const child = spawn('gemini', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
       })
       child.stdout.on('data', () => { /* drain */ })
       const timeout = setTimeout(() => {

--- a/packages/core/src/adapters/kiro.ts
+++ b/packages/core/src/adapters/kiro.ts
@@ -47,7 +47,6 @@ export class KiroAdapter implements AdapterModule {
       const child = spawn('kiro', args, {
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
       this.activeChild = child
@@ -96,7 +95,6 @@ export class KiroAdapter implements AdapterModule {
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       const child = spawn('kiro', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
       })
       child.stdout.on('data', () => { /* drain */ })
       const timeout = setTimeout(() => {

--- a/packages/core/src/adapters/process.ts
+++ b/packages/core/src/adapters/process.ts
@@ -112,7 +112,6 @@ export class ProcessAdapter implements AdapterModule {
         env,
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: IS_WIN,
         detached: !IS_WIN,
       })
 


### PR DESCRIPTION
## Summary
- Root cause: `shell: IS_WIN` in spawn() caused cmd.exe to mangle arguments on Windows
- Removed `shell: true` from all 6 process-spawning adapters (process, claude, codex, cursor, gemini, kiro)
- Fixes 3 pre-existing test failures that were caused by the same issue

## Files Changed
- 6 adapter files: removed `shell: IS_WIN` from spawn options

## Test plan
- [x] All 39 adapter tests pass (3 previously failing now pass)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)