### PR TITLE
feat: add OpenCode adapter for local OpenCode agent support

### DIFF
--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -13,6 +13,7 @@ export { CodexAdapter } from './codex.js'
 export { CursorAdapter } from './cursor.js'
 export { GeminiAdapter } from './gemini.js'
 export { KiroAdapter } from './kiro.js'
+export { OpenCodeAdapter } from './opencode.js'
 export { getLastSessionState, saveSessionState } from './session.js'
 
 import type { AdapterModule } from './adapter.js'
@@ -26,6 +27,7 @@ import { CodexAdapter } from './codex.js'
 import { CursorAdapter } from './cursor.js'
 import { GeminiAdapter } from './gemini.js'
 import { KiroAdapter } from './kiro.js'
+import { OpenCodeAdapter } from './opencode.js'
 
 /**
  * AdapterRegistry — maps adapter_type strings to AdapterModule instances.
@@ -46,6 +48,7 @@ export class AdapterRegistry {
     this.register(new CursorAdapter())
     this.register(new GeminiAdapter())
     this.register(new KiroAdapter())
+    this.register(new OpenCodeAdapter())
   }
 
   /** Register an adapter module. Overwrites any existing adapter with the same type. */

--- a/packages/core/src/adapters/opencode.ts
+++ b/packages/core/src/adapters/opencode.ts
@@ -1,0 +1,137 @@
+/**
+ * OpenCodeAdapter — invokes the OpenCode CLI to execute a heartbeat.
+ *
+ * Spawns `opencode` with the prompt via `--prompt` argument.
+ * Follows the same patterns as ClaudeAdapter: graceful kill,
+ * timeout handling, __shackleai_result__ parsing, and safe env.
+ */
+
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { AdapterContext, AdapterModule, AdapterResult } from './adapter.js'
+import { getSafeEnv } from './env.js'
+import { gracefulKill, KILL_GRACE_MS } from './kill.js'
+import { buildFullPrompt, parseShackleResult } from './util.js'
+
+const IS_WIN = process.platform === 'win32'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export class OpenCodeAdapter implements AdapterModule {
+  readonly type = 'opencode'
+  readonly label = 'OpenCode CLI'
+
+  private activeChild: ChildProcess | null = null
+  private abortKillTimer: ReturnType<typeof setTimeout> | null = null
+
+  async execute(ctx: AdapterContext): Promise<AdapterResult> {
+    const prompt = ctx.adapterConfig.prompt as string | undefined
+    if (!prompt) {
+      return { exitCode: 1, stdout: '', stderr: 'adapterConfig.prompt is required for opencode adapter' }
+    }
+
+    const fullPrompt = buildFullPrompt(prompt, ctx)
+    const timeoutMs = typeof ctx.adapterConfig.timeout === 'number'
+      ? ctx.adapterConfig.timeout * 1000
+      : DEFAULT_TIMEOUT_MS
+    const env = this.buildEnv(ctx)
+    const args = ['--quiet', '--prompt', fullPrompt]
+    const model = ctx.adapterConfig.model as string | undefined
+    if (model) args.unshift('--model', model)
+
+    return new Promise<AdapterResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let killed = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const child = spawn('opencode', args, {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: !IS_WIN,
+      })
+      this.activeChild = child
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      const timeoutId = setTimeout(() => {
+        killed = true
+        killTimer = gracefulKill(child, KILL_GRACE_MS)
+      }, timeoutMs)
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        const stdout = Buffer.concat(stdoutChunks).toString('utf-8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8')
+        const parsed = parseShackleResult(stdout)
+        resolve({
+          exitCode: killed ? 124 : (code ?? 1),
+          stdout,
+          stderr: killed ? `OpenCode CLI killed after ${timeoutMs}ms timeout\n${stderr}` : stderr,
+          sessionState: parsed?.sessionState ?? null,
+          usage: parsed?.usage,
+        })
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutId)
+        if (killTimer) clearTimeout(killTimer)
+        this.clearActiveChild(child)
+        resolve({ exitCode: 127, stdout: '', stderr: `Failed to spawn opencode CLI: ${err.message}` })
+      })
+    })
+  }
+
+  abort(): void {
+    const child = this.activeChild
+    if (!child) return
+    if (this.abortKillTimer) clearTimeout(this.abortKillTimer)
+    this.abortKillTimer = gracefulKill(child, KILL_GRACE_MS)
+  }
+
+  async testEnvironment(): Promise<{ ok: boolean; error?: string }> {
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = spawn('opencode', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      child.stdout.on('data', () => { /* drain */ })
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        resolve({ ok: false, error: 'opencode --version timed out' })
+      }, 10_000)
+      child.on('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code === 0
+          ? { ok: true }
+          : { ok: false, error: `opencode --version exited with code ${code}` })
+      })
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        resolve({ ok: false, error: `opencode CLI not found: ${err.message}` })
+      })
+    })
+  }
+
+  private buildEnv(ctx: AdapterContext): Record<string, string> {
+    const shackleEnv: Record<string, string> = {
+      ...ctx.env,
+      SHACKLEAI_RUN_ID: ctx.heartbeatRunId,
+      SHACKLEAI_AGENT_ID: ctx.agentId,
+    }
+    const env = getSafeEnv(shackleEnv)
+    if (ctx.task) env.SHACKLEAI_TASK_ID = ctx.task
+    if (ctx.ancestry?.mission) env.SHACKLEAI_MISSION = ctx.ancestry.mission
+    if (ctx.ancestry?.project) env.SHACKLEAI_PROJECT = ctx.ancestry.project.name
+    if (ctx.ancestry?.goal) env.SHACKLEAI_GOAL = ctx.ancestry.goal.name
+    if (ctx.env.SHACKLEAI_API_KEY) env.SHACKLEAI_API_KEY = ctx.env.SHACKLEAI_API_KEY
+    if (ctx.sessionState) env.SHACKLEAI_SESSION_STATE = ctx.sessionState
+    return env
+  }
+
+  private clearActiveChild(child: ChildProcess): void {
+    if (this.activeChild === child) this.activeChild = null
+    if (this.abortKillTimer) { clearTimeout(this.abortKillTimer); this.abortKillTimer = null }
+  }
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -43,6 +43,7 @@ export const AdapterType = {
   Cursor: 'cursor',
   Gemini: 'gemini',
   Kiro: 'kiro',
+  OpenCode: 'opencode',
 } as const
 export type AdapterType = (typeof AdapterType)[keyof typeof AdapterType]
 


### PR DESCRIPTION
## Summary
- Add `OpenCodeAdapter` that spawns `opencode` CLI as a child process with prompt, model, and timeout support
- Add `OpenCode: 'opencode'` to `AdapterType` enum in `@shackleai/shared`
- Register `OpenCodeAdapter` in the `AdapterRegistry`

Follows the same patterns as `CodexAdapter`: graceful kill via `kill.ts`, `__shackleai_result__` parsing, safe env, and `testEnvironment()` health check.

Closes #123

## Test plan
- [ ] Verify `OpenCodeAdapter` is registered in `AdapterRegistry`
- [ ] Verify `testEnvironment()` returns `{ ok: false }` when `opencode` CLI is not installed
- [ ] Verify `execute()` returns error when `prompt` is missing from `adapterConfig`
- [ ] Verify timeout kills process with exit code 124
- [ ] Verify `abort()` gracefully kills active child process

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>