### PR TITLE
feat: add CORS configuration for dashboard cross-origin requests

### DIFF
--- a/apps/cli/__tests__/cors.test.ts
+++ b/apps/cli/__tests__/cors.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+
+describe('CORS middleware', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  afterEach(() => {
+    delete process.env.SHACKLEAI_CORS_ORIGIN
+  })
+
+  it('allows localhost origins in development (default)', async () => {
+    app = createApp(db, { skipAuth: true })
+    const res = await app.request('/api/health', {
+      headers: { Origin: 'http://localhost:5173' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173')
+  })
+
+  it('allows localhost without port', async () => {
+    app = createApp(db, { skipAuth: true })
+    const res = await app.request('/api/health', {
+      headers: { Origin: 'http://localhost' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost')
+  })
+
+  it('rejects non-localhost origins when no env var is set', async () => {
+    app = createApp(db, { skipAuth: true })
+    const res = await app.request('/api/health', {
+      headers: { Origin: 'https://evil.com' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('uses SHACKLEAI_CORS_ORIGIN env var when set', async () => {
+    process.env.SHACKLEAI_CORS_ORIGIN = 'https://app.shackle.ai'
+    app = createApp(db, { skipAuth: true })
+    const res = await app.request('/api/health', {
+      headers: { Origin: 'https://app.shackle.ai' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.shackle.ai')
+  })
+
+  it('supports comma-separated origins in env var', async () => {
+    process.env.SHACKLEAI_CORS_ORIGIN = 'https://app.shackle.ai, https://staging.shackle.ai'
+    app = createApp(db, { skipAuth: true })
+
+    const res1 = await app.request('/api/health', {
+      headers: { Origin: 'https://staging.shackle.ai' },
+    })
+    expect(res1.headers.get('Access-Control-Allow-Origin')).toBe('https://staging.shackle.ai')
+  })
+
+  it('responds to preflight OPTIONS with correct headers', async () => {
+    app = createApp(db, { skipAuth: true })
+    const res = await app.request('/api/health', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Authorization, Content-Type',
+      },
+    })
+    // Hono cors middleware returns 204 for preflight
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST')
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Authorization')
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type')
+    expect(res.headers.get('Access-Control-Expose-Headers')).toContain('X-Total-Count')
+    expect(res.headers.get('Access-Control-Max-Age')).toBe('86400')
+  })
+
+  it('does not add CORS headers to non-API routes', async () => {
+    app = createApp(db, { skipAuth: true })
+    // Non-API route — CORS middleware scoped to /api/* should not apply
+    const res = await app.request('/some-page', {
+      headers: { Origin: 'http://localhost:5173' },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { DatabaseProvider } from '@shackleai/db'
 import type { Scheduler } from '@shackleai/core'
@@ -31,19 +32,40 @@ import { VERSION } from '../index.js'
 
 export interface CreateAppOptions {
   scheduler?: Scheduler
-  /** Skip API authentication � for testing only. NEVER set in production. */
+  /** Skip API authentication — for testing only. NEVER set in production. */
   skipAuth?: boolean
 }
 
 export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hono {
   const app = new Hono()
 
-  // --- Health check � unauthenticated ---
+  // --- CORS — allow dashboard cross-origin requests ---
+  const corsOrigin = process.env.SHACKLEAI_CORS_ORIGIN
+  app.use(
+    '/api/*',
+    cors({
+      origin: corsOrigin
+        ? corsOrigin.split(',').map((o) => o.trim())
+        : (origin) => {
+            // In development, allow any localhost origin (any port)
+            if (origin && /^https?:\/\/localhost(:\d+)?$/.test(origin)) {
+              return origin
+            }
+            return null
+          },
+      allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['Authorization', 'Content-Type'],
+      exposeHeaders: ['X-Total-Count'],
+      maxAge: 86400,
+    }),
+  )
+
+  // --- Health check — unauthenticated ---
   app.get('/api/health', (c) => {
     return c.json({ status: 'ok', version: VERSION })
   })
 
-  // --- Global API authentication � protects all /api/* routes except /api/health ---
+  // --- Global API authentication — protects all /api/* routes except /api/health ---
   if (!options?.skipAuth) {
     const apiAuthMiddleware = createApiAuth(db)
     app.use('/api/*', async (c, next) => {


### PR DESCRIPTION
## Summary
- Adds Hono built-in CORS middleware (`hono/cors`) scoped to `/api/*` routes
- Default behavior allows any `localhost` origin (any port) for local development
- Configurable via `SHACKLEAI_CORS_ORIGIN` env var (comma-separated for multiple origins)
- Allows methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
- Allows headers: Authorization, Content-Type
- Exposes headers: X-Total-Count (for paginated list responses)
- Preflight responses cached for 24 hours (`maxAge: 86400`)

## Test plan
- [x] 7 Vitest tests covering:
  - Default localhost origins (with and without port)
  - Non-localhost origin rejection
  - `SHACKLEAI_CORS_ORIGIN` env var single and comma-separated
  - Preflight OPTIONS response headers
  - CORS headers NOT applied to non-API routes

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)