### PR TITLE
feat: add workspace operation log for immutable audit trail

### DIFF
--- a/apps/cli/src/server/routes/workspace-operations.ts
+++ b/apps/cli/src/server/routes/workspace-operations.ts
@@ -1,12 +1,123 @@
 /**
- * Workspace Operations routes — placeholder.
- * The import was added to server/index.ts but the route file was not committed.
- * This stub prevents build failures until the full implementation lands.
+ * Workspace operation log routes — /api/companies/:id/worktrees/:wtId/operations
+ *
+ * Immutable audit trail: GET (list) and POST (append) only. No UPDATE or DELETE.
  */
 
 import { Hono } from 'hono'
 import type { DatabaseProvider } from '@shackleai/db'
+import type { AgentWorktree, WorkspaceOperationType } from '@shackleai/shared'
+import { CreateWorkspaceOperationInput } from '@shackleai/shared'
+import { WorkspaceOperationLogger } from '@shackleai/core'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
 
-export function workspaceOperationsRouter(_db: DatabaseProvider): Hono {
-  return new Hono()
+type Variables = CompanyScopeVariables
+
+export function workspaceOperationsRouter(
+  db: DatabaseProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+  const logger = new WorkspaceOperationLogger(db)
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/worktrees/:wtId/operations — list operations for a workspace
+  app.get(
+    '/:id/worktrees/:wtId/operations',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id') as string
+      const wtId = c.req.param('wtId') as string
+
+      // Verify worktree exists and belongs to company
+      const wtResult = await db.query<AgentWorktree>(
+        'SELECT id FROM agent_worktrees WHERE id = $1 AND company_id = $2',
+        [wtId, companyId],
+      )
+      if (wtResult.rows.length === 0) {
+        return c.json({ error: 'Worktree not found' }, 404)
+      }
+
+      const { limit, offset } = parsePagination(c)
+
+      // Parse optional filters from query params
+      const operationType = c.req.query('operation_type') as
+        | WorkspaceOperationType
+        | undefined
+      const agentId = c.req.query('agent_id')
+      const since = c.req.query('since')
+
+      const operations = await logger.list(
+        wtId,
+        {
+          operationType,
+          agentId: agentId ?? undefined,
+          since: since ?? undefined,
+        },
+        { limit, offset },
+      )
+
+      return c.json({ data: operations })
+    },
+  )
+
+  // POST /api/companies/:id/worktrees/:wtId/operations — log a new operation (append-only)
+  app.post(
+    '/:id/worktrees/:wtId/operations',
+    companyScope,
+    async (c) => {
+      const companyId = c.req.param('id') as string
+      const wtId = c.req.param('wtId') as string
+
+      // Verify worktree exists and belongs to company
+      const wtResult = await db.query<AgentWorktree>(
+        'SELECT id, agent_id FROM agent_worktrees WHERE id = $1 AND company_id = $2',
+        [wtId, companyId],
+      )
+      if (wtResult.rows.length === 0) {
+        return c.json({ error: 'Worktree not found' }, 404)
+      }
+
+      let body: unknown
+      try {
+        body = await c.req.json()
+      } catch {
+        return c.json({ error: 'Invalid JSON body' }, 400)
+      }
+
+      const parsed = CreateWorkspaceOperationInput.safeParse({
+        workspace_id: wtId,
+        agent_id: wtResult.rows[0].agent_id,
+        ...(body as object),
+      })
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Validation failed', details: parsed.error.flatten() },
+          400,
+        )
+      }
+
+      const operation = await logger.log({
+        workspaceId: parsed.data.workspace_id,
+        agentId: parsed.data.agent_id,
+        operationType: parsed.data.operation_type as WorkspaceOperationType,
+        filePath: parsed.data.file_path,
+        details: parsed.data.details,
+      })
+
+      if (!operation) {
+        return c.json({ error: 'Failed to log operation' }, 500)
+      }
+
+      return c.json({ data: operation }, 201)
+    },
+  )
+
+  return app
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,8 @@ export { LicenseManager } from './license.js'
 export type { LicenseStatus, ActivationResult } from './license.js'
 
 export { WorktreeManager } from './worktree/index.js'
+export { WorkspaceOperationLogger } from './worktree/index.js'
+export type { LogOperationInput, OperationFilters } from './worktree/index.js'
 
 export { DelegationService, DelegationError, rollUpParentStatus } from './delegation.js'
 

--- a/packages/core/src/worktree/index.ts
+++ b/packages/core/src/worktree/index.ts
@@ -3,3 +3,5 @@
  */
 
 export { WorktreeManager } from './manager.js'
+export { WorkspaceOperationLogger } from './operation-logger.js'
+export type { LogOperationInput, OperationFilters } from './operation-logger.js'

--- a/packages/core/src/worktree/operation-logger.ts
+++ b/packages/core/src/worktree/operation-logger.ts
@@ -1,0 +1,142 @@
+/**
+ * WorkspaceOperationLogger — immutable audit trail for agent workspace activity.
+ *
+ * All operations are INSERT-only; no UPDATE or DELETE is exposed.
+ * Logging is non-blocking: errors are swallowed so a failed log entry
+ * never interrupts the operation being audited.
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { WorkspaceOperation, WorkspaceOperationType } from '@shackleai/shared'
+
+export interface LogOperationInput {
+  workspaceId: string
+  agentId: string
+  operationType: WorkspaceOperationType
+  filePath?: string | null
+  details?: Record<string, unknown>
+}
+
+export interface OperationFilters {
+  operationType?: WorkspaceOperationType
+  agentId?: string
+  since?: string
+}
+
+export class WorkspaceOperationLogger {
+  private db: DatabaseProvider
+
+  constructor(db: DatabaseProvider) {
+    this.db = db
+  }
+
+  /**
+   * Append an operation to the immutable log.
+   * Returns the created record, or null if logging failed (non-blocking).
+   */
+  async log(input: LogOperationInput): Promise<WorkspaceOperation | null> {
+    try {
+      const id = randomUUID()
+      const result = await this.db.query<WorkspaceOperation>(
+        `INSERT INTO workspace_operations
+           (id, workspace_id, agent_id, operation_type, file_path, details)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING *`,
+        [
+          id,
+          input.workspaceId,
+          input.agentId,
+          input.operationType,
+          input.filePath ?? null,
+          JSON.stringify(input.details ?? {}),
+        ],
+      )
+      return result.rows[0] ?? null
+    } catch (err) {
+      console.error(
+        '[WorkspaceOperationLogger] Failed to log operation:',
+        err instanceof Error ? err.message : err,
+      )
+      return null
+    }
+  }
+
+  /**
+   * List operations for a workspace with optional filters.
+   * Supports filtering by operation_type, agent_id, and since (ISO timestamp).
+   */
+  async list(
+    workspaceId: string,
+    filters?: OperationFilters,
+    pagination?: { limit: number; offset: number },
+  ): Promise<WorkspaceOperation[]> {
+    const limit = pagination?.limit ?? 100
+    const offset = pagination?.offset ?? 0
+
+    const conditions: string[] = ['workspace_id = $1']
+    const params: unknown[] = [workspaceId]
+    let paramIndex = 2
+
+    if (filters?.operationType) {
+      conditions.push(`operation_type = $${paramIndex++}`)
+      params.push(filters.operationType)
+    }
+
+    if (filters?.agentId) {
+      conditions.push(`agent_id = $${paramIndex++}`)
+      params.push(filters.agentId)
+    }
+
+    if (filters?.since) {
+      conditions.push(`created_at > $${paramIndex++}`)
+      params.push(filters.since)
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await this.db.query<WorkspaceOperation>(
+      `SELECT * FROM workspace_operations
+       WHERE ${where}
+       ORDER BY created_at DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
+    )
+
+    return result.rows
+  }
+
+  /**
+   * Count operations for a workspace with optional filters.
+   */
+  async count(
+    workspaceId: string,
+    filters?: OperationFilters,
+  ): Promise<number> {
+    const conditions: string[] = ['workspace_id = $1']
+    const params: unknown[] = [workspaceId]
+    let paramIndex = 2
+
+    if (filters?.operationType) {
+      conditions.push(`operation_type = $${paramIndex++}`)
+      params.push(filters.operationType)
+    }
+
+    if (filters?.agentId) {
+      conditions.push(`agent_id = $${paramIndex++}`)
+      params.push(filters.agentId)
+    }
+
+    if (filters?.since) {
+      conditions.push(`created_at > $${paramIndex++}`)
+      params.push(filters.since)
+    }
+
+    const where = conditions.join(' AND ')
+    const result = await this.db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM workspace_operations WHERE ${where}`,
+      params,
+    )
+
+    return parseInt(result.rows[0]?.count ?? '0', 10)
+  }
+}

--- a/packages/db/src/migrations/029_workspace_operations.ts
+++ b/packages/db/src/migrations/029_workspace_operations.ts
@@ -1,0 +1,16 @@
+export const name = '029_workspace_operations'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS workspace_operations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES agent_worktrees(id),
+  agent_id UUID NOT NULL REFERENCES agents(id),
+  operation_type TEXT NOT NULL,
+  file_path TEXT,
+  details JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_workspace_ops_workspace ON workspace_operations(workspace_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workspace_ops_agent ON workspace_operations(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workspace_ops_type ON workspace_operations(operation_type);
+`


### PR DESCRIPTION
## Summary

- **Migration 029**: `workspace_operations` table with indexes on `workspace_id`, `agent_id`, and `operation_type`
- **WorkspaceOperationLogger**: append-only `log()` with non-blocking error handling, `list()` with filters (operationType, agentId, since), `count()`
- **API routes**: `GET /api/companies/:id/worktrees/:wtId/operations` (with query param filters) and `POST` (append-only)
- **Zod validator**: `CreateWorkspaceOperationInput` in `@shackleai/shared`
- Immutable — no UPDATE or DELETE exposed anywhere

Closes #173

## Test plan

- [ ] Verify migration creates `workspace_operations` table with correct schema and indexes
- [ ] POST an operation and confirm 201 response with correct shape
- [ ] GET operations list and verify descending `created_at` order
- [ ] Test query param filters: `operation_type`, `agent_id`, `since`
- [ ] Verify 404 when worktree does not exist or belongs to different company
- [ ] Verify 400 on invalid JSON body or failed Zod validation
- [ ] Confirm no UPDATE or DELETE endpoints exist

Generated with [Claude Code](https://claude.com/claude-code)