### PR TITLE
fix: wrap delegation in database transaction to prevent partial state

### DIFF
--- a/packages/core/src/delegation.ts
+++ b/packages/core/src/delegation.ts
@@ -46,6 +46,10 @@ export class DelegationService {
    * - Creates child issues with parent_id set to the original issue
    * - Assigns to toAgent with status 'todo'
    * - Returns created issue IDs
+   *
+   * All mutations are wrapped in a transaction. If any step fails
+   * (counter increment, issue insert), all changes are rolled back
+   * to prevent orphaned child issues or phantom counter increments.
    */
   async delegate(
     companyId: string,
@@ -54,6 +58,7 @@ export class DelegationService {
     toAgentId: string,
     subTasks: Array<{ title: string; description?: string | null }>,
   ): Promise<string[]> {
+    // Hierarchy check runs outside the transaction (read-only, no rollback needed)
     const allowed = await this.canDelegate(fromAgentId, toAgentId)
     if (!allowed) {
       throw new DelegationError(
@@ -61,55 +66,58 @@ export class DelegationService {
       )
     }
 
-    // Verify the parent issue exists and belongs to the company
-    const parentResult = await this.db.query<Pick<Issue, 'id'>>(
-      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
-      [issueId, companyId],
-    )
-    if (parentResult.rows.length === 0) {
-      throw new DelegationError('Parent issue not found')
-    }
-
-    const childIds: string[] = []
-
-    for (const task of subTasks) {
-      // Atomically increment company issue_counter
-      const counterResult = await this.db.query<CompanyCounter>(
-        `UPDATE companies SET issue_counter = issue_counter + 1 WHERE id = $1
-         RETURNING issue_prefix, issue_counter`,
-        [companyId],
+    // Wrap all mutations in a transaction to prevent partial state on failure
+    return this.db.transaction(async (tx) => {
+      // Verify the parent issue exists and belongs to the company
+      const parentResult = await tx.query<Pick<Issue, 'id'>>(
+        `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+        [issueId, companyId],
       )
-
-      if (counterResult.rows.length === 0) {
-        throw new DelegationError('Company not found')
+      if (parentResult.rows.length === 0) {
+        throw new DelegationError('Parent issue not found')
       }
 
-      const { issue_prefix, issue_counter } = counterResult.rows[0]
-      const identifier = `${issue_prefix}-${issue_counter}`
+      const childIds: string[] = []
 
-      const insertResult = await this.db.query<Pick<Issue, 'id'>>(
-        `INSERT INTO issues
-           (company_id, identifier, issue_number, title, description, parent_id,
-            status, priority, assignee_agent_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-         RETURNING id`,
-        [
-          companyId,
-          identifier,
-          issue_counter,
-          task.title,
-          task.description ?? null,
-          issueId,
-          IssueStatus.Todo,
-          'medium',
-          toAgentId,
-        ],
-      )
+      for (const task of subTasks) {
+        // Atomically increment company issue_counter
+        const counterResult = await tx.query<CompanyCounter>(
+          `UPDATE companies SET issue_counter = issue_counter + 1 WHERE id = $1
+           RETURNING issue_prefix, issue_counter`,
+          [companyId],
+        )
 
-      childIds.push(insertResult.rows[0].id)
-    }
+        if (counterResult.rows.length === 0) {
+          throw new DelegationError('Company not found')
+        }
 
-    return childIds
+        const { issue_prefix, issue_counter } = counterResult.rows[0]
+        const identifier = `${issue_prefix}-${issue_counter}`
+
+        const insertResult = await tx.query<Pick<Issue, 'id'>>(
+          `INSERT INTO issues
+             (company_id, identifier, issue_number, title, description, parent_id,
+              status, priority, assignee_agent_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           RETURNING id`,
+          [
+            companyId,
+            identifier,
+            issue_counter,
+            task.title,
+            task.description ?? null,
+            issueId,
+            IssueStatus.Todo,
+            'medium',
+            toAgentId,
+          ],
+        )
+
+        childIds.push(insertResult.rows[0].id)
+      }
+
+      return childIds
+    })
   }
 }
 

--- a/packages/db/src/pg-provider.ts
+++ b/packages/db/src/pg-provider.ts
@@ -26,6 +26,36 @@ export class PgProvider implements DatabaseProvider {
     await this.pool.query(sql)
   }
 
+  async transaction<T>(fn: (tx: DatabaseProvider) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      const txProvider: DatabaseProvider = {
+        query: async <R = Record<string, unknown>>(sql: string, params?: unknown[]) => {
+          const result = await client.query<R & pg.QueryResultRow>(sql, params)
+          return { rows: result.rows }
+        },
+        exec: async (sql: string) => {
+          await client.query(sql)
+        },
+        transaction: () => {
+          throw new Error('Nested transactions are not supported')
+        },
+        close: () => {
+          throw new Error('Cannot close a transactional provider')
+        },
+      }
+      const result = await fn(txProvider)
+      await client.query('COMMIT')
+      return result
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
   async close(): Promise<void> {
     await this.pool.end()
   }

--- a/packages/db/src/pglite-provider.ts
+++ b/packages/db/src/pglite-provider.ts
@@ -40,6 +40,18 @@ export class PGliteProvider implements DatabaseProvider {
     await this.db.exec(sql)
   }
 
+  async transaction<T>(fn: (tx: DatabaseProvider) => Promise<T>): Promise<T> {
+    await this.db.exec('BEGIN')
+    try {
+      const result = await fn(this)
+      await this.db.exec('COMMIT')
+      return result
+    } catch (error) {
+      await this.db.exec('ROLLBACK')
+      throw error
+    }
+  }
+
   async close(): Promise<void> {
     await this.db.close()
   }

--- a/packages/db/src/provider.ts
+++ b/packages/db/src/provider.ts
@@ -16,5 +16,13 @@ export interface DatabaseProvider {
   /** Execute one or more SQL statements (no parameter support). Used for migrations. */
   exec(sql: string): Promise<void>
 
+  /**
+   * Run a callback inside a database transaction (BEGIN/COMMIT/ROLLBACK).
+   * The callback receives a transactional DatabaseProvider scoped to a single
+   * connection. If the callback throws, the transaction is rolled back and the
+   * error is re-thrown.
+   */
+  transaction<T>(fn: (tx: DatabaseProvider) => Promise<T>): Promise<T>
+
   close(): Promise<void>
 }


### PR DESCRIPTION
## Summary

- Add `transaction<T>(fn)` method to the `DatabaseProvider` interface
- Implement in both `PGliteProvider` (BEGIN/COMMIT/ROLLBACK on single connection) and `PgProvider` (dedicated client from pool for connection-scoped isolation)
- Wrap `DelegationService.delegate()` mutations in a transaction so counter increments and child issue inserts are atomic -- if any step fails, all changes roll back (no orphaned issues)

## Changes

| File | Change |
|------|--------|
| `packages/db/src/provider.ts` | Add `transaction()` to interface |
| `packages/db/src/pglite-provider.ts` | Implement via BEGIN/COMMIT/ROLLBACK |
| `packages/db/src/pg-provider.ts` | Implement with dedicated pool client |
| `packages/core/src/delegation.ts` | Wrap delegate loop in `db.transaction()` |

## Test plan

- [x] All 11 existing delegation tests pass (hierarchy validation + status roll-up)
- [x] TypeScript builds cleanly (`@shackleai/db` and `@shackleai/core`)
- [x] Lint passes

Closes #153