### PR TITLE
fix: eliminate N+1 API calls in worktree list command

### DIFF
--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -11,7 +11,11 @@ interface ApiResponse<T> {
   error?: string
 }
 
-function formatWorktreeTable(worktrees: AgentWorktree[]): void {
+interface WorktreeWithAgent extends AgentWorktree {
+  agent_name?: string
+}
+
+function formatWorktreeTable(worktrees: WorktreeWithAgent[]): void {
   if (worktrees.length === 0) {
     console.log('No worktrees found.')
     return
@@ -19,7 +23,7 @@ function formatWorktreeTable(worktrees: AgentWorktree[]): void {
 
   const rows = worktrees.map((w) => ({
     ID: w.id.slice(0, 8),
-    Agent: w.agent_id.slice(0, 8),
+    Agent: w.agent_name ?? w.agent_id.slice(0, 8),
     Branch: w.branch,
     Base: w.base_branch,
     Status: w.status,
@@ -51,30 +55,16 @@ async function listWorktrees(options: { agent?: string }): Promise<void> {
     return
   }
 
-  // List all worktrees across all agents — fetch agents first, then their worktrees
-  const agentsRes = await apiClient(`/api/companies/${companyId}/agents`)
-  if (!agentsRes.ok) {
-    const body = (await agentsRes.json()) as ApiResponse<never>
-    console.error(`Error: ${body.error ?? agentsRes.statusText}`)
+  // List all worktrees across all agents — single company-level query
+  const res = await apiClient(`/api/companies/${companyId}/worktrees`)
+  if (!res.ok) {
+    const body = (await res.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? res.statusText}`)
     process.exit(1)
   }
 
-  const agentsBody = (await agentsRes.json()) as ApiResponse<
-    { id: string }[]
-  >
-  const allWorktrees: AgentWorktree[] = []
-
-  for (const agent of agentsBody.data) {
-    const res = await apiClient(
-      `/api/companies/${companyId}/agents/${agent.id}/worktrees`,
-    )
-    if (res.ok) {
-      const body = (await res.json()) as ApiResponse<AgentWorktree[]>
-      allWorktrees.push(...body.data)
-    }
-  }
-
-  formatWorktreeTable(allWorktrees)
+  const body = (await res.json()) as ApiResponse<WorktreeWithAgent[]>
+  formatWorktreeTable(body.data)
 }
 
 async function createWorktree(

--- a/apps/cli/src/server/routes/worktrees.ts
+++ b/apps/cli/src/server/routes/worktrees.ts
@@ -1,11 +1,11 @@
 /**
  * Worktree CRUD routes — /api/companies/:id/agents/:agentId/worktrees
- * and /api/companies/:id/worktrees/cleanup
+ * and /api/companies/:id/worktrees, /api/companies/:id/worktrees/cleanup
  */
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
-import type { Agent } from '@shackleai/shared'
+import type { Agent, AgentWorktree } from '@shackleai/shared'
 import {
   CreateWorktreeInput,
   WorktreeCleanupInput,
@@ -161,6 +161,24 @@ export function worktreesRouter(
       }
     },
   )
+
+  // GET /api/companies/:id/worktrees — list ALL worktrees for the company (single query)
+  app.get('/:id/worktrees', companyScope, async (c) => {
+    const companyId = c.req.param('id') as string
+    const { limit, offset } = parsePagination(c)
+
+    const result = await db.query<AgentWorktree & { agent_name: string }>(
+      `SELECT w.*, a.name AS agent_name
+       FROM agent_worktrees w
+       LEFT JOIN agents a ON a.id = w.agent_id
+       WHERE w.company_id = $1
+       ORDER BY w.created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
+    )
+
+    return c.json({ data: result.rows })
+  })
 
   // POST /api/companies/:id/worktrees/cleanup — trigger cleanup
   app.post('/:id/worktrees/cleanup', companyScope, async (c) => {


### PR DESCRIPTION
## Summary

- Add `GET /api/companies/:id/worktrees` endpoint that returns all worktrees for a company in a single SQL query with a JOIN to the agents table (includes `agent_name`)
- Update CLI `worktree list` command to call the new company-level endpoint instead of fetching all agents then looping per-agent (N+1 pattern)
- Existing per-agent endpoint `GET /api/companies/:id/agents/:agentId/worktrees` is kept for backward compatibility

**Before:** 1 call to fetch agents + N calls (one per agent) = N+1 API calls
**After:** 1 API call with a single SQL JOIN query

Closes #89

## Test plan

- [ ] Verify `shackleai worktree list` returns all worktrees with agent names
- [ ] Verify `shackleai worktree list --agent <id>` still works (per-agent endpoint unchanged)
- [ ] Verify `GET /api/companies/:id/worktrees` returns worktrees with `agent_name` field
- [ ] Verify pagination (`?limit=10&offset=0`) works on the new endpoint

Generated with [Claude Code](https://claude.com/claude-code)