### PR TITLE
feat: add toast notifications for all user actions

### DIFF
--- a/apps/dashboard/src/components/ui/toast.tsx
+++ b/apps/dashboard/src/components/ui/toast.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, createContext, useContext } from 'react'
+import { X } from 'lucide-react'
 
 interface Toast {
   id: number
@@ -20,10 +21,14 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
   const counterRef = useRef(0)
 
+  const dismiss = useCallback((id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
   const toast = useCallback((message: string, type: 'success' | 'error' | 'info' = 'info') => {
     const id = ++counterRef.current
     setToasts(prev => [...prev, { id, message, type }])
-    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 4000)
+    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 3000)
   }, [])
 
   return (
@@ -35,7 +40,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`pointer-events-auto rounded-lg px-4 py-3 text-sm shadow-lg animate-toast-in ${
+            className={`pointer-events-auto flex items-center gap-2 rounded-lg pl-4 pr-2 py-3 text-sm shadow-lg animate-toast-in ${
               t.type === 'success'
                 ? 'bg-emerald-600 text-white'
                 : t.type === 'error'
@@ -43,7 +48,15 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
                   : 'bg-zinc-800 text-zinc-100 border border-zinc-700'
             }`}
           >
-            {t.message}
+            <span className="flex-1">{t.message}</span>
+            <button
+              type="button"
+              onClick={() => dismiss(t.id)}
+              className="shrink-0 rounded p-0.5 opacity-70 hover:opacity-100 transition-opacity"
+              aria-label="Dismiss notification"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
           </div>
         ))}
       </div>

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { useCompanyId } from '@/hooks/useCompanyId'
-import { Bot, Plus, Play, Loader2, Search } from 'lucide-react'
+import { useDebounce } from '@/hooks/useDebounce'
+import { Bot, Plus, Play, Loader2, Search, X } from 'lucide-react'
 import {
   Table,
   TableBody,
@@ -368,6 +369,10 @@ function AgentActions({ companyId, agent }: { companyId: string; agent: Agent })
     mutationFn: () => pauseAgent(companyId, agent.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', companyId] })
+      toast('Agent paused', 'info')
+    },
+    onError: (err: Error) => {
+      toast(`Failed to pause agent: ${err.message}`, 'error')
     },
   })
 
@@ -375,6 +380,10 @@ function AgentActions({ companyId, agent }: { companyId: string; agent: Agent })
     mutationFn: () => resumeAgent(companyId, agent.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', companyId] })
+      toast('Agent resumed', 'success')
+    },
+    onError: (err: Error) => {
+      toast(`Failed to resume agent: ${err.message}`, 'error')
     },
   })
 
@@ -382,6 +391,11 @@ function AgentActions({ companyId, agent }: { companyId: string; agent: Agent })
     mutationFn: () => terminateAgent(companyId, agent.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', companyId] })
+      setConfirmingTerminate(false)
+      toast('Agent terminated', 'info')
+    },
+    onError: (err: Error) => {
+      toast(`Failed to terminate agent: ${err.message}`, 'error')
       setConfirmingTerminate(false)
     },
   })

--- a/apps/dashboard/src/pages/task-detail.tsx
+++ b/apps/dashboard/src/pages/task-detail.tsx
@@ -18,6 +18,7 @@ import {
   type Agent,
 } from '@/lib/api'
 import { formatDate, formatRelativeTime } from '@/lib/utils'
+import { useToast } from '@/components/ui/toast'
 
 const STATUS_OPTIONS = [
   { value: 'backlog', label: 'Backlog' },
@@ -87,6 +88,7 @@ function AddCommentForm({
   issueId: string
 }) {
   const queryClient = useQueryClient()
+  const { toast } = useToast()
   const [body, setBody] = useState('')
 
   const mutation = useMutation({
@@ -94,6 +96,10 @@ function AddCommentForm({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', companyId, issueId] })
       setBody('')
+      toast('Comment added', 'success')
+    },
+    onError: (err: Error) => {
+      toast(`Failed to add comment: ${err.message}`, 'error')
     },
   })
 
@@ -280,10 +286,24 @@ export function TaskDetailPage() {
     enabled: !!companyId,
   })
 
+  const { toast } = useToast()
+
   const updateMutation = useMutation({
     mutationFn: (data: Partial<Issue>) => updateIssue(companyId!, taskId!, data),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['task', companyId, taskId] })
+      const field = Object.keys(variables)[0]
+      const labels: Record<string, string> = {
+        title: 'Title updated',
+        description: 'Description updated',
+        status: 'Status updated',
+        priority: 'Priority updated',
+        assignee_agent_id: 'Assignee updated',
+      }
+      toast(labels[field] ?? 'Task updated', 'success')
+    },
+    onError: (err: Error) => {
+      toast(`Failed to update task: ${err.message}`, 'error')
     },
   })
 


### PR DESCRIPTION
## Summary
- Added dismiss button (X icon) to all toast notifications
- Changed auto-dismiss timer from 4 seconds to 3 seconds
- Added success/error toast feedback for agent pause, resume, and terminate actions on the agents list page
- Added success/error toast feedback for task field updates (title, description, status, priority) on the task detail page
- Added success/error toast feedback for comment creation on the task detail page

All user-facing mutations in the dashboard now provide immediate toast feedback in the bottom-right corner.

## Test plan
- [ ] Create an agent and verify "Agent hired successfully" toast appears
- [ ] Pause an agent from the agents list — verify "Agent paused" toast
- [ ] Resume a paused agent — verify "Agent resumed" toast
- [ ] Terminate an agent — verify "Agent terminated" toast
- [ ] Edit a task title — verify "Title updated" toast
- [ ] Change task status — verify "Status updated" toast
- [ ] Change task priority — verify "Priority updated" toast
- [ ] Add a comment — verify "Comment added" toast
- [ ] Move a task on the kanban board — verify "Task moved to X" toast (pre-existing)
- [ ] Verify toasts auto-dismiss after 3 seconds
- [ ] Verify X button dismisses toast immediately
- [ ] Simulate API failure and verify error toasts appear

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)