### PR TITLE
feat: add document system with revisions and issue linking

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -27,6 +27,7 @@ import { approvalsRouter } from './routes/approvals.js'
 import { secretsRouter } from './routes/secrets.js'
 import { quotasRouter } from './routes/quotas.js'
 import { labelsRouter } from './routes/labels.js'
+import { documentsRouter } from './routes/documents.js'
 import { templatesRouter, companyTemplatesRouter } from './routes/templates.js'
 import { attachmentsRouter } from './routes/attachments.js'
 import { workProductsRouter } from './routes/work-products.js'
@@ -105,6 +106,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
     app.route('/api/companies', attachmentsRouter(db, options.storage))
   }
   app.route('/api/companies', workProductsRouter(db))
+  app.route('/api/companies', documentsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/documents.ts
+++ b/apps/cli/src/server/routes/documents.ts
@@ -1,0 +1,263 @@
+/**
+ * Document CRUD, revisions, and issue-document linking routes
+ * /api/companies/:id/documents and /api/companies/:id/issues/:issueId/documents
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { Document, DocumentRevision } from '@shackleai/shared'
+import {
+  CreateDocumentInput,
+  UpdateDocumentInput,
+  LinkDocumentInput,
+} from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+type Variables = CompanyScopeVariables
+
+export function documentsRouter(
+  db: DatabaseProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/documents
+  app.get('/:id/documents', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const result = await db.query<Document>(
+      'SELECT * FROM documents WHERE company_id = $1 ORDER BY updated_at DESC',
+      [companyId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/documents
+  app.post('/:id/documents', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+    const parsed = CreateDocumentInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+    const { title, content, created_by_agent_id } = parsed.data
+    if (created_by_agent_id) {
+      const agentCheck = await db.query<{ id: string }>(
+        'SELECT id FROM agents WHERE id = $1 AND company_id = $2',
+        [created_by_agent_id, companyId],
+      )
+      if (agentCheck.rows.length === 0) {
+        return c.json({ error: 'Agent not found in this company' }, 404)
+      }
+    }
+    const result = await db.query<Document>(
+      `INSERT INTO documents (company_id, title, content, created_by_agent_id)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [companyId, title, content, created_by_agent_id ?? null],
+    )
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // GET /api/companies/:id/documents/:docId
+  app.get('/:id/documents/:docId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const docId = c.req.param('docId')
+    const result = await db.query<Document>(
+      'SELECT * FROM documents WHERE id = $1 AND company_id = $2',
+      [docId, companyId],
+    )
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+    return c.json({ data: result.rows[0] })
+  })
+
+  // PUT /api/companies/:id/documents/:docId -- auto-creates revision on content change
+  app.put('/:id/documents/:docId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const docId = c.req.param('docId')
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+    const parsed = UpdateDocumentInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+    const updates = parsed.data
+    const existing = await db.query<Document>(
+      'SELECT * FROM documents WHERE id = $1 AND company_id = $2',
+      [docId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+    const doc = existing.rows[0]
+    // Create revision of old content when content changes
+    if (updates.content !== undefined && updates.content !== doc.content) {
+      const revResult = await db.query<{ max_rev: number | null }>(
+        'SELECT MAX(revision_number) AS max_rev FROM document_revisions WHERE document_id = $1',
+        [docId],
+      )
+      const nextRev = (revResult.rows[0]?.max_rev ?? 0) + 1
+      await db.query(
+        `INSERT INTO document_revisions (document_id, content, revision_number, created_by_agent_id)
+         VALUES ($1, $2, $3, $4)`,
+        [docId, doc.content, nextRev, updates.updated_by_agent_id ?? null],
+      )
+    }
+    // Build dynamic update
+    const setClauses: string[] = ['updated_at = NOW()']
+    const values: unknown[] = [docId, companyId]
+    let paramIdx = 3
+    if (updates.title !== undefined) {
+      setClauses.push(`title = $${paramIdx}`)
+      values.push(updates.title)
+      paramIdx++
+    }
+    if (updates.content !== undefined) {
+      setClauses.push(`content = $${paramIdx}`)
+      values.push(updates.content)
+      paramIdx++
+    }
+    const result = await db.query<Document>(
+      `UPDATE documents SET ${setClauses.join(', ')}
+       WHERE id = $1 AND company_id = $2
+       RETURNING *`,
+      values,
+    )
+    return c.json({ data: result.rows[0] })
+  })
+
+  // DELETE /api/companies/:id/documents/:docId
+  app.delete('/:id/documents/:docId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const docId = c.req.param('docId')
+    const result = await db.query(
+      'DELETE FROM documents WHERE id = $1 AND company_id = $2 RETURNING id',
+      [docId, companyId],
+    )
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+    return c.json({ data: { deleted: true } })
+  })
+
+  // GET /api/companies/:id/documents/:docId/revisions
+  app.get('/:id/documents/:docId/revisions', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const docId = c.req.param('docId')
+    const docCheck = await db.query<{ id: string }>(
+      'SELECT id FROM documents WHERE id = $1 AND company_id = $2',
+      [docId, companyId],
+    )
+    if (docCheck.rows.length === 0) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+    const result = await db.query<DocumentRevision>(
+      'SELECT * FROM document_revisions WHERE document_id = $1 ORDER BY revision_number DESC',
+      [docId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // GET /api/companies/:id/issues/:issueId/documents
+  app.get('/:id/issues/:issueId/documents', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+    const issueCheck = await db.query<{ id: string }>(
+      'SELECT id FROM issues WHERE id = $1 AND company_id = $2',
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+    const result = await db.query<Document>(
+      `SELECT d.* FROM documents d
+       INNER JOIN issue_documents idoc ON idoc.document_id = d.id
+       WHERE idoc.issue_id = $1
+       ORDER BY d.updated_at DESC`,
+      [issueId],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/issues/:issueId/documents -- link
+  app.post('/:id/issues/:issueId/documents', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+    const parsed = LinkDocumentInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+    const { document_id } = parsed.data
+    const issueCheck = await db.query<{ id: string }>(
+      'SELECT id FROM issues WHERE id = $1 AND company_id = $2',
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+    const docCheck = await db.query<{ id: string }>(
+      'SELECT id FROM documents WHERE id = $1 AND company_id = $2',
+      [document_id, companyId],
+    )
+    if (docCheck.rows.length === 0) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+    const existing = await db.query(
+      'SELECT * FROM issue_documents WHERE issue_id = $1 AND document_id = $2',
+      [issueId, document_id],
+    )
+    if (existing.rows.length > 0) {
+      return c.json({ error: 'Document already linked to this issue' }, 409)
+    }
+    await db.query(
+      'INSERT INTO issue_documents (issue_id, document_id) VALUES ($1, $2)',
+      [issueId, document_id],
+    )
+    return c.json({ data: { linked: true } }, 201)
+  })
+
+  // DELETE /api/companies/:id/issues/:issueId/documents/:docId -- unlink
+  app.delete('/:id/issues/:issueId/documents/:docId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const issueId = c.req.param('issueId')
+    const docId = c.req.param('docId')
+    const issueCheck = await db.query<{ id: string }>(
+      'SELECT id FROM issues WHERE id = $1 AND company_id = $2',
+      [issueId, companyId],
+    )
+    if (issueCheck.rows.length === 0) {
+      return c.json({ error: 'Issue not found' }, 404)
+    }
+    const result = await db.query(
+      'DELETE FROM issue_documents WHERE issue_id = $1 AND document_id = $2 RETURNING issue_id',
+      [issueId, docId],
+    )
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Document not linked to this issue' }, 404)
+    }
+    return c.json({ data: { unlinked: true } })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/024_documents.ts
+++ b/packages/db/src/migrations/024_documents.ts
@@ -1,0 +1,36 @@
+export const name = '024_documents'
+
+export const sql = `
+  CREATE TABLE IF NOT EXISTS documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    created_by_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS document_revisions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    content TEXT NOT NULL,
+    revision_number INTEGER NOT NULL DEFAULT 1,
+    created_by_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS issue_documents (
+    issue_id UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (issue_id, document_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_documents_company_id ON documents(company_id);
+  CREATE INDEX IF NOT EXISTS idx_documents_created_by ON documents(created_by_agent_id);
+  CREATE INDEX IF NOT EXISTS idx_document_revisions_document_id ON document_revisions(document_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_document_revisions_unique ON document_revisions(document_id, revision_number);
+  CREATE INDEX IF NOT EXISTS idx_issue_documents_document_id ON issue_documents(document_id);
+  CREATE INDEX IF NOT EXISTS idx_issue_documents_issue_id ON issue_documents(issue_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -22,6 +22,7 @@ import * as m020 from './020_quota_windows.js'
 import * as m021 from './021_honesty_checklist.js'
 import * as m022 from './022_labels.js'
 import * as m023 from './023_issue_attachments.js'
+import * as m024 from './024_documents.js'
 
 export interface Migration {
   name: string
@@ -52,6 +53,7 @@ const migrations: Migration[] = [
   m021,
   m022,
   m023,
+  m024,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -351,6 +351,35 @@ export interface IssueWorkProduct {
 }
 
 // ---------------------------------------------------------------------------
+// Documents
+// ---------------------------------------------------------------------------
+
+export interface Document {
+  id: string
+  company_id: string
+  title: string
+  content: string
+  created_by_agent_id: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface DocumentRevision {
+  id: string
+  document_id: string
+  content: string
+  revision_number: number
+  created_by_agent_id: string | null
+  created_at: Date
+}
+
+export interface IssueDocument {
+  issue_id: string
+  document_id: string
+  created_at: Date
+}
+
+// ---------------------------------------------------------------------------
 // Company Templates
 // ---------------------------------------------------------------------------
 

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -411,6 +411,29 @@ export const AssignLabelInput = z.object({
 export type AssignLabelInput = z.infer<typeof AssignLabelInput>
 
 // ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+export const CreateDocumentInput = z.object({
+  title: nonEmpty,
+  content: z.string().optional().default(''),
+  created_by_agent_id: uuid.nullable().optional(),
+})
+export type CreateDocumentInput = z.infer<typeof CreateDocumentInput>
+
+export const UpdateDocumentInput = z.object({
+  title: nonEmpty.optional(),
+  content: z.string().optional(),
+  updated_by_agent_id: uuid.nullable().optional(),
+})
+export type UpdateDocumentInput = z.infer<typeof UpdateDocumentInput>
+
+export const LinkDocumentInput = z.object({
+  document_id: uuid,
+})
+export type LinkDocumentInput = z.infer<typeof LinkDocumentInput>
+
+// ---------------------------------------------------------------------------
 // Company Template
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `documents`, `document_revisions`, and `issue_documents` tables (migration 023)
- Full CRUD API routes at `/api/companies/:id/documents` with revision history and issue linking
- Auto-creates revision snapshot of old content on every document update
- Zod validators and TypeScript interfaces in `@shackleai/shared`

## Routes
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/companies/:id/documents` | List documents |
| POST | `/api/companies/:id/documents` | Create document |
| GET | `/api/companies/:id/documents/:docId` | Get document |
| PUT | `/api/companies/:id/documents/:docId` | Update (auto-revision) |
| DELETE | `/api/companies/:id/documents/:docId` | Delete document |
| GET | `/api/companies/:id/documents/:docId/revisions` | Revision history |
| GET | `/api/companies/:id/issues/:issueId/documents` | List linked docs |
| POST | `/api/companies/:id/issues/:issueId/documents` | Link document |
| DELETE | `/api/companies/:id/issues/:issueId/documents/:docId` | Unlink |

## Test plan
- [x] Build passes (`npm run build`)
- [x] DB migration test passes (14/14)
- [x] Shared validators test passes (51/51)
- [x] CLI route tests pass
- [ ] E2E: Create document, update content, verify revision created
- [ ] E2E: Link/unlink document to issue
- [ ] E2E: Delete document cascades revisions and links

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)