### PR TITLE
feat: add autosave indicator for forms and editors

### DIFF
--- a/apps/dashboard/src/components/ui/autosave-indicator.tsx
+++ b/apps/dashboard/src/components/ui/autosave-indicator.tsx
@@ -1,0 +1,49 @@
+import type { AutosaveStatus } from '@/hooks/useAutosave'
+import { Check, Loader2, AlertCircle } from 'lucide-react'
+
+interface AutosaveIndicatorProps {
+  status: AutosaveStatus
+  className?: string
+}
+
+const config: Record<
+  AutosaveStatus,
+  { icon: React.ReactNode; label: string; className: string } | null
+> = {
+  idle: null,
+  saving: {
+    icon: <Loader2 className="h-3 w-3 animate-spin" />,
+    label: 'Saving...',
+    className: 'text-muted-foreground',
+  },
+  saved: {
+    icon: <Check className="h-3 w-3" />,
+    label: 'Saved',
+    className: 'text-emerald-500',
+  },
+  error: {
+    icon: <AlertCircle className="h-3 w-3" />,
+    label: 'Error saving',
+    className: 'text-destructive',
+  },
+}
+
+/**
+ * Subtle inline indicator for autosave status.
+ * Renders nothing when idle.
+ */
+export function AutosaveIndicator({ status, className }: AutosaveIndicatorProps) {
+  const entry = config[status]
+  if (!entry) return null
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs transition-opacity duration-300 ${entry.className} ${className ?? ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      {entry.icon}
+      {entry.label}
+    </span>
+  )
+}

--- a/apps/dashboard/src/hooks/useAutosave.ts
+++ b/apps/dashboard/src/hooks/useAutosave.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useDebounce } from './useDebounce'
+
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+interface UseAutosaveOptions<T> {
+  /** The current value to autosave */
+  value: T
+  /** The last persisted/server value — autosave is skipped when value matches this */
+  savedValue: T
+  /** Async function that performs the save */
+  onSave: (value: T) => Promise<unknown>
+  /** Debounce delay in ms (default: 2000) */
+  delay?: number
+  /** Whether autosave is enabled (default: true) */
+  enabled?: boolean
+}
+
+interface UseAutosaveReturn {
+  status: AutosaveStatus
+  /** Manually trigger a save immediately */
+  saveNow: () => void
+}
+
+/**
+ * Debounced autosave hook.
+ *
+ * Waits `delay` ms after the last change, then calls `onSave`.
+ * Skips the save if the value hasn't actually changed from the last
+ * persisted value.
+ *
+ * Returns a status indicator and a manual `saveNow` escape hatch.
+ */
+export function useAutosave<T>({
+  value,
+  savedValue,
+  onSave,
+  delay = 2000,
+  enabled = true,
+}: UseAutosaveOptions<T>): UseAutosaveReturn {
+  const [status, setStatus] = useState<AutosaveStatus>('idle')
+  const debouncedValue = useDebounce(value, delay)
+  const onSaveRef = useRef(onSave)
+  const savedValueRef = useRef(savedValue)
+  const isSavingRef = useRef(false)
+
+  // Keep refs in sync without triggering effects
+  useEffect(() => {
+    onSaveRef.current = onSave
+  }, [onSave])
+
+  useEffect(() => {
+    savedValueRef.current = savedValue
+  }, [savedValue])
+
+  const performSave = useCallback(async (val: T) => {
+    if (isSavingRef.current) return
+    if (serialize(val) === serialize(savedValueRef.current)) return
+
+    isSavingRef.current = true
+    setStatus('saving')
+
+    try {
+      await onSaveRef.current(val)
+      setStatus('saved')
+      // Reset to idle after 2s so the "Saved" indicator fades
+      setTimeout(() => {
+        setStatus((prev) => (prev === 'saved' ? 'idle' : prev))
+      }, 2000)
+    } catch {
+      setStatus('error')
+    } finally {
+      isSavingRef.current = false
+    }
+  }, [])
+
+  // Auto-save on debounced value change
+  useEffect(() => {
+    if (!enabled) return
+    performSave(debouncedValue)
+  }, [debouncedValue, enabled, performSave])
+
+  const saveNow = useCallback(() => {
+    performSave(value)
+  }, [value, performSave])
+
+  return { status, saveNow }
+}
+
+/** Simple serialization for shallow equality checks */
+function serialize<T>(val: T): string {
+  if (typeof val === 'string') return val
+  return JSON.stringify(val)
+}

--- a/apps/dashboard/src/pages/task-detail.tsx
+++ b/apps/dashboard/src/pages/task-detail.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router-dom'
 import { useCompanyId } from '@/hooks/useCompanyId'
+import { useAutosave } from '@/hooks/useAutosave'
+import { AutosaveIndicator } from '@/components/ui/autosave-indicator'
 import {
   ArrowLeft,
   Bot,
@@ -516,23 +518,37 @@ function EditableTitle({
   isPending,
 }: {
   value: string
-  onSave: (title: string) => void
+  onSave: (title: string) => Promise<unknown>
   isPending: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
 
-  const handleSave = () => {
-    if (draft.trim() && draft.trim() !== value) {
-      onSave(draft.trim())
-    }
+  const handleAutosave = useCallback(
+    async (val: string) => {
+      const trimmed = val.trim()
+      if (trimmed && trimmed !== value) {
+        await onSave(trimmed)
+      }
+    },
+    [onSave, value],
+  )
+
+  const { status } = useAutosave({
+    value: draft,
+    savedValue: value,
+    onSave: handleAutosave,
+    enabled: editing,
+  })
+
+  const handleDone = () => {
     setEditing(false)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      handleSave()
+      handleDone()
     }
     if (e.key === 'Escape') {
       setDraft(value)
@@ -542,15 +558,18 @@ function EditableTitle({
 
   if (editing) {
     return (
-      <Input
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={handleSave}
-        onKeyDown={handleKeyDown}
-        disabled={isPending}
-        className="text-lg font-semibold"
-        autoFocus
-      />
+      <div className="space-y-1">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={handleDone}
+          onKeyDown={handleKeyDown}
+          disabled={isPending}
+          className="text-lg font-semibold"
+          autoFocus
+        />
+        <AutosaveIndicator status={status} />
+      </div>
     )
   }
 
@@ -574,16 +593,29 @@ function EditableDescription({
   isPending,
 }: {
   value: string | null
-  onSave: (description: string) => void
+  onSave: (description: string) => Promise<unknown>
   isPending: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value ?? '')
 
-  const handleSave = () => {
-    if (draft !== (value ?? '')) {
-      onSave(draft)
-    }
+  const handleAutosave = useCallback(
+    async (val: string) => {
+      if (val !== (value ?? '')) {
+        await onSave(val)
+      }
+    },
+    [onSave, value],
+  )
+
+  const { status } = useAutosave({
+    value: draft,
+    savedValue: value ?? '',
+    onSave: handleAutosave,
+    enabled: editing,
+  })
+
+  const handleDone = () => {
     setEditing(false)
   }
 
@@ -598,9 +630,9 @@ function EditableDescription({
           className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-none"
           autoFocus
         />
-        <div className="flex gap-2">
-          <Button size="sm" onClick={handleSave} disabled={isPending}>
-            {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Save'}
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={handleDone}>
+            Done
           </Button>
           <Button
             size="sm"
@@ -612,6 +644,7 @@ function EditableDescription({
           >
             Cancel
           </Button>
+          <AutosaveIndicator status={status} className="ml-auto" />
         </div>
       </div>
     )
@@ -908,7 +941,7 @@ export function TaskDetailPage() {
           </div>
           <EditableTitle
             value={task.title}
-            onSave={(title) => updateMutation.mutate({ title })}
+            onSave={(title) => updateMutation.mutateAsync({ title })}
             isPending={updateMutation.isPending}
           />
         </div>
@@ -942,7 +975,7 @@ export function TaskDetailPage() {
             <CardContent>
               <EditableDescription
                 value={task.description}
-                onSave={(description) => updateMutation.mutate({ description })}
+                onSave={(description) => updateMutation.mutateAsync({ description })}
                 isPending={updateMutation.isPending}
               />
             </CardContent>


### PR DESCRIPTION
## Summary
- **`useAutosave` hook** (`apps/dashboard/src/hooks/useAutosave.ts`): Debounced autosave (2s default) that tracks status (`idle` | `saving` | `saved` | `error`). Builds on existing `useDebounce` hook. Includes `saveNow()` for manual triggers and skips saves when value hasn't changed from server state.
- **`AutosaveIndicator` component** (`apps/dashboard/src/components/ui/autosave-indicator.tsx`): Subtle inline status text with Lucide icons, fade transitions, and `aria-live="polite"` for screen readers. Renders nothing when idle.
- **Task detail integration**: `EditableTitle` and `EditableDescription` now autosave 2s after the last keystroke instead of requiring explicit Save button clicks. Description editor retains a "Done" button to exit edit mode.

## Test plan
- [ ] Open a task detail page, click title to edit, type changes — verify "Saving..." then "Saved" appears
- [ ] Edit description, wait 2s — verify autosave triggers and indicator shows status
- [ ] Cancel editing — verify draft resets without saving
- [ ] Simulate network error — verify "Error saving" indicator appears
- [ ] Verify no save fires when text matches current server value
- [ ] Check accessibility: screen reader announces status changes via aria-live

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)