### PR TITLE
feat: add Honesty Gate verification checklist for task completion

### DIFF
--- a/apps/cli/__tests__/task-cmd.test.ts
+++ b/apps/cli/__tests__/task-cmd.test.ts
@@ -128,6 +128,69 @@ describe('task CLI command — API integration', () => {
   it('complete task via PATCH status=done', async () => {
     const task = await createTask(app, companyId, { title: 'Completable Task' })
 
+    // No honesty checklist configured — should complete directly
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow }
+    expect(body.data.status).toBe('done')
+  })
+
+  it('honesty gate blocks completion when checklist is incomplete', async () => {
+    const task = await createTask(app, companyId, { title: 'Gated Task' })
+
+    // Set a checklist on the task with unchecked items
+    const checklistRes = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}/checklist`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: [
+            { label: 'Code compiles', checked: false },
+            { label: 'Tests pass', checked: false },
+          ],
+        }),
+      },
+    )
+    expect(checklistRes.status).toBe(200)
+
+    // Attempt to complete — should be blocked
+    const blocked = await app.request(
+      `/api/companies/${companyId}/issues/${task.id}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      },
+    )
+    expect(blocked.status).toBe(400)
+    const blockedBody = (await blocked.json()) as { error: string; unchecked_items: string[] }
+    expect(blockedBody.error).toBe('Honesty gate check failed')
+    expect(blockedBody.unchecked_items).toHaveLength(2)
+
+    // Complete the checklist
+    await app.request(
+      `/api/companies/${companyId}/issues/${task.id}/checklist`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: [
+            { label: 'Code compiles', checked: true },
+            { label: 'Tests pass', checked: true },
+          ],
+        }),
+      },
+    )
+
+    // Now completing should succeed
     const res = await app.request(
       `/api/companies/${companyId}/issues/${task.id}`,
       {

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -5,10 +5,10 @@
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
 import type { Issue } from '@shackleai/shared'
-import { CreateIssueInput, UpdateIssueInput, DelegateIssueInput } from '@shackleai/shared'
+import { CreateIssueInput, UpdateIssueInput, DelegateIssueInput, UpdateChecklistInput } from '@shackleai/shared'
 import { IssueStatus, TriggerType } from '@shackleai/shared'
 import type { Scheduler } from '@shackleai/core'
-import { DelegationService, DelegationError, rollUpParentStatus } from '@shackleai/core'
+import { DelegationService, DelegationError, rollUpParentStatus, checkHonestyGate } from '@shackleai/core'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
 import { parsePagination } from '../pagination.js'
@@ -75,7 +75,7 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
       return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
     }
 
-    const { title, description, parent_id, goal_id, project_id, status, priority, assignee_agent_id } =
+    const { title, description, parent_id, goal_id, project_id, status, priority, assignee_agent_id, honesty_checklist } =
       parsed.data
 
     // Atomically increment company issue_counter and get prefix + new counter value
@@ -95,8 +95,8 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
     const result = await db.query<Issue>(
       `INSERT INTO issues
          (company_id, identifier, issue_number, title, description, parent_id,
-          goal_id, project_id, status, priority, assignee_agent_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          goal_id, project_id, status, priority, assignee_agent_id, honesty_checklist)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         companyId,
@@ -110,6 +110,7 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
         status,
         priority,
         assignee_agent_id ?? null,
+        honesty_checklist ? JSON.stringify(honesty_checklist) : null,
       ],
     )
 
@@ -247,8 +248,30 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
       }
     }
 
+    // Honesty Gate: if transitioning to "done", verify checklist is complete
+    if (updates.status === IssueStatus.Done) {
+      const gate = await checkHonestyGate(db, issueId!, companyId!)
+      if (!gate.passed) {
+        return c.json(
+          {
+            error: 'Honesty gate check failed',
+            reason: gate.reason,
+            unchecked_items: gate.uncheckedItems ?? [],
+          },
+          400,
+        )
+      }
+    }
+
     const setClauses = fields.map((f, i) => `${f} = $${i + 3}`).join(', ')
-    const values = fields.map((f) => updates[f])
+    const values = fields.map((f) => {
+      const val = updates[f]
+      // Serialize arrays/objects to JSON for JSONB columns
+      if (f === 'honesty_checklist' && val !== null && val !== undefined) {
+        return JSON.stringify(val)
+      }
+      return val
+    })
 
     const result = await db.query<Issue>(
       `UPDATE issues SET ${setClauses}, updated_at = NOW()
@@ -379,6 +402,43 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
       }
       throw err
     }
+  })
+
+
+  // PUT /api/companies/:id/issues/:issueId/checklist -- set or update honesty checklist
+  app.put('/:id/issues/:issueId/checklist', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue exists and belongs to company
+    const existing = await db.query<Pick<Issue, 'id'>>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = UpdateChecklistInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const result = await db.query<Issue>(
+      `UPDATE issues SET honesty_checklist = $1, updated_at = NOW()
+       WHERE id = $2 AND company_id = $3
+       RETURNING *`,
+      [JSON.stringify(parsed.data.items), issueId, companyId],
+    )
+
+    return c.json({ data: result.rows[0] })
   })
 
   return app

--- a/packages/core/src/honesty-gate.ts
+++ b/packages/core/src/honesty-gate.ts
@@ -1,0 +1,114 @@
+/**
+ * Honesty Gate — verifies an issue's checklist is fully checked before
+ * allowing status transition to "done".
+ *
+ * Used by both the heartbeat executor (agent-driven completion) and the
+ * API route (manual/external completion).
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+
+export interface HonestyChecklistItem {
+  label: string
+  checked: boolean
+}
+
+export interface HonestyGateResult {
+  passed: boolean
+  /** Present when the gate blocks completion. */
+  reason?: string
+  /** Unchecked items, if any. */
+  uncheckedItems?: string[]
+}
+
+/**
+ * Check whether an issue passes the honesty gate for completion.
+ *
+ * Rules:
+ * 1. If the issue has an explicit honesty_checklist, ALL items must be checked.
+ * 2. If the issue has no checklist, fall back to the company's default_honesty_checklist.
+ *    If a company default exists, it is auto-applied (all items unchecked) and the gate blocks.
+ * 3. If neither exists, the gate passes (no checklist configured).
+ */
+export async function checkHonestyGate(
+  db: DatabaseProvider,
+  issueId: string,
+  companyId: string,
+): Promise<HonestyGateResult> {
+  // Load the issue's checklist
+  const issueResult = await db.query<{ honesty_checklist: HonestyChecklistItem[] | null }>(
+    `SELECT honesty_checklist FROM issues WHERE id = $1 AND company_id = $2`,
+    [issueId, companyId],
+  )
+
+  if (issueResult.rows.length === 0) {
+    return { passed: false, reason: 'Issue not found' }
+  }
+
+  let checklist = issueResult.rows[0].honesty_checklist
+
+  // Parse if stored as string (JSONB should auto-parse, but safety net)
+  if (typeof checklist === 'string') {
+    try {
+      checklist = JSON.parse(checklist) as HonestyChecklistItem[]
+    } catch {
+      return { passed: false, reason: 'Invalid honesty_checklist format on issue' }
+    }
+  }
+
+  // If no issue-level checklist, check company defaults
+  if (!checklist || checklist.length === 0) {
+    const companyResult = await db.query<{ default_honesty_checklist: string[] | null }>(
+      `SELECT default_honesty_checklist FROM companies WHERE id = $1`,
+      [companyId],
+    )
+
+    const companyDefaults = companyResult.rows[0]?.default_honesty_checklist
+
+    // Parse if stored as string
+    let defaults: string[] | null = null
+    if (typeof companyDefaults === 'string') {
+      try {
+        defaults = JSON.parse(companyDefaults) as string[]
+      } catch {
+        defaults = null
+      }
+    } else {
+      defaults = companyDefaults
+    }
+
+    if (!defaults || defaults.length === 0) {
+      // No checklist configured anywhere — gate passes
+      return { passed: true }
+    }
+
+    // Auto-apply company defaults to the issue (all unchecked)
+    const defaultChecklist: HonestyChecklistItem[] = defaults.map((label) => ({
+      label,
+      checked: false,
+    }))
+
+    await db.query(
+      `UPDATE issues SET honesty_checklist = $1, updated_at = NOW() WHERE id = $2`,
+      [JSON.stringify(defaultChecklist), issueId],
+    )
+
+    return {
+      passed: false,
+      reason: 'Honesty checklist not completed — company defaults applied',
+      uncheckedItems: defaults,
+    }
+  }
+
+  // Verify all items are checked
+  const unchecked = checklist.filter((item) => !item.checked)
+  if (unchecked.length > 0) {
+    return {
+      passed: false,
+      reason: `Honesty checklist incomplete: ${unchecked.length} item(s) unchecked`,
+      uncheckedItems: unchecked.map((item) => item.label),
+    }
+  }
+
+  return { passed: true }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,3 +57,7 @@ export { DelegationService, DelegationError, rollUpParentStatus } from './delega
 
 export { SecretsManager, LogRedactor } from './secrets/index.js'
 export type { SecretRow, SecretListItem } from './secrets/index.js'
+
+
+export { checkHonestyGate } from './honesty-gate.js'
+export type { HonestyGateResult } from './honesty-gate.js'

--- a/packages/core/src/runner/executor.ts
+++ b/packages/core/src/runner/executor.ts
@@ -42,6 +42,7 @@ import { SecretsManager } from '../secrets/index.js'
 import { LogRedactor } from '../secrets/index.js'
 import { HeartbeatEventLogger } from './event-logger.js'
 import type { QuotaManager } from '../quota/index.js'
+import { checkHonestyGate } from '../honesty-gate.js'
 
 /** Default timeout in seconds. */
 const DEFAULT_TIMEOUT_S = 300
@@ -434,21 +435,58 @@ export class HeartbeatExecutor {
       // ── Step 9c: Update task status if agent reported one ──────────
       if (adapterResult.taskStatus && task) {
         try {
-          await this.db.query(
-            `UPDATE issues SET status = $1, updated_at = NOW() WHERE id = $2`,
-            [adapterResult.taskStatus, task.id],
-          )
-          this.observatory.logEvent({
-            company_id: companyId,
-            entity_type: 'issue',
-            entity_id: task.id,
-            actor_type: 'agent',
-            actor_id: agentId,
-            action: `task_${adapterResult.taskStatus}`,
-            changes: { title: task.title, newStatus: adapterResult.taskStatus },
-          })
+          // Honesty Gate: if agent is marking task as done, verify checklist first
+          if (adapterResult.taskStatus === 'done') {
+            const gate = await checkHonestyGate(this.db, task.id, companyId)
+            if (!gate.passed) {
+              this.observatory.logEvent({
+                company_id: companyId,
+                entity_type: 'issue',
+                entity_id: task.id,
+                actor_type: 'agent',
+                actor_id: agentId,
+                action: 'honesty_gate_blocked',
+                changes: {
+                  title: task.title,
+                  reason: gate.reason,
+                  uncheckedItems: gate.uncheckedItems ?? [],
+                },
+              })
+              events.emit('error', {
+                message: `Honesty gate blocked task completion: ${gate.reason}`,
+              })
+            } else {
+              await this.db.query(
+                `UPDATE issues SET status = $1, updated_at = NOW() WHERE id = $2`,
+                [adapterResult.taskStatus, task.id],
+              )
+              this.observatory.logEvent({
+                company_id: companyId,
+                entity_type: 'issue',
+                entity_id: task.id,
+                actor_type: 'agent',
+                actor_id: agentId,
+                action: `task_${adapterResult.taskStatus}`,
+                changes: { title: task.title, newStatus: adapterResult.taskStatus },
+              })
+            }
+          } else {
+            await this.db.query(
+              `UPDATE issues SET status = $1, updated_at = NOW() WHERE id = $2`,
+              [adapterResult.taskStatus, task.id],
+            )
+            this.observatory.logEvent({
+              company_id: companyId,
+              entity_type: 'issue',
+              entity_id: task.id,
+              actor_type: 'agent',
+              actor_id: agentId,
+              action: `task_${adapterResult.taskStatus}`,
+              changes: { title: task.title, newStatus: adapterResult.taskStatus },
+            })
+          }
         } catch {
-          // Best-effort — don't fail the heartbeat for status update errors
+          // Best-effort — don’t fail the heartbeat for status update errors
         }
       }
 

--- a/packages/db/src/migrations/021_honesty_checklist.ts
+++ b/packages/db/src/migrations/021_honesty_checklist.ts
@@ -1,0 +1,9 @@
+export const name = '021_honesty_checklist'
+
+export const sql = `
+-- Add honesty checklist to issues (per-issue verification items)
+ALTER TABLE issues ADD COLUMN IF NOT EXISTS honesty_checklist JSONB DEFAULT NULL;
+
+-- Add default honesty checklist to companies (company-wide defaults)
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_honesty_checklist JSONB DEFAULT NULL;
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -19,6 +19,7 @@ import * as m017 from './017_secrets.js'
 import * as m018 from './018_agent_config_revisions.js'
 import * as m019 from './019_heartbeat_run_events.js'
 import * as m020 from './020_quota_windows.js'
+import * as m021 from './021_honesty_checklist.js'
 
 export interface Migration {
   name: string
@@ -46,6 +47,7 @@ const migrations: Migration[] = [
   m018,
   m019,
   m020,
+  m021,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -11,6 +11,7 @@ export interface Company {
   issue_counter: number
   budget_monthly_cents: number
   spent_monthly_cents: number
+  default_honesty_checklist: string[] | null
   require_approval: boolean
   created_at: Date
   updated_at: Date
@@ -34,6 +35,11 @@ export interface Agent {
   updated_at: Date
 }
 
+export interface HonestyChecklistItem {
+  label: string
+  checked: boolean
+}
+
 export interface Issue {
   id: string
   company_id: string
@@ -47,6 +53,7 @@ export interface Issue {
   status: string
   priority: string
   assignee_agent_id: string | null
+  honesty_checklist: HonestyChecklistItem[] | null
   started_at: Date | null
   completed_at: Date | null
   created_at: Date

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -44,6 +44,7 @@ export const CreateCompanyInput = z.object({
     .default(CompanyStatus.Active),
   issue_prefix: nonEmpty,
   budget_monthly_cents: z.number().int().min(0).optional().default(0),
+  default_honesty_checklist: z.array(z.string().min(1)).nullable().optional(),
 })
 export type CreateCompanyInput = z.infer<typeof CreateCompanyInput>
 
@@ -53,6 +54,7 @@ export const UpdateCompanyInput = z.object({
   status: z.enum(companyStatusValues).optional(),
   issue_prefix: nonEmpty.optional(),
   budget_monthly_cents: z.number().int().min(0).optional(),
+  default_honesty_checklist: z.array(z.string().min(1)).nullable().optional(),
 })
 export type UpdateCompanyInput = z.infer<typeof UpdateCompanyInput>
 
@@ -101,6 +103,12 @@ const issuePriorityValues = Object.values(IssuePriority) as [
   ...string[],
 ]
 
+/** A single item in an honesty checklist — label + checked state. */
+export const HonestyChecklistItemSchema = z.object({
+  label: nonEmpty,
+  checked: z.boolean().default(false),
+})
+
 export const CreateIssueInput = z.object({
   company_id: uuid,
   title: nonEmpty,
@@ -114,6 +122,7 @@ export const CreateIssueInput = z.object({
     .optional()
     .default(IssuePriority.Medium),
   assignee_agent_id: uuid.nullable().optional(),
+  honesty_checklist: z.array(HonestyChecklistItemSchema).nullable().optional(),
 })
 export type CreateIssueInput = z.infer<typeof CreateIssueInput>
 
@@ -126,6 +135,7 @@ export const UpdateIssueInput = z.object({
   status: z.enum(issueStatusValues).optional(),
   priority: z.enum(issuePriorityValues).optional(),
   assignee_agent_id: uuid.nullable().optional(),
+  honesty_checklist: z.array(HonestyChecklistItemSchema).nullable().optional(),
 })
 export type UpdateIssueInput = z.infer<typeof UpdateIssueInput>
 
@@ -142,6 +152,12 @@ export const DelegateIssueInput = z.object({
     .min(1),
 })
 export type DelegateIssueInput = z.infer<typeof DelegateIssueInput>
+
+/** Input for setting/updating an issue's honesty checklist. */
+export const UpdateChecklistInput = z.object({
+  items: z.array(HonestyChecklistItemSchema).min(1),
+})
+export type UpdateChecklistInput = z.infer<typeof UpdateChecklistInput>
 
 // ---------------------------------------------------------------------------
 // Goal


### PR DESCRIPTION
## Summary

Closes #148

- Adds an **Honesty Gate** that prevents agents from marking tasks as "done" without completing a verification checklist
- New `honesty_checklist` JSONB field on issues stores per-issue checklist items (`{label, checked}[]`)
- New `default_honesty_checklist` field on companies enables company-wide default checklists
- Gate is enforced in both the heartbeat executor (agent-driven) and the PATCH API route (manual)
- New `PUT /api/companies/:id/issues/:issueId/checklist` endpoint for setting/updating checklists
- Default is NULL (no checklist) — companies opt-in by setting their `default_honesty_checklist`

## Files Changed

| File | Change |
|------|--------|
| `packages/db/src/migrations/021_honesty_checklist.ts` | Migration adding columns |
| `packages/core/src/honesty-gate.ts` | Core gate logic (reusable) |
| `packages/core/src/runner/executor.ts` | Gate check in Step 9c |
| `apps/cli/src/server/routes/issues.ts` | Gate check in PATCH + new PUT /checklist route |
| `packages/shared/src/types.ts` | `HonestyChecklistItem` interface, updated `Issue` and `Company` |
| `packages/shared/src/validators.ts` | `HonestyChecklistItemSchema`, `UpdateChecklistInput` |
| `apps/cli/__tests__/task-cmd.test.ts` | Tests for honesty gate blocking and completion |

## Test plan

- [x] Build passes (`npx turbo build --force`)
- [x] All tests pass (2 pre-existing failures unrelated to this change)
- [x] Task without checklist completes normally (no regression)
- [x] Task with unchecked items blocked from completion (400 with details)
- [x] Task with all items checked completes successfully
- [x] PUT /checklist endpoint sets checklist items

Generated with [Claude Code](https://claude.com/claude-code)