### PR TITLE
feat: add asset management with upload, serving, and deletion

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -31,7 +31,9 @@ import { documentsRouter } from './routes/documents.js'
 import { inboxRouter } from './routes/inbox.js'
 import { templatesRouter, companyTemplatesRouter } from './routes/templates.js'
 import { attachmentsRouter } from './routes/attachments.js'
+import { assetsRouter, assetServeRouter } from './routes/assets.js'
 import { workProductsRouter } from './routes/work-products.js'
+import { workspaceOperationsRouter } from './routes/workspace-operations.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
@@ -106,9 +108,12 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', inboxRouter(db))
   if (options?.storage) {
     app.route('/api/companies', attachmentsRouter(db, options.storage))
+    app.route('/api/companies', assetsRouter(db, options.storage))
+    app.route('/api/assets', assetServeRouter(db, options.storage))
   }
   app.route('/api/companies', workProductsRouter(db))
   app.route('/api/companies', documentsRouter(db))
+  app.route('/api/companies', workspaceOperationsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/assets.ts
+++ b/apps/cli/src/server/routes/assets.ts
@@ -1,0 +1,167 @@
+/**
+ * Asset management routes — /api/companies/:id/assets and /api/assets/:assetId
+ *
+ * Upload, list, serve, and delete company-level file assets.
+ * Uses the pluggable StorageProvider from @shackleai/core.
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { StorageProvider } from '@shackleai/core'
+import type { Asset } from '@shackleai/shared'
+import { MAX_ASSET_SIZE_BYTES, ALLOWED_ASSET_MIME_TYPES } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+/**
+ * Company-scoped asset routes: upload, list, delete.
+ * Mounted at /api/companies so paths include /:id/assets.
+ */
+export function assetsRouter(
+  db: DatabaseProvider,
+  storage: StorageProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/assets — list assets for the company
+  app.get('/:id/assets', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const { limit, offset } = parsePagination(c)
+
+    const result = await db.query<Asset>(
+      `SELECT * FROM assets WHERE company_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/assets — upload a file
+  app.post('/:id/assets', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+
+    const body = await c.req.parseBody()
+    const file = body['file']
+    if (!file || typeof file === 'string') {
+      return c.json({ error: 'Missing file in multipart form data' }, 400)
+    }
+
+    const uploadedBy =
+      typeof body['uploaded_by'] === 'string' && body['uploaded_by'].trim()
+        ? body['uploaded_by'].trim()
+        : null
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const filename = file.name || 'unnamed'
+    const mime = file.type || 'application/octet-stream'
+
+    // Validate file size
+    if (buffer.length > MAX_ASSET_SIZE_BYTES) {
+      return c.json(
+        {
+          error: `File too large. Maximum size is ${MAX_ASSET_SIZE_BYTES / (1024 * 1024)} MB`,
+        },
+        413,
+      )
+    }
+
+    // Validate MIME type
+    if (
+      !(ALLOWED_ASSET_MIME_TYPES as readonly string[]).includes(mime)
+    ) {
+      return c.json(
+        {
+          error: `Unsupported file type: ${mime}. Allowed types: ${ALLOWED_ASSET_MIME_TYPES.join(', ')}`,
+        },
+        415,
+      )
+    }
+
+    // Build storage key: assets/<companyId>/<uuid>-<filename>
+    const uniquePrefix = crypto.randomUUID()
+    const storageKey = `assets/${companyId}/${uniquePrefix}-${filename}`
+
+    const uploadResult = await storage.upload(storageKey, buffer, mime)
+
+    const result = await db.query<Asset>(
+      `INSERT INTO assets (company_id, filename, mime_type, size_bytes, storage_key, uploaded_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [companyId, filename, mime, uploadResult.size, storageKey, uploadedBy],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // DELETE /api/companies/:id/assets/:assetId — delete an asset
+  app.delete('/:id/assets/:assetId', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const assetId = c.req.param('assetId')!
+
+    const result = await db.query<Asset>(
+      `DELETE FROM assets WHERE id = $1 AND company_id = $2 RETURNING *`,
+      [assetId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Asset not found' }, 404)
+    }
+
+    // Delete from storage (non-blocking — DB is source of truth)
+    void storage.delete(result.rows[0].storage_key).catch(() => {
+      // Orphan file cleanup can be handled by a background job
+    })
+
+    return c.json({ data: result.rows[0] })
+  })
+
+  return app
+}
+
+/**
+ * Public asset serving route — /api/assets/:assetId
+ * No company scope required; asset ID is globally unique.
+ */
+export function assetServeRouter(
+  db: DatabaseProvider,
+  storage: StorageProvider,
+): Hono {
+  const app = new Hono()
+
+  // GET /api/assets/:assetId — serve file content
+  app.get('/:assetId', async (c) => {
+    const assetId = c.req.param('assetId')!
+
+    const result = await db.query<Asset>(
+      `SELECT * FROM assets WHERE id = $1`,
+      [assetId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Asset not found' }, 404)
+    }
+
+    const asset = result.rows[0]
+    const download = await storage.download(asset.storage_key)
+
+    return new Response(download.buffer, {
+      headers: {
+        'Content-Type': download.mime,
+        'Content-Length': String(download.size),
+        'Content-Disposition': `inline; filename="${asset.filename}"`,
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/027_assets.ts
+++ b/packages/db/src/migrations/027_assets.ts
@@ -1,0 +1,15 @@
+export const name = '027_assets'
+export const sql = `
+  CREATE TABLE IF NOT EXISTS assets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    filename TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    storage_key TEXT NOT NULL,
+    uploaded_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS idx_assets_company ON assets(company_id, created_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_assets_storage_key ON assets(storage_key);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -25,6 +25,7 @@ import * as m023 from './023_issue_attachments.js'
 import * as m024 from './024_documents.js'
 import * as m025 from './025_wakeup_requests.js'
 import * as m026 from './026_issue_read_states.js'
+import * as m027 from './027_assets.js'
 
 export interface Migration {
   name: string
@@ -58,6 +59,7 @@ const migrations: Migration[] = [
   m024,
   m025,
   m026,
+  m027,
 ]
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -149,6 +149,44 @@ export type WorkProductType =
 /** Maximum file size for attachments (10 MB). */
 export const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
+/** Maximum file size for assets (10 MB). */
+export const MAX_ASSET_SIZE_BYTES = 10 * 1024 * 1024
+
+/** Allowed MIME types for asset uploads. */
+export const ALLOWED_ASSET_MIME_TYPES = [
+  // Images
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  // Documents
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'application/json',
+  // Archives
+  'application/zip',
+  'application/gzip',
+  // Office
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+] as const
+
+export const WorkspaceOperationType = {
+  FileRead: 'file_read',
+  FileWrite: 'file_write',
+  FileDelete: 'file_delete',
+  GitCommit: 'git_commit',
+  GitPush: 'git_push',
+  GitBranch: 'git_branch',
+  CommandExec: 'command_exec',
+} as const
+export type WorkspaceOperationType =
+  (typeof WorkspaceOperationType)[keyof typeof WorkspaceOperationType]
+
 /** Free tier limit for concurrent active worktrees per company. */
 export const FREE_TIER_MAX_WORKTREES = 5
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -325,6 +325,21 @@ export interface IssueLabel {
 
 
 // ---------------------------------------------------------------------------
+// Assets (company-level file storage)
+// ---------------------------------------------------------------------------
+
+export interface Asset {
+  id: string
+  company_id: string
+  filename: string
+  mime_type: string
+  size_bytes: number
+  storage_key: string
+  uploaded_by: string | null
+  created_at: Date
+}
+
+// ---------------------------------------------------------------------------
 // Issue Attachments & Work Products
 // ---------------------------------------------------------------------------
 
@@ -530,5 +545,19 @@ export interface WakeupRequest {
   status: 'pending' | 'processed' | 'expired'
   created_at: string
   processed_at: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Operations — immutable audit trail for agent workspace activity
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceOperation {
+  id: string
+  workspace_id: string
+  agent_id: string
+  operation_type: string
+  file_path: string | null
+  details: Record<string, unknown>
+  created_at: Date
 }
 


### PR DESCRIPTION
Adds asset management layer on top of storage abstraction. Migration 027_assets, 4 API routes (upload, list, serve, delete), MIME validation, 10MB limit. Closes #170