### PR TITLE
fix: add user-friendly CLI error handling with --verbose flag

### DIFF
--- a/apps/cli/__tests__/errors.test.ts
+++ b/apps/cli/__tests__/errors.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for CLI error handling (src/errors.ts)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('CLI error handler', () => {
+  let handleError: typeof import('../src/errors.js').handleError
+  let setVerbose: typeof import('../src/errors.js').setVerbose
+
+  const mockExit = vi.fn<(code?: number) => never>()
+  const mockError = vi.fn()
+
+  beforeEach(async () => {
+    vi.stubGlobal('process', {
+      ...process,
+      exit: mockExit,
+    })
+    vi.spyOn(console, 'error').mockImplementation(mockError)
+
+    // Fresh import each test to reset verbose state
+    vi.resetModules()
+    const mod = await import('../src/errors.js')
+    handleError = mod.handleError
+    setVerbose = mod.setVerbose
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows user-friendly message for ECONNREFUSED', () => {
+    const err = new Error('connect ECONNREFUSED 127.0.0.1:4800') as NodeJS.ErrnoException
+    err.code = 'ECONNREFUSED'
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('Could not connect to the orchestrator server')
+    expect(output).toContain('shackleai start')
+  })
+
+  it('shows user-friendly message for ENOENT', () => {
+    const err = new Error('ENOENT: no such file') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    err.path = '/home/user/.shackleai/config.json'
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('File or directory not found')
+    expect(output).toContain('shackleai init')
+  })
+
+  it('shows user-friendly message for database relation errors', () => {
+    const err = new Error('relation "companies" does not exist')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('Database is not set up correctly')
+    expect(output).toContain('shackleai init')
+  })
+
+  it('shows user-friendly message for duplicate key errors', () => {
+    const err = new Error('duplicate key value violates unique constraint')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('already exists')
+  })
+
+  it('shows user-friendly message for auth errors', () => {
+    const err = new Error('401 Unauthorized')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('Authentication failed')
+  })
+
+  it('falls back to error message for unknown errors', () => {
+    const err = new Error('Something totally unexpected happened')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('Something totally unexpected happened')
+  })
+
+  it('shows stack trace in verbose mode', () => {
+    setVerbose(true)
+    const err = new Error('test error')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('Stack trace')
+  })
+
+  it('hides stack trace by default', () => {
+    const err = new Error('test error')
+
+    handleError(err)
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).not.toContain('Stack trace')
+  })
+
+  it('handles non-Error values gracefully', () => {
+    handleError('string error')
+
+    const output = mockError.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toContain('string error')
+  })
+
+  it('calls process.exit(1)', () => {
+    handleError(new Error('fail'))
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+})

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -54,6 +54,7 @@
     "@shackleai/db": "workspace:*",
     "@shackleai/shared": "workspace:*",
     "commander": "^13.1.0",
-    "hono": "^4.7.10"
+    "hono": "^4.7.10",
+    "picocolors": "^1.1.1"
   }
 }

--- a/apps/cli/src/errors.ts
+++ b/apps/cli/src/errors.ts
@@ -1,0 +1,153 @@
+/**
+ * CLI error handling — user-friendly error messages with optional verbose mode.
+ *
+ * Catches unhandled errors from command actions and displays clean,
+ * categorized messages instead of raw stack traces.
+ */
+
+import pc from 'picocolors'
+
+/** Whether --verbose was passed globally */
+let verbose = false
+
+export function setVerbose(v: boolean): void {
+  verbose = v
+}
+
+export function isVerbose(): boolean {
+  return verbose
+}
+
+/**
+ * Categorize an error and return a user-friendly message + hint.
+ */
+function categorizeError(err: Error): { message: string; hint?: string } {
+  const msg = err.message ?? String(err)
+  const code = (err as NodeJS.ErrnoException).code
+
+  // Network / connection errors
+  if (
+    code === 'ECONNREFUSED' ||
+    code === 'ECONNRESET' ||
+    code === 'ENOTFOUND' ||
+    msg.includes('fetch failed') ||
+    msg.includes('ECONNREFUSED')
+  ) {
+    return {
+      message: 'Could not connect to the orchestrator server.',
+      hint: 'Is the server running? Start it with: shackleai start',
+    }
+  }
+
+  if (code === 'ETIMEDOUT' || msg.includes('ETIMEDOUT')) {
+    return {
+      message: 'Request timed out.',
+      hint: 'The server may be overloaded. Try again in a moment.',
+    }
+  }
+
+  // File / permission errors
+  if (code === 'ENOENT') {
+    return {
+      message: `File or directory not found: ${(err as NodeJS.ErrnoException).path ?? 'unknown'}`,
+      hint: 'Have you run `shackleai init` yet?',
+    }
+  }
+
+  if (code === 'EACCES' || code === 'EPERM') {
+    return {
+      message: 'Permission denied.',
+      hint: 'Check file permissions or run with appropriate privileges.',
+    }
+  }
+
+  // Database errors
+  if (
+    (msg.includes('relation') && msg.includes('does not exist')) ||
+    (msg.includes('database') && msg.includes('does not exist'))
+  ) {
+    return {
+      message: 'Database is not set up correctly.',
+      hint: 'Run `shackleai init` to initialize the database.',
+    }
+  }
+
+  if (msg.includes('unique') || msg.includes('duplicate key')) {
+    return {
+      message: 'A record with that value already exists.',
+      hint: 'Use a different name or ID.',
+    }
+  }
+
+  if (
+    (msg.includes('ECONNREFUSED') && msg.includes('5432')) ||
+    (msg.includes('connect ECONNREFUSED') && msg.includes('postgres'))
+  ) {
+    return {
+      message: 'Could not connect to the database.',
+      hint: 'Check that PostgreSQL is running and DATABASE_URL is correct.',
+    }
+  }
+
+  // Validation errors (Zod or manual)
+  if (msg.includes('ZodError') || msg.includes('Validation') || msg.includes('validation')) {
+    return {
+      message: 'Invalid input.',
+      hint: msg,
+    }
+  }
+
+  // Auth errors
+  if (msg.includes('401') || msg.includes('Unauthorized') || msg.includes('unauthorized')) {
+    return {
+      message: 'Authentication failed.',
+      hint: 'Check your credentials or run `shackleai init` again.',
+    }
+  }
+
+  if (msg.includes('403') || msg.includes('Forbidden') || msg.includes('forbidden')) {
+    return {
+      message: 'Access denied.',
+      hint: 'You do not have permission to perform this action.',
+    }
+  }
+
+  // JSON parse errors
+  if (msg.includes('JSON') && (msg.includes('parse') || msg.includes('Unexpected token'))) {
+    return {
+      message: 'Received an invalid response from the server.',
+      hint: 'The server may be misconfigured or returning HTML instead of JSON.',
+    }
+  }
+
+  // Fallback — show the error message without the stack trace
+  return { message: msg }
+}
+
+/**
+ * Format and print an error to stderr.
+ * In verbose mode, the full stack trace is appended.
+ */
+export function handleError(err: unknown): never {
+  const error = err instanceof Error ? err : new Error(String(err))
+  const { message, hint } = categorizeError(error)
+
+  console.error('')
+  console.error(pc.red(`  Error: ${message}`))
+
+  if (hint) {
+    console.error(pc.yellow(`  Hint:  ${hint}`))
+  }
+
+  if (verbose && error.stack) {
+    console.error('')
+    console.error(pc.dim('  Stack trace:'))
+    const stackLines = error.stack.split('\n').slice(1)
+    for (const line of stackLines) {
+      console.error(pc.dim(`  ${line.trim()}`))
+    }
+  }
+
+  console.error('')
+  process.exit(1)
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -21,6 +21,7 @@ import { registerConfigCommand } from './commands/config-cmd.js'
 import { registerApprovalCommand } from './commands/approval.js'
 import { registerSecretCommand } from './commands/secret.js'
 import { registerQuotaCommand } from './commands/quota.js'
+import { handleError, setVerbose } from './errors.js'
 
 export const VERSION = '0.1.0'
 
@@ -30,6 +31,10 @@ program
   .name('shackleai')
   .description('ShackleAI Orchestrator — The Operating System for AI Agents')
   .version(VERSION)
+  .option('--verbose', 'Show full stack traces on errors')
+  .hook('preAction', () => {
+    setVerbose(program.opts().verbose === true)
+  })
 
 program
   .command('init')
@@ -71,5 +76,14 @@ const isDirectRun =
   process.argv[1]?.includes('@shackleai/orchestrator')
 
 if (isDirectRun) {
-  program.parse()
+  // Global error handlers — catch unhandled rejections and exceptions
+  process.on('unhandledRejection', (reason) => {
+    handleError(reason)
+  })
+
+  process.on('uncaughtException', (err) => {
+    handleError(err)
+  })
+
+  program.parseAsync().catch(handleError)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.12.8
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
 
   apps/dashboard:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a global error handler in the CLI entrypoint that catches all unhandled errors
- Categorizes known error types (network/ECONNREFUSED, auth 401/403, database relation errors, duplicate key, ENOENT, permission denied, validation, JSON parse errors) with user-friendly messages and actionable hints
- Unknown errors show the error message without the stack trace
- `--verbose` global flag enables full stack trace output for debugging
- Uses `picocolors` for colored output: red for errors, yellow for hints, dim for stack traces

## Test plan
- [x] 10 unit tests covering all error categories (ECONNREFUSED, ENOENT, DB relation, duplicate key, auth, unknown, verbose mode, non-Error values, process.exit)
- [x] Lint passes
- [x] Build passes
- [ ] Manual: `shackleai agent list` without server running shows friendly connection error
- [ ] Manual: `shackleai --verbose agent list` shows full stack trace

Closes #145

Generated with [Claude Code](https://claude.com/claude-code)