### PR TITLE
feat: add dark/light/system theme toggle

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -9,7 +9,9 @@
       // Apply saved theme before first paint to prevent flash
       (function() {
         var theme = localStorage.getItem('shackleai-theme') ?? 'dark';
-        if (theme === 'dark') {
+        var isDark = theme === 'dark' ||
+          (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
           document.documentElement.classList.add('dark');
         } else {
           document.documentElement.classList.remove('dark');

--- a/apps/dashboard/src/components/theme-toggle.tsx
+++ b/apps/dashboard/src/components/theme-toggle.tsx
@@ -1,35 +1,27 @@
-import { useState, useEffect } from 'react'
-import { Moon, Sun } from 'lucide-react'
+import { Moon, Sun, Monitor } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useTheme, type Theme } from '@/hooks/useTheme'
+
+const themeConfig: Record<Theme, { icon: typeof Sun; label: string }> = {
+  light: { icon: Sun, label: 'Light mode — click for system' },
+  dark: { icon: Moon, label: 'Dark mode — click for light' },
+  system: { icon: Monitor, label: 'System mode — click for dark' },
+}
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<'dark' | 'light'>(() =>
-    (localStorage.getItem('shackleai-theme') as 'dark' | 'light') ?? 'dark',
-  )
-
-  useEffect(() => {
-    const root = document.documentElement
-    if (theme === 'dark') {
-      root.classList.add('dark')
-    } else {
-      root.classList.remove('dark')
-    }
-    localStorage.setItem('shackleai-theme', theme)
-  }, [theme])
+  const { theme, cycleTheme } = useTheme()
+  const { icon: Icon, label } = themeConfig[theme]
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
-      aria-label="Toggle theme"
+      onClick={cycleTheme}
+      aria-label={label}
+      title={label}
       className="h-8 w-8"
     >
-      {theme === 'dark' ? (
-        <Sun className="h-4 w-4" />
-      ) : (
-        <Moon className="h-4 w-4" />
-      )}
+      <Icon className="h-4 w-4" />
     </Button>
   )
 }

--- a/apps/dashboard/src/hooks/useTheme.ts
+++ b/apps/dashboard/src/hooks/useTheme.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'shackleai-theme'
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === 'system' ? getSystemTheme() : theme
+  const root = document.documentElement
+
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+
+function getStoredTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark' || stored === 'system') {
+    return stored
+  }
+  return 'dark'
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(getStoredTheme)
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next)
+    localStorage.setItem(STORAGE_KEY, next)
+    applyTheme(next)
+  }, [])
+
+  // Apply theme on mount and listen for system preference changes
+  useEffect(() => {
+    applyTheme(theme)
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => {
+      if (theme === 'system') {
+        applyTheme('system')
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [theme])
+
+  const cycleTheme = useCallback(() => {
+    setTheme(
+      theme === 'dark' ? 'light' : theme === 'light' ? 'system' : 'dark',
+    )
+  }, [theme, setTheme])
+
+  const resolvedTheme: 'light' | 'dark' =
+    theme === 'system' ? getSystemTheme() : theme
+
+  return { theme, resolvedTheme, setTheme, cycleTheme } as const
+}


### PR DESCRIPTION
## Summary
- Extract theme logic from `ThemeToggle` component into a dedicated `useTheme` hook supporting three modes: dark, light, and system
- System mode follows OS preference via `matchMedia('prefers-color-scheme: dark')` listener and auto-updates when OS theme changes
- Update `index.html` flash-prevention inline script to handle system mode, preventing FOUC on page load
- Theme preference persisted in `localStorage` under `shackleai-theme`

## Changes
- **New**: `apps/dashboard/src/hooks/useTheme.ts` — reusable hook exposing `theme`, `resolvedTheme`, `setTheme`, and `cycleTheme`
- **Modified**: `apps/dashboard/src/components/theme-toggle.tsx` — simplified to use the hook, cycles dark -> light -> system with Moon/Sun/Monitor icons
- **Modified**: `apps/dashboard/index.html` — flash-prevention script now handles `system` value

## Test plan
- [ ] Click toggle: cycles dark (moon) -> light (sun) -> system (monitor) -> dark
- [ ] In system mode, dashboard follows OS light/dark preference
- [ ] Change OS theme while in system mode — dashboard updates without refresh
- [ ] Reload page — theme persists from localStorage, no flash of wrong theme
- [ ] Verify all existing components render correctly in both light and dark modes

Closes #139

Generated with [Claude Code](https://claude.com/claude-code)