### PR TITLE
fix: properly redact nested llmKeys and sensitive config fields

### DIFF
--- a/apps/cli/__tests__/parity.test.ts
+++ b/apps/cli/__tests__/parity.test.ts
@@ -98,8 +98,8 @@ describe('config export', () => {
   })
 
   it('exportConfig scrubs databaseUrl and secret-containing keys', async () => {
-    // Write a config file with secrets
-    const configPath = join(testDir, 'config.json')
+    const { redactSensitiveFields } = await import('../src/config.js')
+
     const config = {
       mode: 'server',
       companyId: 'abc-123',
@@ -109,31 +109,8 @@ describe('config export', () => {
       authToken: 'tok_12345',
       issue_prefix: 'TEST',
     }
-    await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
 
-    // We test the logic directly by importing and using a custom path.
-    // Since exportConfig uses getConfigPath internally, we test via the
-    // redaction logic inline.
-    const sensitivePattern = /secret|token|password|key/i
-    const SAFE_KEYS = new Set([
-      'issue_prefix',
-      'dataDir',
-      'mode',
-      'companyId',
-      'companyName',
-      'port',
-    ])
-
-    const redacted: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(config)) {
-      if (k === 'databaseUrl') {
-        redacted[k] = '***REDACTED***'
-      } else if (!SAFE_KEYS.has(k) && sensitivePattern.test(k)) {
-        redacted[k] = '***REDACTED***'
-      } else {
-        redacted[k] = v
-      }
-    }
+    const redacted = redactSensitiveFields(config)
 
     expect(redacted.databaseUrl).toBe('***REDACTED***')
     expect(redacted.apiSecret).toBe('***REDACTED***')
@@ -141,6 +118,35 @@ describe('config export', () => {
     expect(redacted.companyName).toBe('Test Corp')
     expect(redacted.mode).toBe('server')
     expect(redacted.issue_prefix).toBe('TEST')
+  })
+
+  it('redactSensitiveFields recursively redacts nested llmKeys', async () => {
+    const { redactSensitiveFields } = await import('../src/config.js')
+
+    const config = {
+      mode: 'local',
+      companyId: 'abc-123',
+      companyName: 'Test Corp',
+      llmKeys: {
+        openai: 'sk-real-openai-key-12345',
+        anthropic: 'sk-ant-real-anthropic-key-67890',
+      },
+    }
+
+    const redacted = redactSensitiveFields(config)
+
+    // llmKeys should be an object, not flattened to a string
+    expect(typeof redacted.llmKeys).toBe('object')
+    expect(redacted.llmKeys).not.toBe('***REDACTED***')
+
+    // Each nested key value should be redacted
+    const llmKeys = redacted.llmKeys as Record<string, unknown>
+    expect(llmKeys.openai).toBe('***REDACTED***')
+    expect(llmKeys.anthropic).toBe('***REDACTED***')
+
+    // Non-sensitive fields preserved
+    expect(redacted.mode).toBe('local')
+    expect(redacted.companyName).toBe('Test Corp')
   })
 })
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -102,11 +102,51 @@ export async function rollbackConfig(): Promise<ShackleAIConfig | null> {
   return config
 }
 
+/** Pattern matching sensitive key names (case-insensitive). */
+const SENSITIVE_PATTERN = /secret|token|password|key/i
+
+/**
+ * Recursively redact sensitive fields from a config object.
+ * - `databaseUrl` is always redacted.
+ * - Any key matching SENSITIVE_PATTERN is redacted unless it is in SAFE_KEYS.
+ * - If a key matches the sensitive pattern and its value is a nested object,
+ *   all leaf values within that object are redacted (e.g. llmKeys.openai).
+ * - Non-sensitive nested objects are traversed normally.
+ */
+export function redactSensitiveFields(
+  obj: Record<string, unknown>,
+  redactAll = false,
+): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {}
+
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === 'databaseUrl') {
+      redacted[k] = '***REDACTED***'
+    } else if (redactAll && typeof v === 'string') {
+      redacted[k] = '***REDACTED***'
+    } else if (
+      v !== null &&
+      v !== undefined &&
+      typeof v === 'object' &&
+      !Array.isArray(v)
+    ) {
+      const childRedactAll = redactAll || (!SAFE_KEYS.has(k) && SENSITIVE_PATTERN.test(k))
+      redacted[k] = redactSensitiveFields(v as Record<string, unknown>, childRedactAll)
+    } else if (!SAFE_KEYS.has(k) && SENSITIVE_PATTERN.test(k)) {
+      redacted[k] = '***REDACTED***'
+    } else if (redactAll) {
+      redacted[k] = '***REDACTED***'
+    } else {
+      redacted[k] = v
+    }
+  }
+
+  return redacted
+}
+
 /**
  * Export current config with secrets redacted.
- * Replaces databaseUrl and any value whose key contains
- * secret, token, password, or key (case-insensitive) with "***REDACTED***".
- * Well-known safe keys (issue_prefix, etc.) are not redacted.
+ * Nested objects (e.g. llmKeys) are traversed recursively.
  */
 export async function exportConfig(): Promise<string | null> {
   const config = await readConfig()
@@ -114,18 +154,6 @@ export async function exportConfig(): Promise<string | null> {
     return null
   }
 
-  const sensitivePattern = /secret|token|password|key/i
-  const redacted: Record<string, unknown> = {}
-
-  for (const [k, v] of Object.entries(config)) {
-    if (k === 'databaseUrl') {
-      redacted[k] = '***REDACTED***'
-    } else if (!SAFE_KEYS.has(k) && sensitivePattern.test(k)) {
-      redacted[k] = '***REDACTED***'
-    } else {
-      redacted[k] = v
-    }
-  }
-
+  const redacted = redactSensitiveFields(config as unknown as Record<string, unknown>)
   return JSON.stringify(redacted, null, 2)
 }


### PR DESCRIPTION
## Summary

- Extracted `redactSensitiveFields()` recursive helper from the flat `exportConfig()` logic
- Nested objects like `llmKeys` are now traversed recursively, preserving structure (shows which providers are configured) while redacting all leaf values
- If a parent key matches the sensitive pattern (`secret|token|password|key`), all child values inherit redaction
- Updated parity tests to use the exported helper directly and added dedicated test for nested `llmKeys` redaction

## Test plan

- [x] `redactSensitiveFields` redacts `databaseUrl`, `apiSecret`, `authToken` at top level
- [x] `redactSensitiveFields` preserves safe keys (`mode`, `companyName`, `issue_prefix`)
- [x] `redactSensitiveFields` recursively redacts `llmKeys.openai` and `llmKeys.anthropic`
- [x] `llmKeys` remains an object (not flattened to `"***REDACTED***"` string)
- [x] All 6 parity tests pass
- [x] Lint and build pass

Closes #158

Generated with [Claude Code](https://claude.com/claude-code)