### PR TITLE
feat: add issue labels system with CRUD and filtering

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -26,6 +26,7 @@ import { commentsRouter } from './routes/comments.js'
 import { approvalsRouter } from './routes/approvals.js'
 import { secretsRouter } from './routes/secrets.js'
 import { quotasRouter } from './routes/quotas.js'
+import { labelsRouter } from './routes/labels.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
@@ -92,6 +93,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', approvalsRouter(db))
   app.route('/api/companies', secretsRouter(db))
   app.route('/api/companies', quotasRouter(db))
+  app.route('/api/companies', labelsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/issues.ts
+++ b/apps/cli/src/server/routes/issues.ts
@@ -27,32 +27,41 @@ export function issuesRouter(db: DatabaseProvider, scheduler?: Scheduler): Hono<
   // GET /api/companies/:id/issues â€” list with filters (status, priority, assignee)
   app.get('/:id/issues', companyScope, async (c) => {
     const companyId = c.req.param('id')
-    const { status, priority, assignee } = c.req.query()
+    const { status, priority, assignee, label } = c.req.query()
 
-    const conditions: string[] = ['company_id = $1']
+    const conditions: string[] = ['i.company_id = $1']
     const params: unknown[] = [companyId]
     let paramIndex = 2
 
     if (status) {
-      conditions.push(`status = $${paramIndex++}`)
+      conditions.push(`i.status = $${paramIndex++}`)
       params.push(status)
     }
 
     if (priority) {
-      conditions.push(`priority = $${paramIndex++}`)
+      conditions.push(`i.priority = $${paramIndex++}`)
       params.push(priority)
     }
 
     if (assignee) {
-      conditions.push(`assignee_agent_id = $${paramIndex++}`)
+      conditions.push(`i.assignee_agent_id = $${paramIndex++}`)
       params.push(assignee)
+    }
+
+
+    // Filter by label name — join through issue_labels + labels
+    let joinClause = ''
+    if (label) {
+      joinClause = `INNER JOIN issue_labels il ON il.issue_id = i.id
+                     INNER JOIN labels lbl ON lbl.id = il.label_id AND lbl.name = $${paramIndex++}`
+      params.push(label)
     }
 
     const { limit, offset } = parsePagination(c)
 
     const where = conditions.join(' AND ')
     const result = await db.query<Issue>(
-      `SELECT * FROM issues WHERE ${where} ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      `SELECT i.* FROM issues i ${joinClause} WHERE ${where} ORDER BY i.created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
       [...params, limit, offset],
     )
 

--- a/apps/cli/src/server/routes/labels.ts
+++ b/apps/cli/src/server/routes/labels.ts
@@ -1,0 +1,263 @@
+/**
+ * Label CRUD + issue-label assignment routes — /api/companies/:id/labels
+ * and /api/companies/:id/issues/:issueId/labels
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Label, IssueLabel } from '@shackleai/shared'
+import { CreateLabelInput, UpdateLabelInput, AssignLabelInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function labelsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // -------------------------------------------------------------------------
+  // Label CRUD — /api/companies/:id/labels
+  // -------------------------------------------------------------------------
+
+  // GET /api/companies/:id/labels — list all labels for a company
+  app.get('/:id/labels', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    const result = await db.query<Label>(
+      `SELECT * FROM labels WHERE company_id = $1 ORDER BY name ASC`,
+      [companyId],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/labels — create a label
+  app.post('/:id/labels', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateLabelInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { name, color, description } = parsed.data
+
+    // Check for duplicate name within company
+    const existing = await db.query<{ id: string }>(
+      `SELECT id FROM labels WHERE company_id = $1 AND name = $2`,
+      [companyId, name],
+    )
+    if (existing.rows.length > 0) {
+      return c.json({ error: 'Label with this name already exists' }, 409)
+    }
+
+    const result = await db.query<Label>(
+      `INSERT INTO labels (company_id, name, color, description)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [companyId, name, color, description ?? null],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // PUT /api/companies/:id/labels/:labelId — update a label
+  app.put('/:id/labels/:labelId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const labelId = c.req.param('labelId')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = UpdateLabelInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const updates = parsed.data
+    const fields = Object.keys(updates) as (keyof typeof updates)[]
+
+    if (fields.length === 0) {
+      const result = await db.query<Label>(
+        `SELECT * FROM labels WHERE id = $1 AND company_id = $2`,
+        [labelId, companyId],
+      )
+      if (result.rows.length === 0) {
+        return c.json({ error: 'Label not found' }, 404)
+      }
+      return c.json({ data: result.rows[0] })
+    }
+
+    // If renaming, check for duplicate
+    if (updates.name) {
+      const dup = await db.query<{ id: string }>(
+        `SELECT id FROM labels WHERE company_id = $1 AND name = $2 AND id != $3`,
+        [companyId, updates.name, labelId],
+      )
+      if (dup.rows.length > 0) {
+        return c.json({ error: 'Label with this name already exists' }, 409)
+      }
+    }
+
+    const setClauses = fields.map((f, i) => `${f} = $${i + 3}`).join(', ')
+    const values = fields.map((f) => updates[f])
+
+    const result = await db.query<Label>(
+      `UPDATE labels SET ${setClauses}, updated_at = NOW()
+       WHERE id = $1 AND company_id = $2
+       RETURNING *`,
+      [labelId, companyId, ...values],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Label not found' }, 404)
+    }
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  // DELETE /api/companies/:id/labels/:labelId — delete a label (cascades junction)
+  app.delete('/:id/labels/:labelId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const labelId = c.req.param('labelId')
+
+    const result = await db.query(
+      `DELETE FROM labels WHERE id = $1 AND company_id = $2 RETURNING id`,
+      [labelId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Label not found' }, 404)
+    }
+
+    return c.json({ data: { deleted: true } })
+  })
+
+  // -------------------------------------------------------------------------
+  // Issue-label assignment — /api/companies/:id/issues/:issueId/labels
+  // -------------------------------------------------------------------------
+
+  // GET /api/companies/:id/issues/:issueId/labels — list labels on an issue
+  app.get('/:id/issues/:issueId/labels', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    // Verify issue belongs to company
+    const issueCheck = await db.query<{ id: string }>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const result = await db.query<Label>(
+      `SELECT l.* FROM labels l
+       INNER JOIN issue_labels il ON il.label_id = l.id
+       WHERE il.issue_id = $1
+       ORDER BY l.name ASC`,
+      [issueId],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/labels — assign a label to an issue
+  app.post('/:id/issues/:issueId/labels', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = AssignLabelInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { label_id } = parsed.data
+
+    // Verify issue belongs to company
+    const issueCheck = await db.query<{ id: string }>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    // Verify label belongs to same company
+    const labelCheck = await db.query<{ id: string }>(
+      `SELECT id FROM labels WHERE id = $1 AND company_id = $2`,
+      [label_id, companyId],
+    )
+    if (labelCheck.rows.length === 0) {
+      return c.json({ error: 'Label not found' }, 404)
+    }
+
+    // Check if already assigned
+    const existing = await db.query<IssueLabel>(
+      `SELECT * FROM issue_labels WHERE issue_id = $1 AND label_id = $2`,
+      [issueId, label_id],
+    )
+    if (existing.rows.length > 0) {
+      return c.json({ error: 'Label already assigned to this issue' }, 409)
+    }
+
+    await db.query(
+      `INSERT INTO issue_labels (issue_id, label_id) VALUES ($1, $2)`,
+      [issueId, label_id],
+    )
+
+    return c.json({ data: { assigned: true } }, 201)
+  })
+
+  // DELETE /api/companies/:id/issues/:issueId/labels/:labelId — remove a label from an issue
+  app.delete('/:id/issues/:issueId/labels/:labelId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+    const labelId = c.req.param('labelId')
+
+    // Verify issue belongs to company
+    const issueCheck = await db.query<{ id: string }>(
+      `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const result = await db.query(
+      `DELETE FROM issue_labels WHERE issue_id = $1 AND label_id = $2 RETURNING issue_id`,
+      [issueId, labelId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Label not assigned to this issue' }, 404)
+    }
+
+    return c.json({ data: { removed: true } })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/022_labels.ts
+++ b/packages/db/src/migrations/022_labels.ts
@@ -1,0 +1,25 @@
+export const name = '022_labels'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS labels (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id),
+  name TEXT NOT NULL,
+  color TEXT NOT NULL DEFAULT '#6b7280',
+  description TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (company_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS issue_labels (
+  issue_id UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+  label_id UUID NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (issue_id, label_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_labels_company_id ON labels(company_id);
+CREATE INDEX IF NOT EXISTS idx_issue_labels_label_id ON issue_labels(label_id);
+CREATE INDEX IF NOT EXISTS idx_issue_labels_issue_id ON issue_labels(issue_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -20,6 +20,7 @@ import * as m018 from './018_agent_config_revisions.js'
 import * as m019 from './019_heartbeat_run_events.js'
 import * as m020 from './020_quota_windows.js'
 import * as m021 from './021_honesty_checklist.js'
+import * as m022 from './022_labels.js'
 
 export interface Migration {
   name: string
@@ -48,6 +49,7 @@ const migrations: Migration[] = [
   m019,
   m020,
   m021,
+  m022,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -306,3 +306,19 @@ export interface QuotaStatus {
   current_tokens: number
   exceeded: boolean
 }
+
+export interface Label {
+  id: string
+  company_id: string
+  name: string
+  color: string
+  description: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface IssueLabel {
+  issue_id: string
+  label_id: string
+  created_at: Date
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -382,3 +382,29 @@ export const CreateQuotaWindowInput = z.object({
   max_tokens: z.number().int().min(1).nullable().optional(),
 })
 export type CreateQuotaWindowInput = z.infer<typeof CreateQuotaWindowInput>
+
+// ---------------------------------------------------------------------------
+// Label
+// ---------------------------------------------------------------------------
+
+/** Valid CSS hex color (3 or 6 digit). */
+const hexColor = z.string().regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, 'Must be a valid hex color (e.g. #ff0000)')
+
+export const CreateLabelInput = z.object({
+  name: nonEmpty,
+  color: hexColor.optional().default('#6b7280'),
+  description: z.string().nullable().optional(),
+})
+export type CreateLabelInput = z.infer<typeof CreateLabelInput>
+
+export const UpdateLabelInput = z.object({
+  name: nonEmpty.optional(),
+  color: hexColor.optional(),
+  description: z.string().nullable().optional(),
+})
+export type UpdateLabelInput = z.infer<typeof UpdateLabelInput>
+
+export const AssignLabelInput = z.object({
+  label_id: uuid,
+})
+export type AssignLabelInput = z.infer<typeof AssignLabelInput>

--- a/tests/e2e/labels.test.ts
+++ b/tests/e2e/labels.test.ts
@@ -1,0 +1,379 @@
+/**
+ * E2E: Label CRUD + Issue Label Assignment + Label Filtering
+ *
+ * Tests the full label lifecycle:
+ *   company -> label CRUD -> issue-label assignment -> issue list filtering by label
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../../apps/cli/src/server/index.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type LabelRow = {
+  id: string
+  company_id: string
+  name: string
+  color: string
+  description: string | null
+}
+
+type IssueRow = {
+  id: string
+  identifier: string
+  title: string
+  status: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let db: PGliteProvider
+let app: ReturnType<typeof createApp>
+let companyId: string
+
+async function createCompany(name = 'Label Corp'): Promise<string> {
+  const res = await app.request('/api/companies', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      issue_prefix: 'LBL',
+    }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: { id: string } }
+  return body.data.id
+}
+
+async function createIssue(title: string): Promise<IssueRow> {
+  const res = await app.request(`/api/companies/${companyId}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: IssueRow }
+  return body.data
+}
+
+async function createLabel(
+  name: string,
+  color = '#ff0000',
+  description?: string,
+): Promise<LabelRow> {
+  const res = await app.request(`/api/companies/${companyId}/labels`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, color, description }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { data: LabelRow }
+  return body.data
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  db = new PGliteProvider()
+  await runMigrations(db)
+  app = createApp(db, { skipAuth: true })
+  companyId = await createCompany()
+})
+
+afterAll(async () => {
+  await db.close()
+})
+
+// ---------------------------------------------------------------------------
+// Label CRUD
+// ---------------------------------------------------------------------------
+
+describe('Label CRUD', () => {
+  it('creates a label with defaults', async () => {
+    const res = await app.request(`/api/companies/${companyId}/labels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'bug' }),
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: LabelRow }
+    expect(body.data.name).toBe('bug')
+    expect(body.data.color).toBe('#6b7280') // default color
+    expect(body.data.company_id).toBe(companyId)
+  })
+
+  it('creates a label with custom color and description', async () => {
+    const label = await createLabel('feature', '#00ff00', 'New feature requests')
+    expect(label.name).toBe('feature')
+    expect(label.color).toBe('#00ff00')
+    expect(label.description).toBe('New feature requests')
+  })
+
+  it('rejects duplicate label names within a company', async () => {
+    await createLabel('duplicate-test', '#aabbcc')
+    const res = await app.request(`/api/companies/${companyId}/labels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'duplicate-test', color: '#112233' }),
+    })
+    expect(res.status).toBe(409)
+  })
+
+  it('rejects invalid hex color', async () => {
+    const res = await app.request(`/api/companies/${companyId}/labels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'bad-color', color: 'red' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('lists all labels for a company', async () => {
+    const res = await app.request(`/api/companies/${companyId}/labels`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: LabelRow[] }
+    expect(body.data.length).toBeGreaterThanOrEqual(2)
+    // Should be ordered by name
+    const names = body.data.map((l) => l.name)
+    const sorted = [...names].sort()
+    expect(names).toEqual(sorted)
+  })
+
+  it('updates a label', async () => {
+    const label = await createLabel('to-update', '#111111')
+    const res = await app.request(
+      `/api/companies/${companyId}/labels/${label.id}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'updated-label', color: '#222222' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: LabelRow }
+    expect(body.data.name).toBe('updated-label')
+    expect(body.data.color).toBe('#222222')
+  })
+
+  it('returns 404 when updating non-existent label', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/labels/00000000-0000-0000-0000-000000000000`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'ghost' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('deletes a label', async () => {
+    const label = await createLabel('to-delete', '#333333')
+    const res = await app.request(
+      `/api/companies/${companyId}/labels/${label.id}`,
+      {
+        method: 'DELETE',
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { deleted: boolean } }
+    expect(body.data.deleted).toBe(true)
+
+    // Verify gone
+    const listRes = await app.request(`/api/companies/${companyId}/labels`)
+    const listBody = (await listRes.json()) as { data: LabelRow[] }
+    expect(listBody.data.find((l) => l.id === label.id)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-Label Assignment
+// ---------------------------------------------------------------------------
+
+describe('Issue-Label Assignment', () => {
+  let issue: IssueRow
+  let label: LabelRow
+
+  beforeAll(async () => {
+    issue = await createIssue('Test issue for labels')
+    label = await createLabel('assign-test', '#444444')
+  })
+
+  it('assigns a label to an issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label_id: label.id }),
+      },
+    )
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: { assigned: boolean } }
+    expect(body.data.assigned).toBe(true)
+  })
+
+  it('rejects duplicate assignment', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label_id: label.id }),
+      },
+    )
+    expect(res.status).toBe(409)
+  })
+
+  it('lists labels on an issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: LabelRow[] }
+    expect(body.data.length).toBe(1)
+    expect(body.data[0].id).toBe(label.id)
+  })
+
+  it('removes a label from an issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels/${label.id}`,
+      {
+        method: 'DELETE',
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { removed: boolean } }
+    expect(body.data.removed).toBe(true)
+
+    // Verify removed
+    const listRes = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels`,
+    )
+    const listBody = (await listRes.json()) as { data: LabelRow[] }
+    expect(listBody.data.length).toBe(0)
+  })
+
+  it('returns 404 for non-existent issue', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/labels`,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 for non-existent label on assign', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${issue.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          label_id: '00000000-0000-0000-0000-000000000000',
+        }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue List Filtering by Label
+// ---------------------------------------------------------------------------
+
+describe('Issue Filtering by Label', () => {
+  let labelBug: LabelRow
+  let labelFeature: LabelRow
+  let issueBug: IssueRow
+  let issueFeature: IssueRow
+
+  beforeAll(async () => {
+    labelBug = await createLabel('filter-bug', '#ff0000')
+    labelFeature = await createLabel('filter-feature', '#00ff00')
+
+    issueBug = await createIssue('Bug issue')
+    issueFeature = await createIssue('Feature issue')
+    await createIssue('Unlabeled issue')
+
+    // Assign labels
+    await app.request(
+      `/api/companies/${companyId}/issues/${issueBug.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label_id: labelBug.id }),
+      },
+    )
+    await app.request(
+      `/api/companies/${companyId}/issues/${issueFeature.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label_id: labelFeature.id }),
+      },
+    )
+  })
+
+  it('filters issues by label name', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues?label=filter-bug`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.length).toBe(1)
+    expect(body.data[0].id).toBe(issueBug.id)
+  })
+
+  it('returns empty for non-existent label filter', async () => {
+    const res = await app.request(
+      `/api/companies/${companyId}/issues?label=nonexistent`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    expect(body.data.length).toBe(0)
+  })
+
+  it('returns all issues without label filter', async () => {
+    const res = await app.request(`/api/companies/${companyId}/issues`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: IssueRow[] }
+    // Should include at least our 3 created issues plus any from other tests
+    expect(body.data.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('cascades label deletion to issue_labels junction', async () => {
+    // Create a label, assign it, then delete the label
+    const tempLabel = await createLabel('cascade-test', '#999999')
+    const tempIssue = await createIssue('Cascade test issue')
+
+    await app.request(
+      `/api/companies/${companyId}/issues/${tempIssue.id}/labels`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label_id: tempLabel.id }),
+      },
+    )
+
+    // Delete the label
+    await app.request(
+      `/api/companies/${companyId}/labels/${tempLabel.id}`,
+      {
+        method: 'DELETE',
+      },
+    )
+
+    // Issue should have no labels now
+    const res = await app.request(
+      `/api/companies/${companyId}/issues/${tempIssue.id}/labels`,
+    )
+    const body = (await res.json()) as { data: LabelRow[] }
+    expect(body.data.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `labels` table and `issue_labels` junction table (migration 022) with cascade deletes and proper indexes
- Full label CRUD routes: `GET/POST/PUT/DELETE /api/companies/:id/labels` with Zod validation, duplicate name protection, and hex color validation
- Issue-label assignment routes: `GET/POST/DELETE /api/companies/:id/issues/:issueId/labels` with cross-company security checks
- Label filter on issue list endpoint via `?label=bug` query parameter using JOIN-based filtering
- Shared types (`Label`, `IssueLabel`) and validators (`CreateLabelInput`, `UpdateLabelInput`, `AssignLabelInput`) in `@shackleai/shared`

## Test plan
- [x] 18 E2E tests passing: label CRUD, assignment, duplicate rejection, cascade deletion, issue filtering
- [x] `pnpm build` passes
- [x] `pnpm lint` passes

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)