### PR TITLE
feat: pluggable storage abstraction (local disk + S3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,3 +71,13 @@ export {
   clearTemplateCache,
 } from './templates/index.js'
 export type { TemplateImportResult } from './templates/index.js'
+
+export { createStorageProvider, LocalDiskProvider, S3Provider } from './storage/index.js'
+export type {
+  StorageProvider,
+  StorageConfig,
+  LocalDiskConfig,
+  S3Config,
+  UploadResult,
+  DownloadResult,
+} from './storage/index.js'

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Storage abstraction — pluggable file storage backends.
+ *
+ * Usage:
+ *   import { createStorageProvider } from '@shackleai/core'
+ *
+ *   const storage = createStorageProvider({ type: 'local-disk' })
+ *   await storage.upload('uploads/logo.png', buffer, 'image/png')
+ */
+
+export type {
+  StorageProvider,
+  StorageConfig,
+  LocalDiskConfig,
+  S3Config,
+  UploadResult,
+  DownloadResult,
+} from './provider.js'
+
+export { LocalDiskProvider } from './local-disk.js'
+export { S3Provider } from './s3.js'
+
+import type { StorageConfig, StorageProvider } from './provider.js'
+import { LocalDiskProvider } from './local-disk.js'
+import { S3Provider } from './s3.js'
+
+/**
+ * Factory: create a storage provider from configuration.
+ *
+ * @example
+ *   // Local disk (default)
+ *   const local = createStorageProvider({ type: 'local-disk' })
+ *
+ *   // S3
+ *   const s3 = createStorageProvider({
+ *     type: 's3',
+ *     bucket: 'my-bucket',
+ *     region: 'us-east-1',
+ *     accessKeyId: '...',
+ *     secretAccessKey: '...',
+ *   })
+ */
+export function createStorageProvider(config: StorageConfig): StorageProvider {
+  switch (config.type) {
+    case 'local-disk': {
+      const { type: _, ...rest } = config
+      return new LocalDiskProvider(rest)
+    }
+    case 's3': {
+      const { type: _, ...rest } = config
+      return new S3Provider(rest)
+    }
+    default:
+      throw new Error(`Unknown storage provider type: ${(config as { type: string }).type}`)
+  }
+}

--- a/packages/core/src/storage/local-disk.ts
+++ b/packages/core/src/storage/local-disk.ts
@@ -1,0 +1,94 @@
+/**
+ * Local disk storage provider.
+ *
+ * Stores files under ~/.shackleai/orchestrator/storage/ by default.
+ * Keys map directly to file paths within the base directory.
+ */
+
+import { mkdir, readFile, writeFile, unlink, access } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import { pathToFileURL } from 'node:url'
+import type { StorageProvider, UploadResult, DownloadResult, LocalDiskConfig } from './provider.js'
+
+const DEFAULT_BASE_PATH = join(homedir(), '.shackleai', 'orchestrator', 'storage')
+
+export class LocalDiskProvider implements StorageProvider {
+  readonly type = 'local-disk' as const
+  private readonly basePath: string
+
+  constructor(config: Omit<LocalDiskConfig, 'type'> = {}) {
+    this.basePath = config.basePath ?? DEFAULT_BASE_PATH
+  }
+
+  async upload(key: string, buffer: Buffer, mime: string): Promise<UploadResult> {
+    const filePath = this.resolve(key)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, buffer)
+
+    // Store mime type in a sidecar .meta file
+    await writeFile(`${filePath}.meta`, JSON.stringify({ mime, size: buffer.length }))
+
+    return { key, size: buffer.length, mime }
+  }
+
+  async download(key: string): Promise<DownloadResult> {
+    const filePath = this.resolve(key)
+    const buffer = await readFile(filePath)
+    const meta = await this.readMeta(filePath)
+
+    return {
+      buffer,
+      mime: meta?.mime ?? 'application/octet-stream',
+      size: buffer.length,
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const filePath = this.resolve(key)
+    try {
+      await unlink(filePath)
+      await unlink(`${filePath}.meta`).catch(() => {})
+    } catch (err: unknown) {
+      if (isNodeError(err) && err.code === 'ENOENT') return
+      throw err
+    }
+  }
+
+  async getUrl(key: string): Promise<string> {
+    const filePath = this.resolve(key)
+    return pathToFileURL(filePath).href
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await access(this.resolve(key))
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** Resolve a key to an absolute file path, preventing path traversal. */
+  private resolve(key: string): string {
+    // Normalize: strip leading slashes, reject '..' segments
+    const normalized = key.replace(/\\/g, '/').replace(/^\/+/, '')
+    if (normalized.includes('..')) {
+      throw new Error(`Invalid storage key: path traversal detected in "${key}"`)
+    }
+    return join(this.basePath, ...normalized.split('/'))
+  }
+
+  private async readMeta(filePath: string): Promise<{ mime: string; size: number } | null> {
+    try {
+      const raw = await readFile(`${filePath}.meta`, 'utf-8')
+      return JSON.parse(raw)
+    } catch {
+      return null
+    }
+  }
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err
+}

--- a/packages/core/src/storage/provider.ts
+++ b/packages/core/src/storage/provider.ts
@@ -1,0 +1,64 @@
+/**
+ * Storage provider interface for pluggable file storage backends.
+ *
+ * Implementations: LocalDiskProvider, S3Provider
+ */
+
+/** Metadata returned after a successful upload */
+export interface UploadResult {
+  key: string
+  size: number
+  mime: string
+}
+
+/** Result of a download operation */
+export interface DownloadResult {
+  buffer: Buffer
+  mime: string
+  size: number
+}
+
+/** Configuration for local disk storage */
+export interface LocalDiskConfig {
+  type: 'local-disk'
+  /** Base directory for file storage. Defaults to ~/.shackleai/orchestrator/storage/ */
+  basePath?: string
+}
+
+/** Configuration for S3-compatible storage */
+export interface S3Config {
+  type: 's3'
+  bucket: string
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+  /** Optional endpoint for S3-compatible services (MinIO, R2, etc.) */
+  endpoint?: string
+}
+
+export type StorageConfig = LocalDiskConfig | S3Config
+
+/**
+ * Abstract storage provider interface.
+ *
+ * All keys are forward-slash-separated paths (e.g. "uploads/org-123/logo.png").
+ * Providers normalize keys internally.
+ */
+export interface StorageProvider {
+  readonly type: string
+
+  /** Upload a file. Returns metadata about the stored object. */
+  upload(key: string, buffer: Buffer, mime: string): Promise<UploadResult>
+
+  /** Download a file by key. Throws if the key does not exist. */
+  download(key: string): Promise<DownloadResult>
+
+  /** Delete a file by key. No-op if the key does not exist. */
+  delete(key: string): Promise<void>
+
+  /** Get a URL for the file (local path or presigned S3 URL). */
+  getUrl(key: string): Promise<string>
+
+  /** Check whether a file exists at the given key. */
+  exists(key: string): Promise<boolean>
+}

--- a/packages/core/src/storage/s3.ts
+++ b/packages/core/src/storage/s3.ts
@@ -1,0 +1,230 @@
+/**
+ * S3-compatible storage provider.
+ *
+ * Uses native fetch against the S3 REST API to avoid heavy AWS SDK dependency.
+ * Implements AWS Signature V4 for request signing.
+ *
+ * Supports S3-compatible services (MinIO, Cloudflare R2) via custom endpoint.
+ */
+
+import { createHmac, createHash } from 'node:crypto'
+import type { StorageProvider, UploadResult, DownloadResult, S3Config } from './provider.js'
+
+export class S3Provider implements StorageProvider {
+  readonly type = 's3' as const
+  private readonly bucket: string
+  private readonly region: string
+  private readonly accessKeyId: string
+  private readonly secretAccessKey: string
+  private readonly endpoint: string
+
+  constructor(config: Omit<S3Config, 'type'>) {
+    this.bucket = config.bucket
+    this.region = config.region
+    this.accessKeyId = config.accessKeyId
+    this.secretAccessKey = config.secretAccessKey
+    this.endpoint = config.endpoint ?? `https://${config.bucket}.s3.${config.region}.amazonaws.com`
+  }
+
+  async upload(key: string, buffer: Buffer, mime: string): Promise<UploadResult> {
+    const url = this.objectUrl(key)
+    const headers = this.sign('PUT', key, {
+      'Content-Type': mime,
+      'Content-Length': String(buffer.length),
+    }, buffer)
+
+    const res = await fetch(url, { method: 'PUT', headers, body: buffer })
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(`S3 PUT failed (${res.status}): ${body}`)
+    }
+
+    return { key, size: buffer.length, mime }
+  }
+
+  async download(key: string): Promise<DownloadResult> {
+    const url = this.objectUrl(key)
+    const headers = this.sign('GET', key, {})
+
+    const res = await fetch(url, { method: 'GET', headers })
+    if (!res.ok) {
+      if (res.status === 404) throw new Error(`S3 object not found: ${key}`)
+      const body = await res.text()
+      throw new Error(`S3 GET failed (${res.status}): ${body}`)
+    }
+
+    const arrayBuf = await res.arrayBuffer()
+    const buffer = Buffer.from(arrayBuf)
+    const mime = res.headers.get('content-type') ?? 'application/octet-stream'
+
+    return { buffer, mime, size: buffer.length }
+  }
+
+  async delete(key: string): Promise<void> {
+    const url = this.objectUrl(key)
+    const headers = this.sign('DELETE', key, {})
+
+    const res = await fetch(url, { method: 'DELETE', headers })
+    // S3 returns 204 on successful delete, 404 is acceptable (no-op)
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text()
+      throw new Error(`S3 DELETE failed (${res.status}): ${body}`)
+    }
+  }
+
+  async getUrl(key: string): Promise<string> {
+    // Return a presigned URL valid for 1 hour
+    return this.presign(key, 3600)
+  }
+
+  async exists(key: string): Promise<boolean> {
+    const url = this.objectUrl(key)
+    const headers = this.sign('HEAD', key, {})
+
+    const res = await fetch(url, { method: 'HEAD', headers })
+    if (res.status === 404) return false
+    if (res.ok) return true
+    const body = await res.text()
+    throw new Error(`S3 HEAD failed (${res.status}): ${body}`)
+  }
+
+  // ---------------------------------------------------------------------------
+  // AWS Signature V4
+  // ---------------------------------------------------------------------------
+
+  private objectUrl(key: string): string {
+    const normalized = key.replace(/^\/+/, '')
+    if (this.endpoint.includes(this.bucket)) {
+      return `${this.endpoint}/${normalized}`
+    }
+    return `${this.endpoint}/${this.bucket}/${normalized}`
+  }
+
+  /**
+   * Sign a request using AWS Signature V4.
+   * Minimal implementation covering the S3 REST operations we need.
+   */
+  private sign(
+    method: string,
+    key: string,
+    extraHeaders: Record<string, string>,
+    body?: Buffer,
+  ): Record<string, string> {
+    const now = new Date()
+    const dateStamp = now.toISOString().replace(/[-:]/g, '').slice(0, 8)
+    const amzDate = now.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z')
+
+    const host = new URL(this.objectUrl(key)).host
+    const canonicalUri = '/' + key.replace(/^\/+/, '')
+
+    const payloadHash = sha256(body ?? Buffer.alloc(0))
+
+    const headers: Record<string, string> = {
+      ...extraHeaders,
+      host,
+      'x-amz-date': amzDate,
+      'x-amz-content-sha256': payloadHash,
+    }
+
+    const signedHeaderKeys = Object.keys(headers).sort()
+    const signedHeaders = signedHeaderKeys.join(';')
+    const canonicalHeaders = signedHeaderKeys.map(k => `${k}:${headers[k]}\n`).join('')
+
+    const canonicalRequest = [
+      method,
+      canonicalUri,
+      '', // query string (empty for these operations)
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n')
+
+    const scope = `${dateStamp}/${this.region}/s3/aws4_request`
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      amzDate,
+      scope,
+      sha256(Buffer.from(canonicalRequest)),
+    ].join('\n')
+
+    const signingKey = this.deriveSigningKey(dateStamp)
+    const signature = hmacHex(signingKey, stringToSign)
+
+    headers['Authorization'] =
+      `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${scope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+    // Remove host — fetch sets it automatically
+    delete headers['host']
+    return headers
+  }
+
+  /**
+   * Generate a presigned URL for GET requests.
+   */
+  private presign(key: string, expiresIn: number): string {
+    const now = new Date()
+    const dateStamp = now.toISOString().replace(/[-:]/g, '').slice(0, 8)
+    const amzDate = now.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z')
+
+    const host = new URL(this.objectUrl(key)).host
+    const canonicalUri = '/' + key.replace(/^\/+/, '')
+    const scope = `${dateStamp}/${this.region}/s3/aws4_request`
+
+    const queryParams = new URLSearchParams({
+      'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+      'X-Amz-Credential': `${this.accessKeyId}/${scope}`,
+      'X-Amz-Date': amzDate,
+      'X-Amz-Expires': String(expiresIn),
+      'X-Amz-SignedHeaders': 'host',
+    })
+
+    // Sort query params for canonical request
+    queryParams.sort()
+    const canonicalQueryString = queryParams.toString()
+
+    const canonicalRequest = [
+      'GET',
+      canonicalUri,
+      canonicalQueryString,
+      `host:${host}\n`,
+      'host',
+      'UNSIGNED-PAYLOAD',
+    ].join('\n')
+
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      amzDate,
+      scope,
+      sha256(Buffer.from(canonicalRequest)),
+    ].join('\n')
+
+    const signingKey = this.deriveSigningKey(dateStamp)
+    const signature = hmacHex(signingKey, stringToSign)
+
+    return `${this.objectUrl(key)}?${canonicalQueryString}&X-Amz-Signature=${signature}`
+  }
+
+  private deriveSigningKey(dateStamp: string): Buffer {
+    const kDate = hmac(Buffer.from(`AWS4${this.secretAccessKey}`), dateStamp)
+    const kRegion = hmac(kDate, this.region)
+    const kService = hmac(kRegion, 's3')
+    return hmac(kService, 'aws4_request')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+function sha256(data: Buffer | string): string {
+  return createHash('sha256').update(data).digest('hex')
+}
+
+function hmac(key: Buffer, data: string): Buffer {
+  return createHmac('sha256', key).update(data).digest()
+}
+
+function hmacHex(key: Buffer, data: string): string {
+  return createHmac('sha256', key).update(data).digest('hex')
+}


### PR DESCRIPTION
## Summary
- Adds `StorageProvider` interface with `upload`, `download`, `delete`, `getUrl`, `exists` methods
- `LocalDiskProvider` stores files in `~/.shackleai/orchestrator/storage/` with `.meta` sidecar files for MIME tracking, includes path traversal protection
- `S3Provider` uses native `fetch` + AWS Signature V4 signing (zero SDK dependency), supports S3-compatible services (MinIO, R2) via custom endpoint, generates presigned URLs
- `createStorageProvider(config)` factory for config-driven provider selection
- All types and classes exported from `@shackleai/core`

## Test plan
- [ ] Unit tests for `LocalDiskProvider` (upload/download/delete/exists/getUrl)
- [ ] Unit tests for path traversal rejection
- [ ] Unit tests for `createStorageProvider` factory
- [ ] Integration test for S3Provider against MinIO or localstack
- [ ] Verify TypeScript compilation and lint pass

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)