### PR TITLE
feat: add company export/import for portable org structures

### DIFF
--- a/apps/cli/src/commands/company.ts
+++ b/apps/cli/src/commands/company.ts
@@ -3,9 +3,12 @@
  */
 
 import type { Command } from 'commander'
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import * as p from '@clack/prompts'
 import type { Company } from '@shackleai/shared'
 import type { TemplateImportResult } from '@shackleai/core'
+import type { CompanyImportResult } from '@shackleai/shared'
 import { apiClient, getCompanyId } from '../api-client.js'
 import { readConfig, writeConfig } from '../config.js'
 
@@ -286,6 +289,130 @@ async function showCurrent(): Promise<void> {
   console.log(`Budget:  $${(c.budget_monthly_cents / 100).toFixed(2)}/mo`)
 }
 
+async function exportCompanyCmd(opts: { output?: string }): Promise<void> {
+  const companyId = await getCompanyId()
+  const spin = p.spinner()
+  spin.start("Exporting company...")
+
+  const res = await apiClient("/api/companies/" + companyId + "/export", {
+    method: "POST",
+  })
+
+  if (!res.ok) {
+    spin.stop("Export failed")
+    const body = (await res.json()) as ApiResponse<never>
+    console.error("Error: " + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<Record<string, unknown>>
+  const json = JSON.stringify(body.data, null, 2)
+
+  if (opts.output) {
+    const filePath = resolve(opts.output)
+    await writeFile(filePath, json, "utf8")
+    spin.stop("Exported to " + filePath)
+  } else {
+    spin.stop("Export complete")
+    console.log(json)
+  }
+}
+
+async function importCompanyCmd(file: string): Promise<void> {
+  const filePath = resolve(file)
+
+  let rawJson: string
+  try {
+    rawJson = await readFile(filePath, "utf8")
+  } catch {
+    console.error("Error: Could not read file " + filePath)
+    process.exit(1)
+  }
+
+  let data: Record<string, unknown>
+  try {
+    data = JSON.parse(rawJson) as Record<string, unknown>
+  } catch {
+    console.error("Error: Invalid JSON in " + filePath)
+    process.exit(1)
+  }
+
+  const spin = p.spinner()
+  spin.start("Importing company...")
+
+  const res = await apiClient("/api/companies/import", {
+    method: "POST",
+    body: JSON.stringify(data),
+  })
+
+  if (!res.ok) {
+    spin.stop("Import failed")
+    const body = (await res.json()) as ApiResponse<never>
+
+    // Handle name collision: prompt for rename
+    if (res.status === 409 && body.error?.includes("already exists")) {
+      console.error(body.error)
+      const newName = await p.text({
+        message: "Enter a new company name",
+        placeholder: (data.company as Record<string, unknown>)?.name + " (copy)",
+        validate: (v) => {
+          if (!v.trim()) return "Company name is required"
+          return undefined
+        },
+      })
+
+      if (p.isCancel(newName)) {
+        p.cancel("Cancelled.")
+        return
+      }
+
+      // Update the company name in the data and retry
+      const companyMeta = data.company as Record<string, unknown>
+      companyMeta.name = newName.trim()
+      data.name = newName.trim()
+
+      spin.start("Importing company...")
+      const retryRes = await apiClient("/api/companies/import", {
+        method: "POST",
+        body: JSON.stringify(data),
+      })
+
+      if (!retryRes.ok) {
+        spin.stop("Import failed")
+        const retryBody = (await retryRes.json()) as ApiResponse<never>
+        console.error("Error: " + (retryBody.error ?? retryRes.statusText))
+        process.exit(1)
+      }
+
+      const retryBody = (await retryRes.json()) as ApiResponse<CompanyImportResult>
+      const r = retryBody.data
+      spin.stop(
+        "Company imported: " + r.company.name + " (" + r.company.id + ")\n" +
+        "  Agents: " + r.agents_created +
+        ", Goals: " + r.goals_created +
+        ", Policies: " + r.policies_created +
+        ", Projects: " + r.projects_created +
+        ", Issues: " + r.issues_created,
+      )
+      return
+    }
+
+    console.error("Error: " + (body.error ?? res.statusText))
+    process.exit(1)
+  }
+
+  const body = (await res.json()) as ApiResponse<CompanyImportResult>
+  const r = body.data
+  spin.stop(
+    "Company imported: " + r.company.name + " (" + r.company.id + ")\n" +
+    "  Agents: " + r.agents_created +
+    ", Goals: " + r.goals_created +
+    ", Policies: " + r.policies_created +
+    ", Projects: " + r.projects_created +
+    ", Issues: " + r.issues_created,
+  )
+}
+
 export function registerCompanyCommand(program: Command): void {
   const company = program
     .command('company')
@@ -326,5 +453,21 @@ export function registerCompanyCommand(program: Command): void {
     .description('Show the current active company')
     .action(async () => {
       await showCurrent()
+    })
+
+  company
+    .command("export")
+    .description("Export current company as portable JSON")
+    .option("-o, --output <file>", "Write to file instead of stdout")
+    .action(async (opts: { output?: string }) => {
+      await exportCompanyCmd(opts)
+    })
+
+  company
+    .command("import")
+    .argument("<file>", "Path to company export JSON file")
+    .description("Import a company from an export JSON file")
+    .action(async (file: string) => {
+      await importCompanyCmd(file)
     })
 }

--- a/apps/cli/src/server/routes/templates.ts
+++ b/apps/cli/src/server/routes/templates.ts
@@ -1,15 +1,18 @@
 /**
- * Template routes — /api/templates and /api/companies/:id/import-template, /api/companies/:id/export-template
+ * Template and company export/import routes — /api/templates and /api/companies/:id/import-template, /api/companies/:id/export-template
  */
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
-import { CompanyTemplateInput } from '@shackleai/shared'
+import { CompanyTemplateInput, CompanyExportInput } from '@shackleai/shared'
+import type { CompanyExport } from '@shackleai/shared'
 import {
   listTemplates,
   getTemplate,
   importTemplate,
   exportTemplate,
+  exportCompany,
+  importCompany,
 } from '@shackleai/core'
 import type { CompanyScopeVariables } from '../middleware/company-scope.js'
 import { companyScope } from '../middleware/company-scope.js'
@@ -122,6 +125,49 @@ export function companyTemplatesRouter(
     const template = await exportTemplate(db, companyId as string, name, description)
 
     return c.json({ data: template })
+  })
+
+
+  // POST /api/companies/:id/export -- export full company state as JSON
+  app.post("/:id/export", companyScope, async (c) => {
+    const companyId = c.req.param("id")
+
+    try {
+      const data = await exportCompany(db, companyId as string)
+      return c.json({ data })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Export failed"
+      return c.json({ error: message }, 500)
+    }
+  })
+
+
+  // POST /api/companies/import -- import a full company export JSON
+  app.post("/import", async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400)
+    }
+
+    const parsed = CompanyExportInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        400,
+      )
+    }
+
+    try {
+      const result = await importCompany(db, parsed.data as CompanyExport)
+      return c.json({ data: result }, 201)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Import failed"
+      // Name collision returns 409 Conflict
+      const status = message.includes("already exists") ? 409 : 500
+      return c.json({ error: message }, status)
+    }
   })
 
   return app

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,8 @@ export {
   getTemplate,
   importTemplate,
   exportTemplate,
+  exportCompany,
+  importCompany,
   clearTemplateCache,
 } from './templates/index.js'
 export type { TemplateImportResult } from './templates/index.js'

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -9,10 +9,15 @@
 import type { DatabaseProvider } from '@shackleai/db'
 import type {
   CompanyTemplate,
+  CompanyExport,
+  CompanyImportResult,
   TemplateSummary,
+  Company,
   Agent,
   Goal,
   Policy,
+  Project,
+  Issue,
 } from '@shackleai/shared'
 import { BUILTIN_TEMPLATES } from './builtin.js'
 
@@ -216,6 +221,295 @@ export async function exportTemplate(
       max_calls_per_hour: p.max_calls_per_hour,
       agent_name: p.agent_id ? agentIdToName.get(p.agent_id) ?? null : null,
     })),
+  }
+}
+
+/**
+ * Export a full company snapshot -- agents, goals, policies, projects, and issues.
+ * All UUIDs are scrubbed and replaced with name-based references.
+ * Secrets, cost_events, heartbeat_runs, and timestamps are stripped.
+ */
+export async function exportCompany(
+  db: DatabaseProvider,
+  companyId: string,
+): Promise<CompanyExport> {
+  // Fetch company metadata
+  const companyResult = await db.query<Company>(
+    `SELECT * FROM companies WHERE id = $1`,
+    [companyId],
+  )
+  if (companyResult.rows.length === 0) {
+    throw new Error(`Company ${companyId} not found`)
+  }
+  const company = companyResult.rows[0]
+
+  // Fetch all entities
+  const agentResult = await db.query<Agent>(
+    `SELECT * FROM agents WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+  const agents = agentResult.rows
+
+  const agentIdToName = new Map<string, string>()
+  for (const a of agents) {
+    agentIdToName.set(a.id, a.name)
+  }
+
+  const goalResult = await db.query<Goal>(
+    `SELECT * FROM goals WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+  const goals = goalResult.rows
+
+  const goalIdToTitle = new Map<string, string>()
+  for (const g of goals) {
+    goalIdToTitle.set(g.id, g.title)
+  }
+
+  const policyResult = await db.query<Policy>(
+    `SELECT * FROM policies WHERE company_id = $1 ORDER BY priority DESC, created_at ASC`,
+    [companyId],
+  )
+
+  const projectResult = await db.query<Project>(
+    `SELECT * FROM projects WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+  const projects = projectResult.rows
+
+  const projectIdToName = new Map<string, string>()
+  for (const pr of projects) {
+    projectIdToName.set(pr.id, pr.name)
+  }
+
+  const issueResult = await db.query<Issue>(
+    `SELECT * FROM issues WHERE company_id = $1 ORDER BY created_at ASC`,
+    [companyId],
+  )
+  const issues = issueResult.rows
+
+  const issueIdToTitle = new Map<string, string>()
+  for (const i of issues) {
+    issueIdToTitle.set(i.id, i.title)
+  }
+
+  return {
+    export_version: '1.0.0',
+    name: company.name,
+    description: company.description ?? '',
+    version: '1.0.0',
+    company: {
+      name: company.name,
+      description: company.description,
+      issue_prefix: company.issue_prefix,
+      budget_monthly_cents: company.budget_monthly_cents,
+      default_honesty_checklist: company.default_honesty_checklist,
+      require_approval: company.require_approval,
+    },
+    agents: agents.map((a) => ({
+      name: a.name,
+      title: a.title,
+      role: a.role,
+      capabilities: a.capabilities,
+      adapter_type: a.adapter_type,
+      adapter_config: a.adapter_config,
+      budget_monthly_cents: a.budget_monthly_cents,
+      reports_to: a.reports_to ? agentIdToName.get(a.reports_to) ?? null : null,
+    })),
+    goals: goals.map((g) => ({
+      title: g.title,
+      description: g.description,
+      level: g.level,
+      owner_agent_name: g.owner_agent_id
+        ? agentIdToName.get(g.owner_agent_id) ?? null
+        : null,
+    })),
+    policies: policyResult.rows.map((po) => ({
+      name: po.name,
+      tool_pattern: po.tool_pattern,
+      action: po.action,
+      priority: po.priority,
+      max_calls_per_hour: po.max_calls_per_hour,
+      agent_name: po.agent_id ? agentIdToName.get(po.agent_id) ?? null : null,
+    })),
+    projects: projects.map((pr) => ({
+      name: pr.name,
+      description: pr.description,
+      status: pr.status,
+      target_date: pr.target_date,
+      goal_title: pr.goal_id ? goalIdToTitle.get(pr.goal_id) ?? null : null,
+      lead_agent_name: pr.lead_agent_id
+        ? agentIdToName.get(pr.lead_agent_id) ?? null
+        : null,
+    })),
+    issues: issues.map((i) => ({
+      title: i.title,
+      description: i.description,
+      status: i.status,
+      priority: i.priority,
+      assignee_agent_name: i.assignee_agent_id
+        ? agentIdToName.get(i.assignee_agent_id) ?? null
+        : null,
+      project_name: i.project_id
+        ? projectIdToName.get(i.project_id) ?? null
+        : null,
+      goal_title: i.goal_id ? goalIdToTitle.get(i.goal_id) ?? null : null,
+      parent_issue_title: i.parent_id
+        ? issueIdToTitle.get(i.parent_id) ?? null
+        : null,
+    })),
+  }
+}
+
+/**
+ * Import a full company export -- creates company + all entities.
+ * Resolves all name-based references to real IDs.
+ * If a company with the same name exists, the caller must provide a renamed company.name.
+ */
+export async function importCompany(
+  db: DatabaseProvider,
+  data: CompanyExport,
+): Promise<CompanyImportResult> {
+  // Check for name collision
+  const existing = await db.query<Company>(
+    `SELECT id FROM companies WHERE name = $1`,
+    [data.company.name],
+  )
+  if (existing.rows.length > 0) {
+    throw new Error(
+      `A company named "${data.company.name}" already exists. Choose a different name.`,
+    )
+  }
+
+  // Phase 1: Create the company
+  const companyResult = await db.query<Company>(
+    `INSERT INTO companies
+       (name, description, issue_prefix, budget_monthly_cents, default_honesty_checklist, require_approval)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [
+      data.company.name,
+      data.company.description ?? null,
+      data.company.issue_prefix,
+      data.company.budget_monthly_cents ?? 0,
+      data.company.default_honesty_checklist
+        ? JSON.stringify(data.company.default_honesty_checklist)
+        : null,
+      data.company.require_approval ?? false,
+    ],
+  )
+  const company = companyResult.rows[0]
+  const companyId = company.id
+
+  // Phase 2: Import agents, goals, policies via existing importTemplate
+  const templateResult = await importTemplate(db, companyId, {
+    name: data.name,
+    description: data.description,
+    version: data.version,
+    agents: data.agents,
+    goals: data.goals,
+    policies: data.policies,
+  })
+
+  // Build lookup maps from created entities
+  const agentNameToId = new Map<string, string>()
+  for (const a of templateResult.agents) {
+    agentNameToId.set(a.name, a.id)
+  }
+
+  const goalTitleToId = new Map<string, string>()
+  for (const g of templateResult.goals) {
+    goalTitleToId.set(g.title, g.id)
+  }
+
+  // Phase 3: Create projects
+  const projectNameToId = new Map<string, string>()
+  let projectsCreated = 0
+
+  for (const ep of data.projects ?? []) {
+    const goalId = ep.goal_title
+      ? goalTitleToId.get(ep.goal_title) ?? null
+      : null
+    const leadAgentId = ep.lead_agent_name
+      ? agentNameToId.get(ep.lead_agent_name) ?? null
+      : null
+
+    const result = await db.query<Project>(
+      `INSERT INTO projects
+         (company_id, name, description, status, target_date, goal_id, lead_agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        companyId,
+        ep.name,
+        ep.description ?? null,
+        ep.status,
+        ep.target_date ?? null,
+        goalId,
+        leadAgentId,
+      ],
+    )
+    projectNameToId.set(ep.name, result.rows[0].id)
+    projectsCreated++
+  }
+
+  // Phase 4: Create issues (two passes -- first without parent_id, then resolve parents)
+  const issueTitleToId = new Map<string, string>()
+  let issuesCreated = 0
+
+  // First pass: create all issues without parent references
+  for (const ei of data.issues ?? []) {
+    const assigneeId = ei.assignee_agent_name
+      ? agentNameToId.get(ei.assignee_agent_name) ?? null
+      : null
+    const projectId = ei.project_name
+      ? projectNameToId.get(ei.project_name) ?? null
+      : null
+    const goalId = ei.goal_title
+      ? goalTitleToId.get(ei.goal_title) ?? null
+      : null
+
+    const result = await db.query<Issue>(
+      `INSERT INTO issues
+         (company_id, title, description, status, priority, assignee_agent_id, project_id, goal_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        companyId,
+        ei.title,
+        ei.description ?? null,
+        ei.status,
+        ei.priority,
+        assigneeId,
+        projectId,
+        goalId,
+      ],
+    )
+    issueTitleToId.set(ei.title, result.rows[0].id)
+    issuesCreated++
+  }
+
+  // Second pass: resolve parent issue references
+  for (const ei of data.issues ?? []) {
+    if (ei.parent_issue_title) {
+      const parentId = issueTitleToId.get(ei.parent_issue_title)
+      const issueId = issueTitleToId.get(ei.title)
+      if (parentId && issueId) {
+        await db.query(
+          `UPDATE issues SET parent_id = $1, updated_at = NOW() WHERE id = $2 AND company_id = $3`,
+          [parentId, issueId, companyId],
+        )
+      }
+    }
+  }
+
+  return {
+    company,
+    agents_created: templateResult.agents_created,
+    goals_created: templateResult.goals_created,
+    policies_created: templateResult.policies_created,
+    projects_created: projectsCreated,
+    issues_created: issuesCreated,
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -380,3 +380,66 @@ export interface TemplateSummary {
   goal_count: number
   policy_count: number
 }
+
+// ---------------------------------------------------------------------------
+// Company Export/Import -- full portable company snapshots
+// ---------------------------------------------------------------------------
+
+/** A project definition within an export -- no IDs, uses agent/goal names. */
+export interface ExportProject {
+  name: string
+  description?: string | null
+  status: string
+  target_date?: string | null
+  /** Name of the goal this project is linked to (resolved at import time). */
+  goal_title?: string | null
+  /** Name of the lead agent (resolved at import time). */
+  lead_agent_name?: string | null
+}
+
+/** An issue definition within an export -- no IDs, uses name-based references. */
+export interface ExportIssue {
+  title: string
+  description?: string | null
+  status: string
+  priority: string
+  /** Name of the assigned agent (resolved at import time). */
+  assignee_agent_name?: string | null
+  /** Name of the project this issue belongs to (resolved at import time). */
+  project_name?: string | null
+  /** Title of the goal this issue is linked to (resolved at import time). */
+  goal_title?: string | null
+  /** Title of the parent issue (resolved at import time). */
+  parent_issue_title?: string | null
+}
+
+/**
+ * A full company export -- portable, ID-free snapshot of all company structure.
+ * Extends CompanyTemplate with projects and issues.
+ * All UUIDs, timestamps, cost_events, and heartbeat_runs are scrubbed.
+ */
+export interface CompanyExport extends CompanyTemplate {
+  /** Export format identifier. */
+  export_version: string
+  /** Company metadata. */
+  company: {
+    name: string
+    description?: string | null
+    issue_prefix: string
+    budget_monthly_cents: number
+    default_honesty_checklist?: string[] | null
+    require_approval: boolean
+  }
+  projects: ExportProject[]
+  issues: ExportIssue[]
+}
+
+/** Result of importing a company export. */
+export interface CompanyImportResult {
+  company: Company
+  agents_created: number
+  goals_created: number
+  policies_created: number
+  projects_created: number
+  issues_created: number
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -449,3 +449,50 @@ export const CompanyTemplateInput = z.object({
   policies: z.array(templatePolicySchema).optional().default([]),
 })
 export type CompanyTemplateInput = z.infer<typeof CompanyTemplateInput>
+
+// ---------------------------------------------------------------------------
+// Company Export/Import
+// ---------------------------------------------------------------------------
+
+const exportProjectSchema = z.object({
+  name: nonEmpty,
+  description: z.string().nullable().optional(),
+  status: z.enum(projectStatusValues).default(ProjectStatus.Active),
+  target_date: z.string().nullable().optional(),
+  goal_title: z.string().nullable().optional(),
+  lead_agent_name: z.string().nullable().optional(),
+})
+
+const exportIssueSchema = z.object({
+  title: nonEmpty,
+  description: z.string().nullable().optional(),
+  status: z.enum(issueStatusValues).default(IssueStatus.Backlog),
+  priority: z.enum(issuePriorityValues).default(IssuePriority.Medium),
+  assignee_agent_name: z.string().nullable().optional(),
+  project_name: z.string().nullable().optional(),
+  goal_title: z.string().nullable().optional(),
+  parent_issue_title: z.string().nullable().optional(),
+})
+
+const exportCompanyMetaSchema = z.object({
+  name: nonEmpty,
+  description: z.string().nullable().optional(),
+  issue_prefix: nonEmpty,
+  budget_monthly_cents: z.number().int().min(0).optional().default(0),
+  default_honesty_checklist: z.array(z.string().min(1)).nullable().optional(),
+  require_approval: z.boolean().optional().default(false),
+})
+
+export const CompanyExportInput = z.object({
+  export_version: z.string().default("1.0.0"),
+  name: nonEmpty,
+  description: z.string().default(""),
+  version: z.string().default("1.0.0"),
+  company: exportCompanyMetaSchema,
+  agents: z.array(templateAgentSchema).min(1),
+  goals: z.array(templateGoalSchema).optional().default([]),
+  policies: z.array(templatePolicySchema).optional().default([]),
+  projects: z.array(exportProjectSchema).optional().default([]),
+  issues: z.array(exportIssueSchema).optional().default([]),
+})
+export type CompanyExportInput = z.infer<typeof CompanyExportInput>


### PR DESCRIPTION
## Summary
- Adds `POST /api/companies/:id/export` to export a full company snapshot as portable JSON (agents, goals, policies, projects, issues) with all UUIDs scrubbed and secrets stripped
- Adds `POST /api/companies/import` to import from exported JSON, creating all entities with name-based reference resolution (two-pass for parent issues)
- Adds CLI commands: `shackleai company export [--output file.json]` and `shackleai company import <file.json>` with collision detection (prompts for rename if company name exists)
- Adds `CompanyExport`, `CompanyImportResult` types to `@shackleai/shared` and `CompanyExportInput` Zod validator
- Adds `exportCompany()` and `importCompany()` to `@shackleai/core`

## Test plan
- [ ] Export a company with agents, goals, policies, projects, and issues — verify JSON contains no UUIDs or timestamps
- [ ] Import the exported JSON into a fresh instance — verify all entities are created with correct references
- [ ] Import again with same name — verify 409 collision and rename prompt works
- [ ] Test CLI: `shackleai company export -o test.json` writes file correctly
- [ ] Test CLI: `shackleai company import test.json` creates company
- [ ] Verify secrets, cost_events, heartbeat_runs are NOT included in export

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)