### PR TITLE
feat: add company templates for pre-built org structures

### DIFF
--- a/apps/cli/__tests__/templates.test.ts
+++ b/apps/cli/__tests__/templates.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGliteProvider, runMigrations } from '@shackleai/db'
+import { createApp } from '../src/server/index.js'
+import type { Company, Agent, Goal, Policy, CompanyTemplate, TemplateSummary } from '@shackleai/shared'
+
+interface ApiResponse<T> {
+  data: T
+  error?: string
+}
+
+describe('template routes', () => {
+  let db: PGliteProvider
+  let app: ReturnType<typeof createApp>
+
+  beforeAll(async () => {
+    db = new PGliteProvider()
+    await runMigrations(db)
+    app = createApp(db, { skipAuth: true })
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /api/templates
+  // -------------------------------------------------------------------------
+
+  it('GET /api/templates returns built-in templates', async () => {
+    const res = await app.request('/api/templates')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ApiResponse<TemplateSummary[]>
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(body.data.length).toBeGreaterThanOrEqual(2)
+
+    const slugs = body.data.map((t) => t.slug)
+    expect(slugs).toContain('software-team')
+    expect(slugs).toContain('startup')
+  })
+
+  it('GET /api/templates lists template metadata', async () => {
+    const res = await app.request('/api/templates')
+    const body = (await res.json()) as ApiResponse<TemplateSummary[]>
+
+    const swTeam = body.data.find((t) => t.slug === 'software-team')
+    expect(swTeam).toBeDefined()
+    expect(swTeam!.name).toBe('Software Team')
+    expect(swTeam!.agent_count).toBe(4)
+    expect(swTeam!.goal_count).toBe(2)
+    expect(swTeam!.policy_count).toBe(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /api/templates/:slug
+  // -------------------------------------------------------------------------
+
+  it('GET /api/templates/:slug returns a specific template', async () => {
+    const res = await app.request('/api/templates/startup')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ApiResponse<CompanyTemplate>
+    expect(body.data.name).toBe('Startup')
+    expect(body.data.agents).toHaveLength(3)
+  })
+
+  it('GET /api/templates/:slug returns 404 for unknown slug', async () => {
+    const res = await app.request('/api/templates/nonexistent')
+    expect(res.status).toBe(404)
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /api/companies/:id/import-template — by slug
+  // -------------------------------------------------------------------------
+
+  it('POST import-template creates agents, goals, policies from built-in slug', async () => {
+    // Create a company first
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Template Test Co', issue_prefix: 'TTC' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    // Import the software-team template
+    const importRes = await app.request(
+      `/api/companies/${company.id}/import-template`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: 'software-team' }),
+      },
+    )
+    expect(importRes.status).toBe(201)
+
+    const importBody = (await importRes.json()) as ApiResponse<{
+      agents_created: number
+      goals_created: number
+      policies_created: number
+      agents: Agent[]
+      goals: Goal[]
+      policies: Policy[]
+    }>
+
+    expect(importBody.data.agents_created).toBe(4)
+    expect(importBody.data.goals_created).toBe(2)
+    expect(importBody.data.policies_created).toBe(2)
+
+    // Verify agents were actually created in the DB
+    const agentsRes = await app.request(`/api/companies/${company.id}/agents`)
+    const agentsBody = (await agentsRes.json()) as ApiResponse<Agent[]>
+    expect(agentsBody.data).toHaveLength(4)
+
+    // Verify reports_to was resolved correctly
+    const pm = agentsBody.data.find((a) => a.name === 'Product Manager')
+    const fe = agentsBody.data.find((a) => a.name === 'Frontend Engineer')
+    expect(pm).toBeDefined()
+    expect(fe).toBeDefined()
+    expect(fe!.reports_to).toBe(pm!.id)
+  })
+
+  it('POST import-template returns 404 for unknown slug', async () => {
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Slug404 Co', issue_prefix: 'S4C' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    const importRes = await app.request(
+      `/api/companies/${company.id}/import-template`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: 'nonexistent-template' }),
+      },
+    )
+    expect(importRes.status).toBe(404)
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /api/companies/:id/import-template — inline JSON
+  // -------------------------------------------------------------------------
+
+  it('POST import-template accepts inline template JSON', async () => {
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Inline Co', issue_prefix: 'INL' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    const inlineTemplate = {
+      name: 'Custom Team',
+      description: 'A custom two-agent team',
+      version: '1.0.0',
+      agents: [
+        {
+          name: 'Lead',
+          role: 'manager',
+          adapter_type: 'process',
+        },
+        {
+          name: 'Dev',
+          role: 'worker',
+          adapter_type: 'process',
+          reports_to: 'Lead',
+        },
+      ],
+      goals: [
+        {
+          title: 'Ship the product',
+          level: 'strategic',
+          owner_agent_name: 'Lead',
+        },
+      ],
+      policies: [],
+    }
+
+    const importRes = await app.request(
+      `/api/companies/${company.id}/import-template`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(inlineTemplate),
+      },
+    )
+    expect(importRes.status).toBe(201)
+
+    const body = (await importRes.json()) as ApiResponse<{
+      agents_created: number
+      goals_created: number
+      agents: Agent[]
+      goals: Goal[]
+    }>
+    expect(body.data.agents_created).toBe(2)
+    expect(body.data.goals_created).toBe(1)
+
+    // Verify reports_to resolved
+    const lead = body.data.agents.find((a) => a.name === 'Lead')
+    const dev = body.data.agents.find((a) => a.name === 'Dev')
+    expect(dev!.reports_to).toBe(lead!.id)
+
+    // Verify goal owner resolved
+    expect(body.data.goals[0].owner_agent_id).toBe(lead!.id)
+  })
+
+  it('POST import-template returns 400 for invalid template', async () => {
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Bad Template Co', issue_prefix: 'BTC' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    const importRes = await app.request(
+      `/api/companies/${company.id}/import-template`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Missing agents', version: '1.0.0' }),
+      },
+    )
+    expect(importRes.status).toBe(400)
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /api/companies/:id/export-template
+  // -------------------------------------------------------------------------
+
+  it('POST export-template exports company as ID-free template', async () => {
+    // Create a company with some agents
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Export Co', issue_prefix: 'EXP' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    // Import a template so we have data to export
+    await app.request(`/api/companies/${company.id}/import-template`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'startup' }),
+    })
+
+    // Export it
+    const exportRes = await app.request(
+      `/api/companies/${company.id}/export-template`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'My Exported Template',
+          description: 'Exported from Export Co',
+        }),
+      },
+    )
+    expect(exportRes.status).toBe(200)
+
+    const body = (await exportRes.json()) as ApiResponse<CompanyTemplate>
+    const tmpl = body.data
+
+    expect(tmpl.name).toBe('My Exported Template')
+    expect(tmpl.description).toBe('Exported from Export Co')
+    expect(tmpl.agents).toHaveLength(3)
+    expect(tmpl.goals).toHaveLength(2)
+    expect(tmpl.policies).toHaveLength(2)
+
+    // Verify IDs are scrubbed — reports_to should be a name, not a UUID
+    const cto = tmpl.agents.find((a) => a.name === 'CTO')
+    expect(cto).toBeDefined()
+    expect(cto!.reports_to).toBe('CEO')
+
+    // Verify goal owner is a name
+    const goal = tmpl.goals!.find((g) => g.title === 'Achieve product-market fit')
+    expect(goal).toBeDefined()
+    expect(goal!.owner_agent_name).toBe('CEO')
+  })
+
+  it('POST export-template uses company name as default template name', async () => {
+    const createRes = await app.request('/api/companies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Default Name Co', issue_prefix: 'DNC' }),
+    })
+    const company = ((await createRes.json()) as ApiResponse<Company>).data
+
+    // Export without specifying name
+    const exportRes = await app.request(
+      `/api/companies/${company.id}/export-template`,
+      { method: 'POST' },
+    )
+    expect(exportRes.status).toBe(200)
+
+    const body = (await exportRes.json()) as ApiResponse<CompanyTemplate>
+    expect(body.data.name).toBe('Default Name Co')
+  })
+})

--- a/apps/cli/src/commands/company.ts
+++ b/apps/cli/src/commands/company.ts
@@ -5,6 +5,7 @@
 import type { Command } from 'commander'
 import * as p from '@clack/prompts'
 import type { Company } from '@shackleai/shared'
+import type { TemplateImportResult } from '@shackleai/core'
 import { apiClient, getCompanyId } from '../api-client.js'
 import { readConfig, writeConfig } from '../config.js'
 
@@ -125,6 +126,97 @@ async function createCompanyInteractive(): Promise<void> {
   }
 }
 
+async function createCompanyFromTemplate(templateSlug: string): Promise<void> {
+  p.intro(`Create company from template: ${templateSlug}`)
+
+  const name = await p.text({
+    message: 'Company name',
+    placeholder: 'Acme Corp',
+    validate: (v) => {
+      if (!v.trim()) return 'Company name is required'
+      return undefined
+    },
+  })
+
+  if (p.isCancel(name)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const mission = await p.text({
+    message: 'Issue prefix',
+    placeholder: 'ACME',
+    validate: (v) => {
+      if (!v.trim()) return 'Issue prefix is required'
+      return undefined
+    },
+  })
+
+  if (p.isCancel(mission)) {
+    p.cancel('Cancelled.')
+    return
+  }
+
+  const spin = p.spinner()
+  spin.start('Creating company...')
+
+  const createRes = await apiClient('/api/companies', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: name.trim(),
+      issue_prefix: mission.trim().toUpperCase(),
+    }),
+  })
+
+  if (!createRes.ok) {
+    spin.stop('Failed to create company')
+    const body = (await createRes.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? createRes.statusText}`)
+    process.exit(1)
+  }
+
+  const companyBody = (await createRes.json()) as ApiResponse<Company>
+  const company = companyBody.data
+
+  spin.message('Importing template...')
+
+  const importRes = await apiClient(
+    `/api/companies/${company.id}/import-template`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ slug: templateSlug }),
+    },
+  )
+
+  if (!importRes.ok) {
+    spin.stop('Failed to import template')
+    const body = (await importRes.json()) as ApiResponse<never>
+    console.error(`Error: ${body.error ?? importRes.statusText}`)
+    console.error(
+      `Company "${company.name}" was created but template was not applied.`,
+    )
+    process.exit(1)
+  }
+
+  const importBody = (await importRes.json()) as ApiResponse<TemplateImportResult>
+  const result = importBody.data
+
+  spin.stop(
+    `Company created: ${company.name} (${company.id})\n` +
+      `  Agents: ${result.agents_created}, Goals: ${result.goals_created}, Policies: ${result.policies_created}`,
+  )
+
+  const shouldSwitch = await p.confirm({
+    message: 'Switch to this company now?',
+  })
+
+  if (p.isCancel(shouldSwitch)) return
+
+  if (shouldSwitch) {
+    await switchToCompany(company)
+  }
+}
+
 async function switchToCompany(company: Company): Promise<void> {
   const config = await readConfig()
   if (!config) {
@@ -209,8 +301,16 @@ export function registerCompanyCommand(program: Command): void {
   company
     .command('create')
     .description('Create a new company (interactive)')
-    .action(async () => {
-      await createCompanyInteractive()
+    .option(
+      '--template <slug>',
+      'Create from a built-in template (e.g. software-team, startup)',
+    )
+    .action(async (opts: { template?: string }) => {
+      if (opts.template) {
+        await createCompanyFromTemplate(opts.template)
+      } else {
+        await createCompanyInteractive()
+      }
     })
 
   company

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -27,6 +27,7 @@ import { approvalsRouter } from './routes/approvals.js'
 import { secretsRouter } from './routes/secrets.js'
 import { quotasRouter } from './routes/quotas.js'
 import { labelsRouter } from './routes/labels.js'
+import { templatesRouter, companyTemplatesRouter } from './routes/templates.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
@@ -77,7 +78,9 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
     })
   }
 
+  app.route('/api/templates', templatesRouter())
   app.route('/api/companies', companiesRouter(db))
+  app.route('/api/companies', companyTemplatesRouter(db))
   app.route('/api/companies', dashboardRouter(db))
   app.route('/api/companies', agentsRouter(db, options?.scheduler))
   app.route('/api/companies', issuesRouter(db, options?.scheduler))

--- a/apps/cli/src/server/routes/templates.ts
+++ b/apps/cli/src/server/routes/templates.ts
@@ -1,0 +1,128 @@
+/**
+ * Template routes — /api/templates and /api/companies/:id/import-template, /api/companies/:id/export-template
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import { CompanyTemplateInput } from '@shackleai/shared'
+import {
+  listTemplates,
+  getTemplate,
+  importTemplate,
+  exportTemplate,
+} from '@shackleai/core'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+/**
+ * Top-level template routes — mounted at /api/templates
+ * These don't require a company scope.
+ */
+export function templatesRouter(): Hono {
+  const app = new Hono()
+
+  // GET /api/templates — list all available built-in templates
+  app.get('/', (c) => {
+    const templates = listTemplates()
+    return c.json({ data: templates })
+  })
+
+  // GET /api/templates/:slug — get a specific template by slug
+  app.get('/:slug', (c) => {
+    const slug = c.req.param('slug')
+    const template = getTemplate(slug)
+
+    if (!template) {
+      return c.json({ error: `Template "${slug}" not found` }, 404)
+    }
+
+    return c.json({ data: template })
+  })
+
+  return app
+}
+
+/**
+ * Company-scoped template routes — mounted at /api/companies
+ * These require an existing company.
+ */
+export function companyTemplatesRouter(
+  db: DatabaseProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // POST /api/companies/:id/import-template — import a template into a company
+  app.post('/:id/import-template', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    // Accept either { slug: "software-team" } for built-in, or full template JSON
+    const bodyObj = body as Record<string, unknown>
+
+    let templateData: CompanyTemplateInput
+
+    if (typeof bodyObj.slug === 'string') {
+      // Load built-in template by slug
+      const builtin = getTemplate(bodyObj.slug)
+      if (!builtin) {
+        return c.json({ error: `Template "${bodyObj.slug}" not found` }, 404)
+      }
+      templateData = builtin as CompanyTemplateInput
+    } else {
+      // Parse the body as a full template
+      const parsed = CompanyTemplateInput.safeParse(body)
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Validation failed', details: parsed.error.flatten() },
+          400,
+        )
+      }
+      templateData = parsed.data
+    }
+
+    const result = await importTemplate(db, companyId as string, templateData)
+
+    return c.json({ data: result }, 201)
+  })
+
+  // POST /api/companies/:id/export-template — export current company as template
+  app.post('/:id/export-template', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const company = c.get('company')
+
+    let name = company.name
+    let description: string | undefined
+
+    try {
+      const body = (await c.req.json()) as Record<string, unknown>
+      if (typeof body.name === 'string' && body.name.trim()) {
+        name = body.name.trim()
+      }
+      if (typeof body.description === 'string') {
+        description = body.description
+      }
+    } catch {
+      // Body is optional — use company name as template name
+    }
+
+    const template = await exportTemplate(db, companyId as string, name, description)
+
+    return c.json({ data: template })
+  })
+
+  return app
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,3 +61,13 @@ export type { SecretRow, SecretListItem } from './secrets/index.js'
 
 export { checkHonestyGate } from './honesty-gate.js'
 export type { HonestyGateResult } from './honesty-gate.js'
+
+
+export {
+  listTemplates,
+  getTemplate,
+  importTemplate,
+  exportTemplate,
+  clearTemplateCache,
+} from './templates/index.js'
+export type { TemplateImportResult } from './templates/index.js'

--- a/packages/core/src/templates/builtin.ts
+++ b/packages/core/src/templates/builtin.ts
@@ -1,0 +1,163 @@
+/**
+ * Built-in company templates — inlined to avoid filesystem resolution issues
+ * when running from compiled dist/ directories.
+ */
+
+import type { CompanyTemplate } from '@shackleai/shared'
+
+export const BUILTIN_TEMPLATES: Record<string, CompanyTemplate> = {
+  'software-team': {
+    name: 'Software Team',
+    description:
+      'A standard software development team with PM, frontend, backend, and QA agents.',
+    version: '1.0.0',
+    agents: [
+      {
+        name: 'Product Manager',
+        title: 'Product Manager',
+        role: 'manager',
+        capabilities:
+          'Requirements gathering, backlog prioritization, sprint planning, stakeholder communication',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: null,
+      },
+      {
+        name: 'Frontend Engineer',
+        title: 'Frontend Engineer',
+        role: 'worker',
+        capabilities:
+          'React, TypeScript, CSS, UI components, accessibility, responsive design',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: 'Product Manager',
+      },
+      {
+        name: 'Backend Engineer',
+        title: 'Backend Engineer',
+        role: 'worker',
+        capabilities:
+          'Node.js, TypeScript, PostgreSQL, REST APIs, system design, performance optimization',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: 'Product Manager',
+      },
+      {
+        name: 'QA Engineer',
+        title: 'QA Engineer',
+        role: 'worker',
+        capabilities:
+          'Test planning, automated testing, regression testing, bug triage, quality metrics',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 3000,
+        reports_to: 'Product Manager',
+      },
+    ],
+    goals: [
+      {
+        title: 'Deliver high-quality software on schedule',
+        description:
+          'Ensure the team ships features that meet requirements with minimal defects.',
+        level: 'strategic',
+        owner_agent_name: 'Product Manager',
+      },
+      {
+        title: 'Maintain code quality standards',
+        description:
+          'Keep test coverage high and technical debt manageable.',
+        level: 'initiative',
+        owner_agent_name: 'QA Engineer',
+      },
+    ],
+    policies: [
+      {
+        name: 'Allow all tools for engineers',
+        tool_pattern: '*',
+        action: 'allow',
+        priority: 0,
+      },
+      {
+        name: 'Log deployments',
+        tool_pattern: 'deploy:*',
+        action: 'log',
+        priority: 10,
+      },
+    ],
+  },
+
+  startup: {
+    name: 'Startup',
+    description:
+      'A lean startup team with CEO, CTO, and engineer agents for rapid iteration.',
+    version: '1.0.0',
+    agents: [
+      {
+        name: 'CEO',
+        title: 'Chief Executive Officer',
+        role: 'ceo',
+        capabilities:
+          'Vision setting, strategic planning, resource allocation, stakeholder management',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: null,
+      },
+      {
+        name: 'CTO',
+        title: 'Chief Technology Officer',
+        role: 'manager',
+        capabilities:
+          'Architecture decisions, tech stack selection, engineering roadmap, code review',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: 'CEO',
+      },
+      {
+        name: 'Engineer',
+        title: 'Full-Stack Engineer',
+        role: 'worker',
+        capabilities:
+          'Full-stack development, TypeScript, React, Node.js, PostgreSQL, DevOps',
+        adapter_type: 'claude',
+        adapter_config: {},
+        budget_monthly_cents: 5000,
+        reports_to: 'CTO',
+      },
+    ],
+    goals: [
+      {
+        title: 'Achieve product-market fit',
+        description:
+          'Build and iterate on the core product to find product-market fit as fast as possible.',
+        level: 'strategic',
+        owner_agent_name: 'CEO',
+      },
+      {
+        title: 'Ship MVP in 30 days',
+        description:
+          'Deliver a minimum viable product with core features within one month.',
+        level: 'initiative',
+        owner_agent_name: 'CTO',
+      },
+    ],
+    policies: [
+      {
+        name: 'Allow all tools',
+        tool_pattern: '*',
+        action: 'allow',
+        priority: 0,
+      },
+      {
+        name: 'Deny destructive ops without CTO',
+        tool_pattern: 'deploy:production',
+        action: 'log',
+        priority: 10,
+      },
+    ],
+  },
+}

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -1,0 +1,225 @@
+/**
+ * Company templates — built-in and custom org structure templates
+ *
+ * Templates are portable, ID-free descriptions of a company's agent hierarchy,
+ * goals, and policies. When imported, the template creates all entities and
+ * resolves name-based references to real IDs.
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+import type {
+  CompanyTemplate,
+  TemplateSummary,
+  Agent,
+  Goal,
+  Policy,
+} from '@shackleai/shared'
+import { BUILTIN_TEMPLATES } from './builtin.js'
+
+/** List all available built-in templates as summaries. */
+export function listTemplates(): TemplateSummary[] {
+  const summaries: TemplateSummary[] = []
+
+  for (const [slug, template] of Object.entries(BUILTIN_TEMPLATES)) {
+    summaries.push({
+      slug,
+      name: template.name,
+      description: template.description,
+      version: template.version,
+      agent_count: template.agents.length,
+      goal_count: template.goals?.length ?? 0,
+      policy_count: template.policies?.length ?? 0,
+    })
+  }
+
+  return summaries
+}
+
+/** Get a specific built-in template by slug. */
+export function getTemplate(slug: string): CompanyTemplate | null {
+  return BUILTIN_TEMPLATES[slug] ?? null
+}
+
+/** Result of importing a template into a company. */
+export interface TemplateImportResult {
+  agents_created: number
+  goals_created: number
+  policies_created: number
+  agents: Agent[]
+  goals: Goal[]
+  policies: Policy[]
+}
+
+/**
+ * Import a template into an existing company, creating all agents, goals, and policies.
+ * Name-based references (reports_to, owner_agent_name, agent_name) are resolved to real IDs.
+ */
+export async function importTemplate(
+  db: DatabaseProvider,
+  companyId: string,
+  template: CompanyTemplate,
+): Promise<TemplateImportResult> {
+  // Phase 1: Create all agents (without reports_to -- we resolve it in phase 2)
+  const agentNameToId = new Map<string, string>()
+  const createdAgents: Agent[] = []
+
+  for (const ta of template.agents) {
+    const result = await db.query<Agent>(
+      `INSERT INTO agents
+         (company_id, name, title, role, capabilities, adapter_type, adapter_config, budget_monthly_cents)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        companyId,
+        ta.name,
+        ta.title ?? null,
+        ta.role,
+        ta.capabilities ?? null,
+        ta.adapter_type,
+        JSON.stringify(ta.adapter_config ?? {}),
+        ta.budget_monthly_cents ?? 0,
+      ],
+    )
+
+    const agent = result.rows[0]
+    agentNameToId.set(ta.name, agent.id)
+    createdAgents.push(agent)
+  }
+
+  // Phase 2: Resolve reports_to references
+  for (const ta of template.agents) {
+    if (ta.reports_to) {
+      const reportsToId = agentNameToId.get(ta.reports_to)
+      const agentId = agentNameToId.get(ta.name)
+      if (reportsToId && agentId) {
+        await db.query(
+          `UPDATE agents SET reports_to = $1, updated_at = NOW() WHERE id = $2 AND company_id = $3`,
+          [reportsToId, agentId, companyId],
+        )
+        const idx = createdAgents.findIndex((a) => a.id === agentId)
+        if (idx !== -1) {
+          createdAgents[idx] = { ...createdAgents[idx], reports_to: reportsToId }
+        }
+      }
+    }
+  }
+
+  // Phase 3: Create goals
+  const createdGoals: Goal[] = []
+  for (const tg of template.goals ?? []) {
+    const ownerAgentId = tg.owner_agent_name
+      ? agentNameToId.get(tg.owner_agent_name) ?? null
+      : null
+
+    const result = await db.query<Goal>(
+      `INSERT INTO goals (company_id, title, description, level, owner_agent_id)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [companyId, tg.title, tg.description ?? null, tg.level, ownerAgentId],
+    )
+    createdGoals.push(result.rows[0])
+  }
+
+  // Phase 4: Create policies
+  const createdPolicies: Policy[] = []
+  for (const tp of template.policies ?? []) {
+    const agentId = tp.agent_name
+      ? agentNameToId.get(tp.agent_name) ?? null
+      : null
+
+    const result = await db.query<Policy>(
+      `INSERT INTO policies
+         (company_id, agent_id, name, tool_pattern, action, priority, max_calls_per_hour)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        companyId,
+        agentId,
+        tp.name,
+        tp.tool_pattern,
+        tp.action,
+        tp.priority ?? 0,
+        tp.max_calls_per_hour ?? null,
+      ],
+    )
+    createdPolicies.push(result.rows[0])
+  }
+
+  return {
+    agents_created: createdAgents.length,
+    goals_created: createdGoals.length,
+    policies_created: createdPolicies.length,
+    agents: createdAgents,
+    goals: createdGoals,
+    policies: createdPolicies,
+  }
+}
+
+/**
+ * Export a company's current agents, goals, and policies as a template.
+ * All IDs are scrubbed -- references use names instead.
+ */
+export async function exportTemplate(
+  db: DatabaseProvider,
+  companyId: string,
+  templateName: string,
+  templateDescription?: string,
+): Promise<CompanyTemplate> {
+  const agentResult = await db.query<Agent>(
+    `SELECT * FROM agents WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+  const agents = agentResult.rows
+
+  const agentIdToName = new Map<string, string>()
+  for (const a of agents) {
+    agentIdToName.set(a.id, a.name)
+  }
+
+  const goalResult = await db.query<Goal>(
+    `SELECT * FROM goals WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+
+  const policyResult = await db.query<Policy>(
+    `SELECT * FROM policies WHERE company_id = $1 ORDER BY priority DESC, created_at ASC`,
+    [companyId],
+  )
+
+  return {
+    name: templateName,
+    description: templateDescription ?? '',
+    version: '1.0.0',
+    agents: agents.map((a) => ({
+      name: a.name,
+      title: a.title,
+      role: a.role,
+      capabilities: a.capabilities,
+      adapter_type: a.adapter_type,
+      adapter_config: a.adapter_config,
+      budget_monthly_cents: a.budget_monthly_cents,
+      reports_to: a.reports_to ? agentIdToName.get(a.reports_to) ?? null : null,
+    })),
+    goals: goalResult.rows.map((g) => ({
+      title: g.title,
+      description: g.description,
+      level: g.level,
+      owner_agent_name: g.owner_agent_id
+        ? agentIdToName.get(g.owner_agent_id) ?? null
+        : null,
+    })),
+    policies: policyResult.rows.map((p) => ({
+      name: p.name,
+      tool_pattern: p.tool_pattern,
+      action: p.action,
+      priority: p.priority,
+      max_calls_per_hour: p.max_calls_per_hour,
+      agent_name: p.agent_id ? agentIdToName.get(p.agent_id) ?? null : null,
+    })),
+  }
+}
+
+/** No-op -- kept for API compatibility. Templates are now inlined. */
+export function clearTemplateCache(): void {
+  // Templates are inlined, no cache to clear
+}

--- a/packages/core/src/templates/software-team.json
+++ b/packages/core/src/templates/software-team.json
@@ -1,0 +1,75 @@
+{
+  "name": "Software Team",
+  "description": "A standard software development team with PM, frontend, backend, and QA agents.",
+  "version": "1.0.0",
+  "agents": [
+    {
+      "name": "Product Manager",
+      "title": "Product Manager",
+      "role": "manager",
+      "capabilities": "Requirements gathering, backlog prioritization, sprint planning, stakeholder communication",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": null
+    },
+    {
+      "name": "Frontend Engineer",
+      "title": "Frontend Engineer",
+      "role": "worker",
+      "capabilities": "React, TypeScript, CSS, UI components, accessibility, responsive design",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": "Product Manager"
+    },
+    {
+      "name": "Backend Engineer",
+      "title": "Backend Engineer",
+      "role": "worker",
+      "capabilities": "Node.js, TypeScript, PostgreSQL, REST APIs, system design, performance optimization",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": "Product Manager"
+    },
+    {
+      "name": "QA Engineer",
+      "title": "QA Engineer",
+      "role": "worker",
+      "capabilities": "Test planning, automated testing, regression testing, bug triage, quality metrics",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 3000,
+      "reports_to": "Product Manager"
+    }
+  ],
+  "goals": [
+    {
+      "title": "Deliver high-quality software on schedule",
+      "description": "Ensure the team ships features that meet requirements with minimal defects.",
+      "level": "strategic",
+      "owner_agent_name": "Product Manager"
+    },
+    {
+      "title": "Maintain code quality standards",
+      "description": "Keep test coverage high and technical debt manageable.",
+      "level": "initiative",
+      "owner_agent_name": "QA Engineer"
+    }
+  ],
+  "policies": [
+    {
+      "name": "Allow all tools for engineers",
+      "tool_pattern": "*",
+      "action": "allow",
+      "priority": 0
+    },
+    {
+      "name": "Log deployments",
+      "tool_pattern": "deploy:*",
+      "action": "log",
+      "priority": 10
+    }
+  ]
+}

--- a/packages/core/src/templates/startup.json
+++ b/packages/core/src/templates/startup.json
@@ -1,0 +1,65 @@
+{
+  "name": "Startup",
+  "description": "A lean startup team with CEO, CTO, and engineer agents for rapid iteration.",
+  "version": "1.0.0",
+  "agents": [
+    {
+      "name": "CEO",
+      "title": "Chief Executive Officer",
+      "role": "ceo",
+      "capabilities": "Vision setting, strategic planning, resource allocation, stakeholder management",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": null
+    },
+    {
+      "name": "CTO",
+      "title": "Chief Technology Officer",
+      "role": "manager",
+      "capabilities": "Architecture decisions, tech stack selection, engineering roadmap, code review",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": "CEO"
+    },
+    {
+      "name": "Engineer",
+      "title": "Full-Stack Engineer",
+      "role": "worker",
+      "capabilities": "Full-stack development, TypeScript, React, Node.js, PostgreSQL, DevOps",
+      "adapter_type": "claude",
+      "adapter_config": {},
+      "budget_monthly_cents": 5000,
+      "reports_to": "CTO"
+    }
+  ],
+  "goals": [
+    {
+      "title": "Achieve product-market fit",
+      "description": "Build and iterate on the core product to find product-market fit as fast as possible.",
+      "level": "strategic",
+      "owner_agent_name": "CEO"
+    },
+    {
+      "title": "Ship MVP in 30 days",
+      "description": "Deliver a minimum viable product with core features within one month.",
+      "level": "initiative",
+      "owner_agent_name": "CTO"
+    }
+  ],
+  "policies": [
+    {
+      "name": "Allow all tools",
+      "tool_pattern": "*",
+      "action": "allow",
+      "priority": 0
+    },
+    {
+      "name": "Deny destructive ops without CTO",
+      "tool_pattern": "deploy:production",
+      "action": "log",
+      "priority": 10
+    }
+  ]
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -322,3 +322,61 @@ export interface IssueLabel {
   label_id: string
   created_at: Date
 }
+
+// ---------------------------------------------------------------------------
+// Company Templates
+// ---------------------------------------------------------------------------
+
+/** An agent definition within a template — no IDs, just configuration. */
+export interface TemplateAgent {
+  name: string
+  title?: string | null
+  role: string
+  capabilities?: string | null
+  adapter_type: string
+  adapter_config?: Record<string, unknown>
+  budget_monthly_cents?: number
+  /** Name of the agent this one reports to (resolved at import time). */
+  reports_to?: string | null
+}
+
+/** A goal definition within a template. */
+export interface TemplateGoal {
+  title: string
+  description?: string | null
+  level: string
+  /** Name of the owning agent (resolved at import time). */
+  owner_agent_name?: string | null
+}
+
+/** A policy definition within a template. */
+export interface TemplatePolicy {
+  name: string
+  tool_pattern: string
+  action: string
+  priority?: number
+  max_calls_per_hour?: number | null
+  /** Name of the agent this policy applies to (resolved at import time). null = company-wide. */
+  agent_name?: string | null
+}
+
+/** A full company template — portable, ID-free description of an org structure. */
+export interface CompanyTemplate {
+  name: string
+  description: string
+  version: string
+  agents: TemplateAgent[]
+  goals?: TemplateGoal[]
+  policies?: TemplatePolicy[]
+}
+
+/** Metadata returned when listing templates (no full content). */
+export interface TemplateSummary {
+  slug: string
+  name: string
+  description: string
+  version: string
+  agent_count: number
+  goal_count: number
+  policy_count: number
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -408,3 +408,44 @@ export const AssignLabelInput = z.object({
   label_id: uuid,
 })
 export type AssignLabelInput = z.infer<typeof AssignLabelInput>
+
+// ---------------------------------------------------------------------------
+// Company Template
+// ---------------------------------------------------------------------------
+
+const templateAgentSchema = z.object({
+  name: nonEmpty,
+  title: z.string().nullable().optional(),
+  role: z.enum(agentRoleValues).default(AgentRole.General),
+  capabilities: z.string().nullable().optional(),
+  adapter_type: z.enum(adapterTypeValues).default(AdapterType.Process),
+  adapter_config: z.record(z.string(), z.unknown()).optional().default({}),
+  budget_monthly_cents: z.number().int().min(0).optional().default(0),
+  reports_to: z.string().nullable().optional(),
+})
+
+const templateGoalSchema = z.object({
+  title: nonEmpty,
+  description: z.string().nullable().optional(),
+  level: z.enum(goalLevelValues).default(GoalLevel.Task),
+  owner_agent_name: z.string().nullable().optional(),
+})
+
+const templatePolicySchema = z.object({
+  name: nonEmpty,
+  tool_pattern: nonEmpty,
+  action: z.enum(policyActionValues).default(PolicyAction.Allow),
+  priority: z.number().int().min(0).default(0),
+  max_calls_per_hour: z.number().int().min(0).nullable().optional(),
+  agent_name: z.string().nullable().optional(),
+})
+
+export const CompanyTemplateInput = z.object({
+  name: nonEmpty,
+  description: z.string().default(''),
+  version: z.string().default('1.0.0'),
+  agents: z.array(templateAgentSchema).min(1),
+  goals: z.array(templateGoalSchema).optional().default([]),
+  policies: z.array(templatePolicySchema).optional().default([]),
+})
+export type CompanyTemplateInput = z.infer<typeof CompanyTemplateInput>


### PR DESCRIPTION
## Summary

- Adds a template system for creating companies with pre-configured agents, goals, and policies
- Ships 2 built-in templates: `software-team` (PM, Frontend, Backend, QA) and `startup` (CEO, CTO, Engineer)
- Templates use name-based references (e.g. `reports_to: "Product Manager"`) that are resolved to real UUIDs on import
- Companies can be exported as templates with all IDs scrubbed

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/templates` | List available built-in templates |
| `GET` | `/api/templates/:slug` | Get a specific template by slug |
| `POST` | `/api/companies/:id/import-template` | Import template (by slug or inline JSON) |
| `POST` | `/api/companies/:id/export-template` | Export company as portable template |

## CLI

```bash
shackleai company create --template software-team
```

## Files changed

- `packages/shared/src/types.ts` — Template type definitions
- `packages/shared/src/validators.ts` — Zod validator for template input
- `packages/core/src/templates/` — Template service (builtin.ts, index.ts, JSON files)
- `packages/core/src/index.ts` — Export template functions
- `apps/cli/src/server/routes/templates.ts` — API routes
- `apps/cli/src/server/index.ts` — Route registration
- `apps/cli/src/commands/company.ts` — CLI --template option

## Test plan

- [x] GET /api/templates returns built-in templates with correct metadata
- [x] GET /api/templates/:slug returns full template; 404 for unknown
- [x] POST import-template by slug creates agents, goals, policies
- [x] POST import-template resolves reports_to name references to IDs
- [x] POST import-template accepts inline JSON template
- [x] POST import-template returns 400 for invalid template
- [x] POST import-template returns 404 for unknown slug
- [x] POST export-template scrubs IDs and uses agent names
- [x] POST export-template defaults to company name
- [x] All 10 tests passing; existing test suite unaffected

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)