### PR TITLE
feat: add keyboard shortcuts system with help modal

### DIFF
--- a/apps/dashboard/src/components/KeyboardShortcutsHelp.tsx
+++ b/apps/dashboard/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+import type { KeyboardShortcut } from '@/hooks/useKeyboardShortcuts'
+
+interface KeyboardShortcutsHelpProps {
+  open: boolean
+  onClose: () => void
+  shortcuts: KeyboardShortcut[]
+}
+
+/** Render a human-readable key label. */
+function formatKey(key: string): string {
+  const map: Record<string, string> = {
+    Shift: 'Shift',
+    '?': '?',
+  }
+  return map[key] ?? key.toUpperCase()
+}
+
+export function KeyboardShortcutsHelp({
+  open,
+  onClose,
+  shortcuts,
+}: KeyboardShortcutsHelpProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Close on Escape — capture phase so it fires before the shortcut handler
+  useEffect(() => {
+    if (!open) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [open, onClose])
+
+  // Focus the close button when the modal opens
+  useEffect(() => {
+    if (!open) return
+    const el = dialogRef.current
+    if (el) {
+      const focusable = el.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      focusable?.focus()
+    }
+  }, [open])
+
+  if (!open) return null
+
+  // Group shortcuts by category
+  const categories: Array<{
+    key: string
+    label: string
+    items: KeyboardShortcut[]
+  }> = []
+  const categoryLabels: Record<string, string> = {
+    navigation: 'Navigation',
+    actions: 'Actions',
+  }
+
+  for (const s of shortcuts) {
+    let group = categories.find((c) => c.key === s.category)
+    if (!group) {
+      group = {
+        key: s.category,
+        label: categoryLabels[s.category] ?? s.category,
+        items: [],
+      }
+      categories.push(group)
+    }
+    group.items.push(s)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+      role="presentation"
+    >
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div
+        ref={dialogRef}
+        className="relative z-50 w-full max-w-md overflow-hidden rounded-xl border border-border bg-background shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold">Keyboard Shortcuts</h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            aria-label="Close shortcuts help"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="max-h-[60vh] overflow-y-auto p-4 space-y-5">
+          {categories.map((category) => (
+            <div key={category.key}>
+              <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {category.label}
+              </h3>
+              <div className="space-y-1.5">
+                {category.items.map((shortcut) => (
+                  <div
+                    key={shortcut.id}
+                    className="flex items-center justify-between rounded-lg px-2 py-1.5 text-sm"
+                  >
+                    <span className="text-foreground">{shortcut.label}</span>
+                    <span className="flex items-center gap-1">
+                      {shortcut.keys.map((key, i) => (
+                        <span key={i} className="flex items-center gap-0.5">
+                          {i > 0 && (
+                            <span className="mx-0.5 text-[10px] text-muted-foreground">
+                              then
+                            </span>
+                          )}
+                          <kbd className="inline-flex min-w-[20px] items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground">
+                            {formatKey(key)}
+                          </kbd>
+                        </span>
+                      ))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Cmd+K note — not managed by this system */}
+          <div className="border-t border-border pt-3">
+            <div className="flex items-center justify-between rounded-lg px-2 py-1.5 text-sm">
+              <span className="text-foreground">Open command palette</span>
+              <span className="flex items-center gap-1">
+                <kbd className="inline-flex min-w-[20px] items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground">
+                  Ctrl
+                </kbd>
+                <span className="mx-0.5 text-[10px] text-muted-foreground">
+                  +
+                </span>
+                <kbd className="inline-flex min-w-[20px] items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground">
+                  K
+                </kbd>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-border px-4 py-2 text-[10px] text-muted-foreground">
+          Press{' '}
+          <kbd className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[9px]">
+            ESC
+          </kbd>{' '}
+          to close
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/dashboard/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export interface KeyboardShortcut {
+  /** Unique identifier */
+  id: string
+  /** Human-readable description */
+  label: string
+  /** Key sequence — single key or two-key chord (e.g. ['g', 'a']) */
+  keys: string[]
+  /** Category for grouping in the help modal */
+  category: 'navigation' | 'actions'
+  /** Action to execute */
+  action: () => void
+}
+
+interface UseKeyboardShortcutsOptions {
+  /** Extra shortcuts beyond the defaults */
+  shortcuts?: KeyboardShortcut[]
+  /** Callbacks for built-in actions */
+  onToggleHelp?: () => void
+}
+
+/**
+ * Determines whether the event target is an interactive element where
+ * we should NOT intercept single-key shortcuts.
+ */
+function isEditableTarget(e: KeyboardEvent): boolean {
+  const tag = (e.target as HTMLElement)?.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if ((e.target as HTMLElement)?.isContentEditable) return true
+  return false
+}
+
+/**
+ * Global keyboard shortcuts with support for two-key chords (e.g. g then a).
+ *
+ * Design choices:
+ * - Does NOT intercept Cmd/Ctrl combos — those belong to the browser or
+ *   CommandPalette (Ctrl+K).
+ * - Ignores keystrokes inside editable fields.
+ * - Two-key chords must be completed within 1.5 s.
+ */
+export function useKeyboardShortcuts({
+  shortcuts: extraShortcuts = [],
+  onToggleHelp,
+}: UseKeyboardShortcutsOptions = {}) {
+  const navigate = useNavigate()
+  const pendingKeyRef = useRef<string | null>(null)
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Build the default shortcut table.
+  const defaults: KeyboardShortcut[] = [
+    {
+      id: 'go-overview',
+      label: 'Go to Overview',
+      keys: ['g', 'o'],
+      category: 'navigation',
+      action: () => navigate('/'),
+    },
+    {
+      id: 'go-agents',
+      label: 'Go to Agents',
+      keys: ['g', 'a'],
+      category: 'navigation',
+      action: () => navigate('/agents'),
+    },
+    {
+      id: 'go-tasks',
+      label: 'Go to Tasks',
+      keys: ['g', 'i'],
+      category: 'navigation',
+      action: () => navigate('/tasks'),
+    },
+    {
+      id: 'go-board',
+      label: 'Go to Board',
+      keys: ['g', 'b'],
+      category: 'navigation',
+      action: () => navigate('/board'),
+    },
+    {
+      id: 'go-activity',
+      label: 'Go to Activity',
+      keys: ['g', 'v'],
+      category: 'navigation',
+      action: () => navigate('/activity'),
+    },
+    {
+      id: 'go-costs',
+      label: 'Go to Costs',
+      keys: ['g', 'c'],
+      category: 'navigation',
+      action: () => navigate('/costs'),
+    },
+    {
+      id: 'go-org-chart',
+      label: 'Go to Org Chart',
+      keys: ['g', 'r'],
+      category: 'navigation',
+      action: () => navigate('/org-chart'),
+    },
+    {
+      id: 'go-settings',
+      label: 'Go to Settings',
+      keys: ['g', 's'],
+      category: 'navigation',
+      action: () => navigate('/settings'),
+    },
+    {
+      id: 'show-help',
+      label: 'Show keyboard shortcuts',
+      keys: ['Shift', '?'],
+      category: 'actions',
+      action: () => onToggleHelp?.(),
+    },
+  ]
+
+  const allShortcuts = [...defaults, ...extraShortcuts]
+
+  const clearPending = useCallback(() => {
+    pendingKeyRef.current = null
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current)
+      pendingTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Never intercept modifier combos (Cmd+K, Ctrl+K, etc.)
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+
+      // Never intercept inside editable fields
+      if (isEditableTarget(e)) return
+
+      const key = e.key
+
+      // --- Handle Shift+? (shows as '?' with shiftKey) ---
+      if (key === '?' && e.shiftKey) {
+        const match = allShortcuts.find(
+          (s) => s.keys.length === 2 && s.keys[0] === 'Shift' && s.keys[1] === '?',
+        )
+        if (match) {
+          e.preventDefault()
+          clearPending()
+          match.action()
+          return
+        }
+      }
+
+      // --- Two-key chord handling ---
+      if (pendingKeyRef.current) {
+        const firstKey = pendingKeyRef.current
+        clearPending()
+
+        const match = allShortcuts.find(
+          (s) =>
+            s.keys.length === 2 &&
+            s.keys[0] !== 'Shift' &&
+            s.keys[0] === firstKey &&
+            s.keys[1] === key,
+        )
+        if (match) {
+          e.preventDefault()
+          match.action()
+        }
+        return
+      }
+
+      // --- Start a chord if any shortcut begins with this key ---
+      const startsChord = allShortcuts.some(
+        (s) => s.keys.length === 2 && s.keys[0] !== 'Shift' && s.keys[0] === key,
+      )
+      if (startsChord) {
+        pendingKeyRef.current = key
+        pendingTimerRef.current = setTimeout(clearPending, 1500)
+        return
+      }
+
+      // --- Single-key shortcuts ---
+      const match = allShortcuts.find(
+        (s) => s.keys.length === 1 && s.keys[0] === key,
+      )
+      if (match) {
+        e.preventDefault()
+        match.action()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      clearPending()
+    }
+  })
+
+  return { shortcuts: allShortcuts }
+}

--- a/apps/dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/dashboard/src/layouts/DashboardLayout.tsx
@@ -21,7 +21,9 @@ import { CompanySelector } from '@/components/CompanySelector'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { LiveIndicator } from '@/components/LiveIndicator'
 import { CommandPalette } from '@/components/CommandPalette'
+import { KeyboardShortcutsHelp } from '@/components/KeyboardShortcutsHelp'
 import { useRecentPages } from '@/hooks/useRecentPages'
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 
 const navItems = [
   { to: '/', icon: LayoutDashboard, label: 'Overview', end: true },
@@ -46,8 +48,14 @@ function getPageLabel(pathname: string): string {
 export function DashboardLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(false)
+  const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false)
   const location = useLocation()
   const { addRecentPage } = useRecentPages()
+
+  // Global keyboard shortcuts (g+a, g+i, Shift+?, etc.)
+  const { shortcuts } = useKeyboardShortcuts({
+    onToggleHelp: () => setShortcutsHelpOpen((prev) => !prev),
+  })
 
   // Track page visits for recent pages
   useEffect(() => {
@@ -71,6 +79,13 @@ export function DashboardLayout() {
     <div className="flex h-screen overflow-hidden">
       {/* Command Palette */}
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+
+      {/* Keyboard Shortcuts Help Modal */}
+      <KeyboardShortcutsHelp
+        open={shortcutsHelpOpen}
+        onClose={() => setShortcutsHelpOpen(false)}
+        shortcuts={shortcuts}
+      />
 
       {/* Mobile overlay */}
       {sidebarOpen && (


### PR DESCRIPTION
## Summary
- Added `useKeyboardShortcuts` hook with configurable two-key chord support (1.5s timeout between keys)
- Added `KeyboardShortcutsHelp` modal component showing all available shortcuts
- Default navigation shortcuts: `g` then `a` (agents), `g` then `i` (tasks), `g` then `c` (costs), `g` then `o` (overview), `g` then `b` (board), `g` then `v` (activity), `g` then `r` (org chart), `g` then `s` (settings)
- `Shift+?` toggles the help modal
- Skips shortcuts inside editable fields (inputs, textareas, contenteditable)
- Does not conflict with existing `Ctrl+K` command palette

## Files changed
- `apps/dashboard/src/hooks/useKeyboardShortcuts.ts` — new hook
- `apps/dashboard/src/components/KeyboardShortcutsHelp.tsx` — new modal component
- `apps/dashboard/src/layouts/DashboardLayout.tsx` — integration

## Test plan
- [ ] Press `g` then `a` — navigates to /agents
- [ ] Press `g` then `i` — navigates to /tasks
- [ ] Press `g` then `c` — navigates to /costs
- [ ] Press `Shift+?` — opens help modal, press again or ESC to close
- [ ] Type in a search input — shortcuts do not fire
- [ ] Press `Ctrl+K` — command palette still works as before
- [ ] Verify all navigation shortcuts listed in help modal work correctly

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)