### PR TITLE
feat: add WebSocket server for real-time live events

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -55,6 +55,10 @@
     "@shackleai/shared": "workspace:*",
     "commander": "^13.1.0",
     "hono": "^4.7.10",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.18.1"
   }
 }

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -27,6 +27,7 @@ import { AgentApiKeyStatus } from '@shackleai/shared'
 import { readConfig, writeConfig, resolveDatabaseUrl } from '../config.js'
 import type { ShackleAIConfig } from '../config.js'
 import { createApp } from '../server/index.js'
+import { getWebSocketManager } from '../server/realtime/ws.js'
 import { VERSION } from '../index.js'
 
 export async function startCommand(options: { port: number }): Promise<void> {
@@ -131,13 +132,20 @@ export async function startCommand(options: { port: number }): Promise<void> {
   Company: ${config.companyName}
   Mode:    ${config.mode}
 
-  Dashboard: http://127.0.0.1:${port}
-  Health:    http://127.0.0.1:${port}/api/health
+  Dashboard:  http://127.0.0.1:${port}
+  Health:     http://127.0.0.1:${port}/api/health
+  WebSocket:  ws://127.0.0.1:${port}/ws?companyId=<id>
 
   Press Ctrl+C to stop.
   `)
 
-  serve({ fetch: app.fetch, port, hostname: '127.0.0.1' })
+  const httpServer = serve({ fetch: app.fetch, port, hostname: '127.0.0.1' })
+
+  // Attach WebSocket server for real-time dashboard events
+  // Cast needed because @hono/node-server's ServerType includes HTTP/2,
+  // but ws only accepts http.Server — we always use HTTP/1.1 here.
+  const wsManager = getWebSocketManager()
+  wsManager.attach(httpServer as unknown as import('node:http').Server)
 
   // Prevent stdin from keeping the process waiting for input on Windows
   if (process.stdin.isTTY) {
@@ -152,6 +160,7 @@ export async function startCommand(options: { port: number }): Promise<void> {
   // Graceful shutdown on Ctrl+C
   const shutdown = () => {
     console.log('\n  Shutting down ShackleAI Orchestrator...')
+    wsManager.close()
     scheduler.stop()
     db!.close().catch(() => {})
     process.exit(0)

--- a/apps/cli/src/server/realtime/__tests__/ws.test.ts
+++ b/apps/cli/src/server/realtime/__tests__/ws.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import http from 'node:http'
+import { WebSocket } from 'ws'
+import { WebSocketManager } from '../ws.js'
+
+/** Create a simple HTTP server for testing. */
+function createTestServer(): Promise<{ server: http.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200)
+      res.end('ok')
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      const port = typeof addr === 'object' && addr ? addr.port : 0
+      resolve({ server, port })
+    })
+  })
+}
+
+interface TestClient {
+  ws: WebSocket
+  messages: Record<string, unknown>[]
+  waitForMessage: (index?: number) => Promise<Record<string, unknown>>
+}
+
+/**
+ * Connect a WebSocket and collect all messages.
+ * Messages are buffered so we never miss the welcome message.
+ */
+function connectClient(
+  port: number,
+  companyId: string,
+): Promise<TestClient> {
+  return new Promise((resolve, reject) => {
+    const messages: Record<string, unknown>[] = []
+    const waiters: Array<() => void> = []
+
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/ws?companyId=${companyId}`,
+    )
+
+    ws.on('message', (data) => {
+      messages.push(JSON.parse(data.toString()) as Record<string, unknown>)
+      // Wake up any waiters
+      for (const w of waiters.splice(0)) w()
+    })
+
+    ws.on('open', () => {
+      resolve({
+        ws,
+        messages,
+        waitForMessage: (index = 0) => {
+          if (messages.length > index) {
+            return Promise.resolve(messages[index])
+          }
+          return new Promise<Record<string, unknown>>((res) => {
+            const check = () => {
+              if (messages.length > index) {
+                res(messages[index])
+              } else {
+                waiters.push(check)
+              }
+            }
+            waiters.push(check)
+          })
+        },
+      })
+    })
+
+    ws.on('error', reject)
+  })
+}
+
+describe('WebSocketManager', () => {
+  let manager: WebSocketManager
+  let server: http.Server
+  let port: number
+  const clients: WebSocket[] = []
+
+  afterEach(async () => {
+    for (const ws of clients) {
+      try {
+        ws.close()
+      } catch {
+        // ignore
+      }
+    }
+    clients.length = 0
+
+    manager?.close()
+
+    await new Promise<void>((resolve) => {
+      if (server?.listening) {
+        server.close(() => resolve())
+      } else {
+        resolve()
+      }
+    })
+  })
+
+  it('accepts connections and sends welcome message', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    const client = await connectClient(port, 'company-1')
+    clients.push(client.ws)
+
+    const msg = await client.waitForMessage(0)
+    expect(msg.type).toBe('connected')
+    expect(msg.companyId).toBe('company-1')
+    expect(msg.payload).toEqual({
+      message: 'WebSocket connection established',
+    })
+  })
+
+  it('broadcasts events only to matching companyId', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    const c1 = await connectClient(port, 'company-1')
+    const c2 = await connectClient(port, 'company-2')
+    clients.push(c1.ws, c2.ws)
+
+    // Wait for welcome messages
+    await c1.waitForMessage(0)
+    await c2.waitForMessage(0)
+
+    manager.broadcast('company-1', {
+      type: 'heartbeat_start',
+      companyId: 'company-1',
+      timestamp: new Date().toISOString(),
+      payload: { runId: 'run-1', agentId: 'agent-1', trigger: 'cron' },
+    })
+
+    // c1 should get the broadcast (index 1 = second message after welcome)
+    const received = await c1.waitForMessage(1)
+    expect(received.type).toBe('heartbeat_start')
+
+    // c2 should NOT get any more messages beyond welcome
+    await new Promise((r) => setTimeout(r, 100))
+    expect(c2.messages).toHaveLength(1) // only welcome
+  })
+
+  it('tracks connection count', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    expect(manager.getConnectionCount()).toBe(0)
+
+    const c1 = await connectClient(port, 'company-1')
+    clients.push(c1.ws)
+    await c1.waitForMessage(0) // wait for welcome
+
+    expect(manager.getConnectionCount()).toBe(1)
+    expect(manager.getConnectionCount('company-1')).toBe(1)
+    expect(manager.getConnectionCount('company-2')).toBe(0)
+  })
+
+  it('rejects connections without companyId', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    clients.push(ws)
+
+    await new Promise<void>((resolve) => {
+      ws.on('error', () => resolve())
+      ws.on('close', () => resolve())
+    })
+
+    expect(manager.getConnectionCount()).toBe(0)
+  })
+
+  it('rejects connections on non-/ws paths', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/other?companyId=company-1`,
+    )
+    clients.push(ws)
+
+    await new Promise<void>((resolve) => {
+      ws.on('error', () => resolve())
+      ws.on('close', () => resolve())
+    })
+
+    expect(manager.getConnectionCount()).toBe(0)
+  })
+
+  it('cleans up on close', async () => {
+    const setup = await createTestServer()
+    server = setup.server
+    port = setup.port
+
+    manager = new WebSocketManager()
+    manager.attach(server)
+
+    const c1 = await connectClient(port, 'company-1')
+    clients.push(c1.ws)
+    await c1.waitForMessage(0) // wait for welcome
+
+    expect(manager.getConnectionCount()).toBe(1)
+
+    manager.close()
+
+    // Wait for close to propagate
+    await new Promise((r) => setTimeout(r, 100))
+    expect(manager.getConnectionCount()).toBe(0)
+  })
+})

--- a/apps/cli/src/server/realtime/ws.ts
+++ b/apps/cli/src/server/realtime/ws.ts
@@ -1,0 +1,234 @@
+/**
+ * WebSocketManager — manages WebSocket connections for real-time dashboard updates.
+ *
+ * Features:
+ * - Upgrades HTTP requests on /ws to WebSocket connections
+ * - Tracks connections by companyId for scoped broadcasting
+ * - Ping/pong keepalive with 30-second interval
+ * - Auto-cleanup on disconnect or pong timeout
+ *
+ * Usage:
+ *   const wsManager = new WebSocketManager()
+ *   wsManager.attach(httpServer)
+ *   wsManager.broadcast(companyId, { type: 'heartbeat_start', ... })
+ */
+
+import type { IncomingMessage } from 'node:http'
+import type { Server as HttpServer } from 'node:http'
+import { WebSocketServer, WebSocket } from 'ws'
+import type { WebSocketEvent } from '@shackleai/shared'
+
+/** Ping/pong keepalive interval in milliseconds (30 seconds). */
+const KEEPALIVE_INTERVAL_MS = 30_000
+
+interface TrackedConnection {
+  ws: WebSocket
+  companyId: string
+  /** Whether we received a pong since the last ping. */
+  alive: boolean
+}
+
+export class WebSocketManager {
+  private wss: WebSocketServer | null = null
+  private connections = new Map<WebSocket, TrackedConnection>()
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null
+
+  /**
+   * Attach to an existing HTTP server and start accepting WebSocket upgrades on /ws.
+   * Must be called after the HTTP server is created (e.g. after `serve()` from @hono/node-server).
+   */
+  attach(server: HttpServer): void {
+    this.wss = new WebSocketServer({ noServer: true })
+
+    // Handle upgrade requests — only accept /ws path
+    server.on('upgrade', (request: IncomingMessage, socket, head) => {
+      const url = new URL(
+        request.url ?? '/',
+        `http://${request.headers.host ?? 'localhost'}`,
+      )
+
+      if (url.pathname !== '/ws') {
+        socket.destroy()
+        return
+      }
+
+      // Extract companyId from query string: /ws?companyId=xxx
+      const companyId = url.searchParams.get('companyId')
+      if (!companyId) {
+        socket.write('HTTP/1.1 400 Bad Request\r\n\r\n')
+        socket.destroy()
+        return
+      }
+
+      this.wss!.handleUpgrade(request, socket, head, (ws) => {
+        this.handleConnection(ws, companyId)
+      })
+    })
+
+    this.startKeepalive()
+  }
+
+  /**
+   * Broadcast an event to all connected clients for a given company.
+   * Non-blocking — silently skips clients with closed connections.
+   */
+  broadcast(companyId: string, event: WebSocketEvent): void {
+    const message = JSON.stringify(event)
+
+    for (const tracked of this.connections.values()) {
+      if (tracked.companyId !== companyId) continue
+      if (tracked.ws.readyState !== WebSocket.OPEN) continue
+
+      try {
+        tracked.ws.send(message)
+      } catch {
+        // Best-effort — connection may have closed between check and send
+      }
+    }
+  }
+
+  /**
+   * Broadcast to ALL connected clients regardless of company.
+   * Use sparingly — only for system-wide events.
+   */
+  broadcastAll(event: WebSocketEvent): void {
+    const message = JSON.stringify(event)
+
+    for (const tracked of this.connections.values()) {
+      if (tracked.ws.readyState !== WebSocket.OPEN) continue
+
+      try {
+        tracked.ws.send(message)
+      } catch {
+        // Best-effort
+      }
+    }
+  }
+
+  /** Get the count of active connections, optionally filtered by companyId. */
+  getConnectionCount(companyId?: string): number {
+    if (!companyId) return this.connections.size
+
+    let count = 0
+    for (const tracked of this.connections.values()) {
+      if (tracked.companyId === companyId) count++
+    }
+    return count
+  }
+
+  /** Gracefully shut down — close all connections and stop keepalive. */
+  close(): void {
+    if (this.keepaliveTimer) {
+      clearInterval(this.keepaliveTimer)
+      this.keepaliveTimer = null
+    }
+
+    for (const tracked of this.connections.values()) {
+      try {
+        tracked.ws.close(1001, 'Server shutting down')
+      } catch {
+        // Already closed
+      }
+    }
+
+    this.connections.clear()
+    this.wss?.close()
+    this.wss = null
+  }
+
+  // -- Private ----------------------------------------------------------------
+
+  private handleConnection(ws: WebSocket, companyId: string): void {
+    const tracked: TrackedConnection = { ws, companyId, alive: true }
+    this.connections.set(ws, tracked)
+
+    ws.on('pong', () => {
+      tracked.alive = true
+    })
+
+    ws.on('close', () => {
+      this.connections.delete(ws)
+    })
+
+    ws.on('error', () => {
+      this.connections.delete(ws)
+      try {
+        ws.terminate()
+      } catch {
+        // Already terminated
+      }
+    })
+
+    // Send a welcome message so the client knows the connection is established
+    const welcome: WebSocketEvent = {
+      type: 'connected',
+      companyId,
+      timestamp: new Date().toISOString(),
+      payload: { message: 'WebSocket connection established' },
+    }
+
+    try {
+      ws.send(JSON.stringify(welcome))
+    } catch {
+      // Connection may have closed immediately
+    }
+  }
+
+  /**
+   * Start the keepalive loop — sends ping to all connections every 30 seconds.
+   * Terminates connections that did not respond with pong since the last ping.
+   */
+  private startKeepalive(): void {
+    this.keepaliveTimer = setInterval(() => {
+      for (const [ws, tracked] of this.connections) {
+        if (!tracked.alive) {
+          // No pong received since last ping — terminate
+          this.connections.delete(ws)
+          try {
+            ws.terminate()
+          } catch {
+            // Already dead
+          }
+          continue
+        }
+
+        // Mark as not alive — will be set back to true when pong is received
+        tracked.alive = false
+        try {
+          ws.ping()
+        } catch {
+          this.connections.delete(ws)
+        }
+      }
+    }, KEEPALIVE_INTERVAL_MS)
+
+    // Don't let the keepalive timer prevent Node.js from exiting
+    if (this.keepaliveTimer.unref) {
+      this.keepaliveTimer.unref()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton — importable by executor, routes, or any server module
+// ---------------------------------------------------------------------------
+
+let _instance: WebSocketManager | null = null
+
+/** Get the global WebSocketManager singleton. Creates it if it doesn't exist. */
+export function getWebSocketManager(): WebSocketManager {
+  if (!_instance) {
+    _instance = new WebSocketManager()
+  }
+  return _instance
+}
+
+/**
+ * Convenience broadcast — safe to call even before WebSocket is attached (no-op).
+ * Import this from routes or the executor to emit real-time events.
+ */
+export function broadcast(companyId: string, event: WebSocketEvent): void {
+  if (_instance) {
+    _instance.broadcast(companyId, event)
+  }
+}

--- a/apps/cli/src/server/routes/workspace-operations.ts
+++ b/apps/cli/src/server/routes/workspace-operations.ts
@@ -1,0 +1,12 @@
+/**
+ * Workspace Operations routes — placeholder.
+ * The import was added to server/index.ts but the route file was not committed.
+ * This stub prevents build failures until the full implementation lands.
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+
+export function workspaceOperationsRouter(_db: DatabaseProvider): Hono {
+  return new Hono()
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -195,3 +195,17 @@ export const WORKTREE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
 /** Minimum git version required for worktree support. */
 export const GIT_MIN_VERSION = '2.5.0'
+
+// ---------------------------------------------------------------------------
+// WebSocket real-time event types
+// ---------------------------------------------------------------------------
+
+export const WebSocketEventType = {
+  HeartbeatStart: 'heartbeat_start',
+  HeartbeatEnd: 'heartbeat_end',
+  AgentStatusChange: 'agent_status_change',
+  TaskUpdate: 'task_update',
+  CostEvent: 'cost_event',
+} as const
+export type WebSocketEventType =
+  (typeof WebSocketEventType)[keyof typeof WebSocketEventType]

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -561,3 +561,59 @@ export interface WorkspaceOperation {
   created_at: Date
 }
 
+// ---------------------------------------------------------------------------
+// WebSocket Events — real-time dashboard updates
+// ---------------------------------------------------------------------------
+
+/**
+ * A WebSocket event sent to connected dashboard clients.
+ * All events include companyId so the server can broadcast
+ * only to connections belonging to the same company.
+ */
+export interface WebSocketEvent {
+  /** Event type discriminator (e.g. 'heartbeat_start', 'agent_status_change'). */
+  type: string
+  /** Company scope — used for routing to the correct connections. */
+  companyId: string
+  /** ISO-8601 timestamp of when the event occurred. */
+  timestamp: string
+  /** Event-specific payload. */
+  payload: Record<string, unknown>
+}
+
+/** Payload for heartbeat_start / heartbeat_end events. */
+export interface HeartbeatEventPayload {
+  runId: string
+  agentId: string
+  trigger: string
+  status?: string
+  exitCode?: number
+  durationMs?: number
+}
+
+/** Payload for agent_status_change events. */
+export interface AgentStatusChangePayload {
+  agentId: string
+  previousStatus: string
+  newStatus: string
+}
+
+/** Payload for task_update events. */
+export interface TaskUpdatePayload {
+  issueId: string
+  title: string
+  previousStatus?: string
+  newStatus: string
+  agentId?: string
+}
+
+/** Payload for cost_event events. */
+export interface CostEventPayload {
+  agentId: string
+  provider: string
+  model: string
+  costCents: number
+  inputTokens: number
+  outputTokens: number
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,13 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
 
   apps/dashboard:
     dependencies:
@@ -952,6 +959,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -2250,6 +2260,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -2876,6 +2898,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4163,6 +4189,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Adds `WebSocketManager` class that upgrades HTTP connections on `/ws` to WebSocket, tracks connections by `companyId`, and broadcasts events only to matching company clients
- Implements ping/pong keepalive (30s interval) with auto-cleanup of dead connections and graceful shutdown
- Adds shared types (`WebSocketEvent`, `HeartbeatEventPayload`, `AgentStatusChangePayload`, `TaskUpdatePayload`, `CostEventPayload`) and `WebSocketEventType` constant to `@shackleai/shared`
- Wires WebSocket into the Hono server startup with a singleton pattern and `broadcast()` convenience export for use by executor and routes
- Includes stub for missing `workspace-operations` route (pre-existing build break on main)

## Event Types
| Event | Description |
|-------|-------------|
| `heartbeat_start` | Agent heartbeat begins |
| `heartbeat_end` | Agent heartbeat completes |
| `agent_status_change` | Agent status transitions (idle/active/paused) |
| `task_update` | Issue status changes |
| `cost_event` | LLM cost recorded |

## Test Plan
- [x] 6 unit tests: connection, broadcast isolation, connection count, reject without companyId, reject wrong path, cleanup on close
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint`)
- [ ] Manual: connect via `wscat -c ws://127.0.0.1:4800/ws?companyId=<id>` and verify welcome message

Closes #165

Generated with [Claude Code](https://claude.com/claude-code)