### PR TITLE
fix: preserve all agent fields during approval execution

### DIFF
--- a/apps/cli/src/server/routes/approvals.ts
+++ b/apps/cli/src/server/routes/approvals.ts
@@ -111,15 +111,22 @@ export function approvalsRouter(db: DatabaseProvider): Hono<{ Variables: Variabl
         : approval.payload
 
       const agentResult = await db.query<Agent>(
-        `INSERT INTO agents (company_id, name, role, adapter_type, adapter_config)
-         VALUES ($1, $2, $3, $4, $5)
+        `INSERT INTO agents
+           (company_id, name, title, role, status, reports_to, capabilities,
+            adapter_type, adapter_config, budget_monthly_cents)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          RETURNING *`,
         [
           companyId,
           payload.name ?? 'Unnamed Agent',
+          payload.title ?? null,
           payload.role ?? 'general',
+          payload.status ?? 'idle',
+          payload.reports_to ?? null,
+          payload.capabilities ?? null,
           payload.adapter_type ?? 'process',
           JSON.stringify(payload.adapter_config ?? {}),
+          payload.budget_monthly_cents ?? 0,
         ],
       )
       createdAgent = agentResult.rows[0]


### PR DESCRIPTION
## Summary
- The approval execution path for `agent_create` was only inserting 4 fields (`name`, `role`, `adapter_type`, `adapter_config`), silently dropping `title`, `status`, `reports_to`, `capabilities`, and `budget_monthly_cents` from the approval payload
- Expanded the INSERT to include all 10 agent columns, matching the direct agent creation path in `agents.ts`

Closes #146

## Test plan
- [ ] Create an agent with all fields on a company with `require_approval = true` — verify the approval payload contains all fields
- [ ] Approve the pending approval — verify the created agent has `title`, `capabilities`, `budget_monthly_cents`, `reports_to`, and `status` preserved
- [ ] Verify existing approval tests still pass

Generated with [Claude Code](https://claude.ai/code)