### PR TITLE
feat: add issue attachments and work products tracking

### DIFF
--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -21,6 +21,7 @@ import {
   CrewAIAdapter,
   GovernanceEngine,
   QuotaManager,
+  createStorageProvider,
 } from '@shackleai/core'
 import { AgentApiKeyStatus } from '@shackleai/shared'
 import { readConfig, writeConfig, resolveDatabaseUrl } from '../config.js'
@@ -109,7 +110,10 @@ export async function startCommand(options: { port: number }): Promise<void> {
   )
   await scheduler.start()
 
-  const app = createApp(db, { scheduler })
+  // Storage provider for file attachments (defaults to local disk)
+  const storage = createStorageProvider({ type: 'local-disk' })
+
+  const app = createApp(db, { scheduler, storage })
 
   // Find an available port — try requested port first, then auto-increment
   const requestedPort = options.port

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -9,7 +9,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { DatabaseProvider } from '@shackleai/db'
-import type { Scheduler } from '@shackleai/core'
+import type { Scheduler, StorageProvider } from '@shackleai/core'
 import { companiesRouter } from './routes/companies.js'
 import { dashboardRouter } from './routes/dashboard.js'
 import { agentsRouter } from './routes/agents.js'
@@ -28,12 +28,16 @@ import { secretsRouter } from './routes/secrets.js'
 import { quotasRouter } from './routes/quotas.js'
 import { labelsRouter } from './routes/labels.js'
 import { templatesRouter, companyTemplatesRouter } from './routes/templates.js'
+import { attachmentsRouter } from './routes/attachments.js'
+import { workProductsRouter } from './routes/work-products.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
 
 export interface CreateAppOptions {
   scheduler?: Scheduler
+  /** Pluggable file storage backend for attachments. */
+  storage?: StorageProvider
   /** Skip API authentication — for testing only. NEVER set in production. */
   skipAuth?: boolean
 }
@@ -97,6 +101,10 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', secretsRouter(db))
   app.route('/api/companies', quotasRouter(db))
   app.route('/api/companies', labelsRouter(db))
+  if (options?.storage) {
+    app.route('/api/companies', attachmentsRouter(db, options.storage))
+  }
+  app.route('/api/companies', workProductsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/attachments.ts
+++ b/apps/cli/src/server/routes/attachments.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue attachment CRUD routes — /api/companies/:id/issues/:issueId/attachments
+ *
+ * Upload, list, download, and delete file attachments on issues.
+ * Uses the pluggable StorageProvider from @shackleai/core.
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { StorageProvider } from '@shackleai/core'
+import type { Issue, IssueAttachment } from '@shackleai/shared'
+import { MAX_ATTACHMENT_SIZE_BYTES } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+/**
+ * Verify the issue exists and belongs to the company.
+ * Returns null if not found, otherwise the issue id.
+ */
+async function verifyIssueOwnership(
+  db: DatabaseProvider,
+  issueId: string,
+  companyId: string,
+): Promise<string | null> {
+  const result = await db.query<Pick<Issue, 'id'>>(
+    `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+    [issueId, companyId],
+  )
+  return result.rows.length > 0 ? result.rows[0].id : null
+}
+
+export function attachmentsRouter(
+  db: DatabaseProvider,
+  storage: StorageProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/issues/:issueId/attachments — list attachments
+  app.get('/:id/issues/:issueId/attachments', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const { limit, offset } = parsePagination(c)
+    const result = await db.query<IssueAttachment>(
+      `SELECT * FROM issue_attachments WHERE issue_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [issueId, limit, offset],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/attachments — upload file
+  app.post('/:id/issues/:issueId/attachments', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const body = await c.req.parseBody()
+    const file = body['file']
+    if (!file || typeof file === 'string') {
+      return c.json({ error: 'Missing file in multipart form data' }, 400)
+    }
+
+    const agentId =
+      typeof body['agent_id'] === 'string' && body['agent_id'].trim()
+        ? body['agent_id'].trim()
+        : null
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const filename = file.name || 'unnamed'
+    const mime = file.type || 'application/octet-stream'
+
+    if (buffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+      return c.json(
+        {
+          error: `File too large. Maximum size is ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)} MB`,
+        },
+        413,
+      )
+    }
+
+    // Build storage key: attachments/<companyId>/<issueId>/<uuid>-<filename>
+    const uniquePrefix = crypto.randomUUID()
+    const storageKey = `attachments/${companyId}/${issueId}/${uniquePrefix}-${filename}`
+
+    const uploadResult = await storage.upload(storageKey, buffer, mime)
+
+    const result = await db.query<IssueAttachment>(
+      `INSERT INTO issue_attachments (issue_id, filename, mime_type, size_bytes, storage_key, uploaded_by_agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [issueId, filename, mime, uploadResult.size, storageKey, agentId],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/issues/:issueId/attachments/:attachId — download
+  app.get(
+    '/:id/issues/:issueId/attachments/:attachId',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id')!
+      const issueId = c.req.param('issueId')!
+      const attachId = c.req.param('attachId')!
+
+      const found = await verifyIssueOwnership(db, issueId, companyId)
+      if (!found) {
+        return c.json({ error: 'Issue not found' }, 404)
+      }
+
+      const result = await db.query<IssueAttachment>(
+        `SELECT * FROM issue_attachments WHERE id = $1 AND issue_id = $2`,
+        [attachId, issueId],
+      )
+
+      if (result.rows.length === 0) {
+        return c.json({ error: 'Attachment not found' }, 404)
+      }
+
+      const attachment = result.rows[0]
+      const download = await storage.download(attachment.storage_key)
+
+      return new Response(download.buffer, {
+        headers: {
+          'Content-Type': download.mime,
+          'Content-Length': String(download.size),
+          'Content-Disposition': `attachment; filename="${attachment.filename}"`,
+        },
+      })
+    },
+  )
+
+  // DELETE /api/companies/:id/issues/:issueId/attachments/:attachId — delete
+  app.delete(
+    '/:id/issues/:issueId/attachments/:attachId',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id')!
+      const issueId = c.req.param('issueId')!
+      const attachId = c.req.param('attachId')!
+
+      const found = await verifyIssueOwnership(db, issueId, companyId)
+      if (!found) {
+        return c.json({ error: 'Issue not found' }, 404)
+      }
+
+      const result = await db.query<IssueAttachment>(
+        `DELETE FROM issue_attachments WHERE id = $1 AND issue_id = $2 RETURNING *`,
+        [attachId, issueId],
+      )
+
+      if (result.rows.length === 0) {
+        return c.json({ error: 'Attachment not found' }, 404)
+      }
+
+      // Delete from storage (non-blocking — DB is source of truth)
+      void storage.delete(result.rows[0].storage_key).catch(() => {
+        // Orphan file cleanup can be handled by a background job
+      })
+
+      return c.json({ data: result.rows[0] })
+    },
+  )
+
+  return app
+}

--- a/apps/cli/src/server/routes/work-products.ts
+++ b/apps/cli/src/server/routes/work-products.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue work product CRUD routes — /api/companies/:id/issues/:issueId/work-products
+ *
+ * Track deliverables (PRs, documents, reports, deployments) produced for an issue.
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Issue, IssueWorkProduct } from '@shackleai/shared'
+import { CreateWorkProductInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+/**
+ * Verify the issue exists and belongs to the company.
+ */
+async function verifyIssueOwnership(
+  db: DatabaseProvider,
+  issueId: string,
+  companyId: string,
+): Promise<string | null> {
+  const result = await db.query<Pick<Issue, 'id'>>(
+    `SELECT id FROM issues WHERE id = $1 AND company_id = $2`,
+    [issueId, companyId],
+  )
+  return result.rows.length > 0 ? result.rows[0].id : null
+}
+
+export function workProductsRouter(
+  db: DatabaseProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/issues/:issueId/work-products — list
+  app.get('/:id/issues/:issueId/work-products', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    const { limit, offset } = parsePagination(c)
+    const result = await db.query<IssueWorkProduct>(
+      `SELECT * FROM issue_work_products WHERE issue_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [issueId, limit, offset],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/work-products — create
+  app.post('/:id/issues/:issueId/work-products', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const issueId = c.req.param('issueId')!
+
+    const found = await verifyIssueOwnership(db, issueId, companyId)
+    if (!found) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateWorkProductInput.safeParse({
+      issue_id: issueId,
+      ...(body as object),
+    })
+    if (!parsed.success) {
+      return c.json(
+        { error: 'Validation failed', details: parsed.error.flatten() },
+        400,
+      )
+    }
+
+    const { title, description, type, url, agent_id } = parsed.data
+
+    const result = await db.query<IssueWorkProduct>(
+      `INSERT INTO issue_work_products (issue_id, title, description, type, url, agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [issueId, title, description ?? null, type, url, agent_id ?? null],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/issues/:issueId/work-products/:wpId — get single
+  app.get(
+    '/:id/issues/:issueId/work-products/:wpId',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id')!
+      const issueId = c.req.param('issueId')!
+      const wpId = c.req.param('wpId')!
+
+      const found = await verifyIssueOwnership(db, issueId, companyId)
+      if (!found) {
+        return c.json({ error: 'Issue not found' }, 404)
+      }
+
+      const result = await db.query<IssueWorkProduct>(
+        `SELECT * FROM issue_work_products WHERE id = $1 AND issue_id = $2`,
+        [wpId, issueId],
+      )
+
+      if (result.rows.length === 0) {
+        return c.json({ error: 'Work product not found' }, 404)
+      }
+
+      return c.json({ data: result.rows[0] })
+    },
+  )
+
+  // DELETE /api/companies/:id/issues/:issueId/work-products/:wpId — delete
+  app.delete(
+    '/:id/issues/:issueId/work-products/:wpId',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id')!
+      const issueId = c.req.param('issueId')!
+      const wpId = c.req.param('wpId')!
+
+      const found = await verifyIssueOwnership(db, issueId, companyId)
+      if (!found) {
+        return c.json({ error: 'Issue not found' }, 404)
+      }
+
+      const result = await db.query<IssueWorkProduct>(
+        `DELETE FROM issue_work_products WHERE id = $1 AND issue_id = $2 RETURNING *`,
+        [wpId, issueId],
+      )
+
+      if (result.rows.length === 0) {
+        return c.json({ error: 'Work product not found' }, 404)
+      }
+
+      return c.json({ data: result.rows[0] })
+    },
+  )
+
+  return app
+}

--- a/packages/db/src/migrations/023_issue_attachments.ts
+++ b/packages/db/src/migrations/023_issue_attachments.ts
@@ -1,0 +1,27 @@
+export const name = '023_issue_attachments'
+
+export const sql = `
+  CREATE TABLE IF NOT EXISTS issue_attachments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    issue_id UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    filename TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    storage_key TEXT NOT NULL UNIQUE,
+    uploaded_by_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS idx_attachments_issue ON issue_attachments(issue_id);
+
+  CREATE TABLE IF NOT EXISTS issue_work_products (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    issue_id UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT,
+    type TEXT NOT NULL,
+    url TEXT NOT NULL,
+    agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS idx_work_products_issue ON issue_work_products(issue_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -21,6 +21,7 @@ import * as m019 from './019_heartbeat_run_events.js'
 import * as m020 from './020_quota_windows.js'
 import * as m021 from './021_honesty_checklist.js'
 import * as m022 from './022_labels.js'
+import * as m023 from './023_issue_attachments.js'
 
 export interface Migration {
   name: string
@@ -50,6 +51,7 @@ const migrations: Migration[] = [
   m020,
   m021,
   m022,
+  m023,
 ]
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -135,6 +135,20 @@ export const WorktreeStatus = {
 export type WorktreeStatus =
   (typeof WorktreeStatus)[keyof typeof WorktreeStatus]
 
+export const WorkProductType = {
+  PullRequest: 'pull_request',
+  Document: 'document',
+  Report: 'report',
+  Artifact: 'artifact',
+  Deployment: 'deployment',
+  Other: 'other',
+} as const
+export type WorkProductType =
+  (typeof WorkProductType)[keyof typeof WorkProductType]
+
+/** Maximum file size for attachments (10 MB). */
+export const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
+
 /** Free tier limit for concurrent active worktrees per company. */
 export const FREE_TIER_MAX_WORKTREES = 5
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -323,6 +323,33 @@ export interface IssueLabel {
   created_at: Date
 }
 
+
+// ---------------------------------------------------------------------------
+// Issue Attachments & Work Products
+// ---------------------------------------------------------------------------
+
+export interface IssueAttachment {
+  id: string
+  issue_id: string
+  filename: string
+  mime_type: string
+  size_bytes: number
+  storage_key: string
+  uploaded_by_agent_id: string | null
+  created_at: Date
+}
+
+export interface IssueWorkProduct {
+  id: string
+  issue_id: string
+  title: string
+  description: string | null
+  type: string
+  url: string
+  agent_id: string | null
+  created_at: Date
+}
+
 // ---------------------------------------------------------------------------
 // Company Templates
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -17,6 +17,7 @@ import {
   GoalStatus,
   ProjectStatus,
   AgentApiKeyStatus,
+  WorkProductType,
 } from './constants.js'
 
 // ---------------------------------------------------------------------------
@@ -496,3 +497,23 @@ export const CompanyExportInput = z.object({
   issues: z.array(exportIssueSchema).optional().default([]),
 })
 export type CompanyExportInput = z.infer<typeof CompanyExportInput>
+
+
+// ---------------------------------------------------------------------------
+// Work Products
+// ---------------------------------------------------------------------------
+
+const workProductTypeValues = Object.values(WorkProductType) as [
+  string,
+  ...string[],
+]
+
+export const CreateWorkProductInput = z.object({
+  issue_id: z.string().uuid().optional(),
+  title: z.string().min(1),
+  description: z.string().nullable().optional(),
+  type: z.enum(workProductTypeValues),
+  url: z.string().min(1),
+  agent_id: z.string().uuid().nullable().optional(),
+})
+export type CreateWorkProductInput = z.infer<typeof CreateWorkProductInput>


### PR DESCRIPTION
## Summary
- **Migration 023**: Creates `issue_attachments` and `issue_work_products` tables with proper FK constraints and indexes
- **Attachment API**: Upload (multipart, 10MB limit), list, download, and delete file attachments using the pluggable `StorageProvider` from #128
- **Work Products API**: CRUD for tracking deliverables (PRs, documents, reports, deployments) linked to issues with Zod validation
- **Shared types**: `IssueAttachment`, `IssueWorkProduct`, `WorkProductType` enum, `MAX_ATTACHMENT_SIZE_BYTES`, `CreateWorkProductInput` validator

### API Routes Added
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/companies/:id/issues/:issueId/attachments` | Upload file (multipart form) |
| GET | `/api/companies/:id/issues/:issueId/attachments` | List attachments |
| GET | `/api/companies/:id/issues/:issueId/attachments/:attachId` | Download file |
| DELETE | `/api/companies/:id/issues/:issueId/attachments/:attachId` | Delete attachment |
| POST | `/api/companies/:id/issues/:issueId/work-products` | Create work product |
| GET | `/api/companies/:id/issues/:issueId/work-products` | List work products |
| GET | `/api/companies/:id/issues/:issueId/work-products/:wpId` | Get work product |
| DELETE | `/api/companies/:id/issues/:issueId/work-products/:wpId` | Delete work product |

Closes #163

## Test plan
- [ ] Verify migration applies cleanly on fresh DB
- [ ] Upload attachment via multipart POST, verify file stored and DB record created
- [ ] List attachments returns uploaded files
- [ ] Download returns correct file content and headers
- [ ] Delete removes DB record and storage file
- [ ] File size > 10MB returns 413
- [ ] Work product CRUD with valid/invalid payloads
- [ ] Verify company scope middleware blocks cross-company access
- [ ] Verify 404 for non-existent issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)