### PR TITLE
feat: task lifecycle guards — parent blocked until children complete

### DIFF
--- a/apps/cli/__tests__/issues.test.ts
+++ b/apps/cli/__tests__/issues.test.ts
@@ -630,3 +630,110 @@ describe('issues routes — filtering', () => {
     expect(body.data.every((i) => i.assignee_agent_id === filtAgentId)).toBe(true)
   })
 })
+
+describe('issues routes — lifecycle guards (parent/child)', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+  let companyId: string
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db, { skipAuth: true })
+    const company = await createCompany(app, 'GUARD')
+    companyId = company.id
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  it('rejects completing a parent issue when children are incomplete', async () => {
+    const parent = await createIssue(app, companyId, { title: 'Parent Task', status: 'in_progress' })
+    await createIssue(app, companyId, { title: 'Child A', parent_id: parent.id, status: 'in_progress' })
+    await createIssue(app, companyId, { title: 'Child B', parent_id: parent.id, status: 'backlog' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string; incomplete_children: unknown[]; message: string }
+    expect(body.error).toBe('Cannot complete parent issue while children are incomplete')
+    expect(body.incomplete_children).toHaveLength(2)
+    expect(body.message).toContain('Child A')
+    expect(body.message).toContain('Child B')
+  })
+
+  it('rejects cancelling a parent issue when children are incomplete', async () => {
+    const parent = await createIssue(app, companyId, { title: 'Cancel Parent', status: 'in_progress' })
+    await createIssue(app, companyId, { title: 'Active Child', parent_id: parent.id, status: 'todo' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'cancelled' }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Cannot complete parent issue while children are incomplete')
+  })
+
+  it('allows completing a parent when all children are done', async () => {
+    const parent = await createIssue(app, companyId, { title: 'Good Parent', status: 'in_progress' })
+    await createIssue(app, companyId, { title: 'Done Child 1', parent_id: parent.id, status: 'done' })
+    await createIssue(app, companyId, { title: 'Done Child 2', parent_id: parent.id, status: 'done' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('allows completing a parent when all children are done or cancelled', async () => {
+    const parent = await createIssue(app, companyId, { title: 'Mixed Parent', status: 'in_progress' })
+    await createIssue(app, companyId, { title: 'Done Child', parent_id: parent.id, status: 'done' })
+    await createIssue(app, companyId, { title: 'Cancelled Child', parent_id: parent.id, status: 'cancelled' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('allows completing an issue with no children (leaf task)', async () => {
+    const leaf = await createIssue(app, companyId, { title: 'Leaf Task', status: 'in_progress' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${leaf.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('allows non-terminal status changes on parent with incomplete children', async () => {
+    const parent = await createIssue(app, companyId, { title: 'Status Change Parent', status: 'backlog' })
+    await createIssue(app, companyId, { title: 'WIP Child', parent_id: parent.id, status: 'in_progress' })
+
+    const res = await app.request(`/api/companies/${companyId}/issues/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'in_progress' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('in_progress')
+  })
+})

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -208,6 +208,45 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
       return c.json({ data: result.rows[0] })
     }
 
+    // Lifecycle guard: block completing a parent issue while children are incomplete
+    const isTerminalStatus =
+      updates.status === IssueStatus.Done || updates.status === IssueStatus.Cancelled
+    if (isTerminalStatus) {
+      const childResult = await db.query<
+        Pick<Issue, 'id' | 'identifier' | 'title' | 'status'>
+      >(
+        `SELECT id, identifier, title, status FROM issues WHERE parent_id = $1`,
+        [issueId],
+      )
+      const incompleteChildren = childResult.rows.filter(
+        (child) =>
+          child.status !== IssueStatus.Done &&
+          child.status !== IssueStatus.Cancelled,
+      )
+      if (incompleteChildren.length > 0) {
+        const childList = incompleteChildren
+          .map(
+            (child) =>
+              `${child.identifier} "${child.title}" (${child.status})`,
+          )
+          .join(', ')
+        return c.json(
+          {
+            error:
+              'Cannot complete parent issue while children are incomplete',
+            incomplete_children: incompleteChildren.map((child) => ({
+              id: child.id,
+              identifier: child.identifier,
+              title: child.title,
+              status: child.status,
+            })),
+            message: `Incomplete children: ${childList}`,
+          },
+          400,
+        )
+      }
+    }
+
     const setClauses = fields.map((f, i) => `${f} = $${i + 3}`).join(', ')
     const values = fields.map((f) => updates[f])
 


### PR DESCRIPTION
## Summary
- Adds a lifecycle guard to the issue PATCH route that prevents parent issues from being set to `done` or `cancelled` while any child issue remains incomplete
- Returns a 400 response with detailed `incomplete_children` array listing each blocking child's id, identifier, title, and status
- Treats `done` and `cancelled` as terminal states — children in either state do not block the parent

## Test plan
- [x] Parent with incomplete children cannot be marked `done` (returns 400 with child details)
- [x] Parent with incomplete children cannot be marked `cancelled` (returns 400)
- [x] Parent with all children `done` can be completed (200)
- [x] Parent with mixed `done`/`cancelled` children can be completed (200)
- [x] Leaf issue (no children) can be completed normally (200)
- [x] Non-terminal status changes (e.g., `backlog` -> `in_progress`) are not blocked even with incomplete children (200)
- [x] All 40 tests pass (34 existing + 6 new)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)