### PR TITLE
fix: read DATABASE_URL from env var, stop storing in plaintext config

### DIFF
--- a/apps/cli/src/commands/config-cmd.ts
+++ b/apps/cli/src/commands/config-cmd.ts
@@ -4,7 +4,7 @@
 
 import type { Command } from 'commander'
 import * as p from '@clack/prompts'
-import { listConfigHistory, rollbackConfig, exportConfig } from '../config.js'
+import { listConfigHistory, rollbackConfig, exportConfig, stripSensitiveFromConfig, getConfigPath } from '../config.js'
 
 async function configHistory(): Promise<void> {
   const history = await listConfigHistory()
@@ -36,6 +36,25 @@ async function configExport(): Promise<void> {
   console.log(exported)
 }
 
+async function configRedact(): Promise<void> {
+  const stripped = await stripSensitiveFromConfig()
+  if (stripped.length === 0) {
+    p.log.info('No sensitive values found in config (or no config exists).')
+    p.log.info(
+      'Tip: Set SHACKLEAI_DATABASE_URL env var so credentials never touch disk.',
+    )
+    return
+  }
+  p.log.success(`Stripped ${stripped.length} sensitive field(s) from config:`)
+  for (const field of stripped) {
+    console.log(`  - ${field}`)
+  }
+  p.log.info(`Config file: ${getConfigPath()}`)
+  p.log.info(
+    'Set SHACKLEAI_DATABASE_URL env var before running `shackleai start`.',
+  )
+}
+
 export function registerConfigCommand(program: Command): void {
   const configCmd = program
     .command('config')
@@ -55,4 +74,9 @@ export function registerConfigCommand(program: Command): void {
     .command('export')
     .description('Print config with secrets redacted')
     .action(configExport)
+
+  configCmd
+    .command('redact')
+    .description('Strip sensitive values (databaseUrl, llmKeys) from config file')
+    .action(configRedact)
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -79,21 +79,32 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   }
 
   let databaseUrl: string | undefined
+  let databaseUrlFromEnv = false
   if (mode === 'server') {
-    const urlInput = await p.text({
-      message: 'DATABASE_URL',
-      placeholder: 'postgresql://user:pass@host:5432/dbname',
-      validate: (v) => {
-        if (!v.trim()) return 'Database URL is required for server mode'
-        return undefined
-      },
-    })
+    const envUrl = process.env.SHACKLEAI_DATABASE_URL
+    if (envUrl) {
+      p.log.info(`Using DATABASE_URL from SHACKLEAI_DATABASE_URL env var.`)
+      databaseUrl = envUrl
+      databaseUrlFromEnv = true
+    } else {
+      p.log.info(
+        'Tip: Set SHACKLEAI_DATABASE_URL env var to avoid storing credentials in config.',
+      )
+      const urlInput = await p.text({
+        message: 'DATABASE_URL',
+        placeholder: 'postgresql://user:pass@host:5432/dbname',
+        validate: (v) => {
+          if (!v.trim()) return 'Database URL is required for server mode'
+          return undefined
+        },
+      })
 
-    if (p.isCancel(urlInput)) {
-      p.cancel('Setup cancelled.')
-      process.exit(0)
+      if (p.isCancel(urlInput)) {
+        p.cancel('Setup cancelled.')
+        process.exit(0)
+      }
+      databaseUrl = urlInput
     }
-    databaseUrl = urlInput
   }
 
   // Initialize DB
@@ -144,12 +155,12 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   }
   spin.stop('Company created')
 
-  // Save config
+  // Save config — never persist databaseUrl if it came from env var
   await writeConfig({
     mode: mode as 'local' | 'server',
     companyId,
     companyName: companyName.trim(),
-    ...(databaseUrl ? { databaseUrl } : {}),
+    ...(databaseUrl && !databaseUrlFromEnv ? { databaseUrl } : {}),
     ...(mode === 'local' ? { dataDir: 'default' } : {}),
   })
 

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -23,7 +23,7 @@ import {
   QuotaManager,
 } from '@shackleai/core'
 import { AgentApiKeyStatus } from '@shackleai/shared'
-import { readConfig, writeConfig } from '../config.js'
+import { readConfig, writeConfig, resolveDatabaseUrl } from '../config.js'
 import type { ShackleAIConfig } from '../config.js'
 import { createApp } from '../server/index.js'
 import { VERSION } from '../index.js'
@@ -62,13 +62,18 @@ export async function startCommand(options: { port: number }): Promise<void> {
     if (config.mode === 'local') {
       db = new PGliteProvider(config.dataDir ?? 'default')
     } else {
-      if (!config.databaseUrl) {
+      const { url: dbUrl, source } = resolveDatabaseUrl(config)
+      if (!dbUrl) {
         console.error(
-          'Server mode requires a DATABASE_URL. Run `shackleai init` again.',
+          'Server mode requires a database URL.\n' +
+          'Set SHACKLEAI_DATABASE_URL env var or run `shackleai init` again.',
         )
         process.exit(1)
       }
-      db = new PgProvider(config.databaseUrl)
+      if (source === 'env') {
+        console.log('  Using DATABASE_URL from SHACKLEAI_DATABASE_URL env var.')
+      }
+      db = new PgProvider(dbUrl)
     }
   }
 
@@ -219,11 +224,11 @@ async function autoInitFromEnv(
     }
   }
 
+  // Never persist databaseUrl from env vars — it stays in the environment
   const config: ShackleAIConfig = {
     mode,
     companyId,
     companyName: companyName.trim(),
-    ...(databaseUrl ? { databaseUrl } : {}),
     ...(mode === 'local' ? { dataDir: 'default' } : {}),
   }
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -45,6 +45,58 @@ export async function readConfig(): Promise<ShackleAIConfig | null> {
   }
 }
 
+/**
+ * Resolve the database URL with env-var priority:
+ *   1. SHACKLEAI_DATABASE_URL env var (highest priority)
+ *   2. config.databaseUrl from config file (fallback)
+ *
+ * Returns { url, source } so callers know where it came from.
+ */
+export function resolveDatabaseUrl(config: ShackleAIConfig): {
+  url: string | undefined
+  source: 'env' | 'config' | 'none'
+} {
+  const envUrl = process.env.SHACKLEAI_DATABASE_URL
+  if (envUrl) {
+    return { url: envUrl, source: 'env' }
+  }
+  if (config.databaseUrl) {
+    return { url: config.databaseUrl, source: 'config' }
+  }
+  return { url: undefined, source: 'none' }
+}
+
+/**
+ * Strip sensitive fields from the config file on disk.
+ * Removes databaseUrl and llmKeys, then writes the cleaned config.
+ * Returns the list of fields that were stripped.
+ */
+export async function stripSensitiveFromConfig(): Promise<string[]> {
+  const config = await readConfig()
+  if (!config) {
+    return []
+  }
+
+  const stripped: string[] = []
+
+  if (config.databaseUrl) {
+    delete config.databaseUrl
+    stripped.push('databaseUrl')
+  }
+
+  if (config.llmKeys) {
+    if (config.llmKeys.openai) stripped.push('llmKeys.openai')
+    if (config.llmKeys.anthropic) stripped.push('llmKeys.anthropic')
+    delete config.llmKeys
+  }
+
+  if (stripped.length > 0) {
+    await writeConfig(config)
+  }
+
+  return stripped
+}
+
 export async function writeConfig(config: ShackleAIConfig): Promise<void> {
   const configPath = getConfigPath()
   const baseDir = getBaseDir()

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -38,7 +38,7 @@ program
 
 program
   .command('init')
-  .description('Initialize a new ShackleAI orchestrator')
+  .description('Initialize a new ShackleAI orchestrator (set SHACKLEAI_DATABASE_URL env var for secure DB config)')
   .option('--force', 'Reinitialize even if already configured')
   .option('--yes', 'Non-interactive mode with defaults')
   .option('--name <name>', 'Company name (required with --yes)')


### PR DESCRIPTION
## Summary
- **SHACKLEAI_DATABASE_URL env var** now takes priority over `config.databaseUrl` — credentials never need to touch disk
- `shackleai init` detects the env var automatically, skips the DATABASE_URL prompt, and does not write it to config
- `shackleai start` resolves DB URL via env var first, then falls back to config file
- `autoInitFromEnv` (Docker path) no longer persists `databaseUrl` to config
- New **`shackleai config redact`** command strips `databaseUrl` and `llmKeys` from existing config files
- `init --help` updated to mention the env var

## Test plan
- [ ] `SHACKLEAI_DATABASE_URL=postgres://... shackleai init --yes --name Test` — verify config.json has no `databaseUrl`
- [ ] `shackleai start` with env var set and no `databaseUrl` in config — verify it connects using env var
- [ ] `shackleai start` with `databaseUrl` in config and no env var — verify fallback works
- [ ] `shackleai config redact` on a config with `databaseUrl` — verify it is stripped
- [ ] `shackleai config redact` on a clean config — verify "no sensitive values" message
- [ ] `shackleai config export` — verify `databaseUrl` still shows as `***REDACTED***`

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)