### PR TITLE
feat: add sidebar badges and company page memory

### DIFF
--- a/apps/dashboard/src/hooks/useCompanyPageMemory.ts
+++ b/apps/dashboard/src/hooks/useCompanyPageMemory.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useCompanyId } from './useCompanyId'
+
+const STORAGE_KEY = 'shackle:company-page-memory'
+
+interface PageMemory {
+  [companyId: string]: string // companyId -> last visited pathname
+}
+
+function readMemory(): PageMemory {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    return JSON.parse(raw) as PageMemory
+  } catch {
+    return {}
+  }
+}
+
+function writeMemory(memory: PageMemory) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(memory))
+}
+
+/**
+ * Remembers the last visited page per company in localStorage.
+ * When the company changes, navigates to the last visited page for that company.
+ */
+export function useCompanyPageMemory() {
+  const companyId = useCompanyId()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const prevCompanyId = useRef<string | null>(null)
+  const isRestoring = useRef(false)
+
+  // Save current page whenever pathname changes
+  useEffect(() => {
+    if (!companyId || isRestoring.current) {
+      isRestoring.current = false
+      return
+    }
+
+    const memory = readMemory()
+    memory[companyId] = location.pathname
+    writeMemory(memory)
+  }, [companyId, location.pathname])
+
+  // Restore page when company changes
+  useEffect(() => {
+    if (!companyId) return
+
+    // Only restore on actual company switches, not initial load
+    if (prevCompanyId.current !== null && prevCompanyId.current !== companyId) {
+      const memory = readMemory()
+      const savedPath = memory[companyId]
+
+      if (savedPath && savedPath !== location.pathname) {
+        isRestoring.current = true
+        // Preserve the company query param when navigating
+        const params = new URLSearchParams(location.search)
+        params.set('company', companyId)
+        navigate(`${savedPath}?${params.toString()}`, { replace: true })
+      }
+    }
+
+    prevCompanyId.current = companyId
+  }, [companyId, navigate, location.pathname, location.search])
+
+  const getLastPage = useCallback(
+    (forCompanyId: string): string | null => {
+      const memory = readMemory()
+      return memory[forCompanyId] ?? null
+    },
+    [],
+  )
+
+  return { getLastPage }
+}

--- a/apps/dashboard/src/hooks/useInboxCounts.ts
+++ b/apps/dashboard/src/hooks/useInboxCounts.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchInboxCounts, type InboxCounts } from '@/lib/api'
+import { useCompanyId } from './useCompanyId'
+import { usePollingInterval, POLLING_INTERVALS } from './usePolling'
+
+/**
+ * Polls GET /api/companies/:id/inbox/count every 10 seconds.
+ * Returns per-category badge counts for the sidebar.
+ *
+ * Requires a `userOrAgentId` to scope the unread/comment counts.
+ * Falls back to 'default' when no explicit user id is available
+ * (the API requires the parameter).
+ */
+export function useInboxCounts(userOrAgentId = 'default') {
+  const companyId = useCompanyId()
+  const refetchInterval = usePollingInterval(POLLING_INTERVALS.inbox)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['inbox-counts', companyId, userOrAgentId],
+    queryFn: () => fetchInboxCounts(companyId!, userOrAgentId),
+    enabled: !!companyId,
+    refetchInterval,
+    staleTime: 5_000,
+  })
+
+  const empty: InboxCounts = {
+    unread_issues: 0,
+    pending_approvals: 0,
+    new_comments: 0,
+    total: 0,
+  }
+
+  return {
+    counts: data ?? empty,
+    isLoading,
+    error,
+  }
+}

--- a/apps/dashboard/src/hooks/usePolling.ts
+++ b/apps/dashboard/src/hooks/usePolling.ts
@@ -10,6 +10,7 @@ export const POLLING_INTERVALS = {
   activity: 5_000,
   costs: 10_000,
   overview: 5_000,
+  inbox: 10_000,
 } as const
 
 // --- Page visibility external store ---

--- a/apps/dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/dashboard/src/layouts/DashboardLayout.tsx
@@ -24,14 +24,27 @@ import { CommandPalette } from '@/components/CommandPalette'
 import { KeyboardShortcutsHelp } from '@/components/KeyboardShortcutsHelp'
 import { useRecentPages } from '@/hooks/useRecentPages'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
+import { useInboxCounts } from '@/hooks/useInboxCounts'
+import { useCompanyPageMemory } from '@/hooks/useCompanyPageMemory'
 
-const navItems = [
+/** Badge key used to map nav items to inbox count fields. */
+type BadgeKey = 'unread_issues' | 'pending_approvals' | 'new_comments'
+
+interface NavItem {
+  to: string
+  icon: typeof LayoutDashboard
+  label: string
+  end?: boolean
+  badgeKey?: BadgeKey
+}
+
+const navItems: NavItem[] = [
   { to: '/', icon: LayoutDashboard, label: 'Overview', end: true },
   { to: '/agents', icon: Bot, label: 'Agents' },
   { to: '/org-chart', icon: Network, label: 'Org Chart' },
-  { to: '/tasks', icon: ListTodo, label: 'Tasks' },
+  { to: '/tasks', icon: ListTodo, label: 'Tasks', badgeKey: 'unread_issues' },
   { to: '/board', icon: LayoutGrid, label: 'Board' },
-  { to: '/activity', icon: Activity, label: 'Activity' },
+  { to: '/activity', icon: Activity, label: 'Activity', badgeKey: 'new_comments' },
   { to: '/costs', icon: DollarSign, label: 'Costs' },
   { to: '/settings', icon: Settings, label: 'Settings' },
 ]
@@ -51,6 +64,10 @@ export function DashboardLayout() {
   const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false)
   const location = useLocation()
   const { addRecentPage } = useRecentPages()
+  const { counts } = useInboxCounts()
+
+  // Remember last visited page per company, restore on switch
+  useCompanyPageMemory()
 
   // Global keyboard shortcuts (g+a, g+i, Shift+?, etc.)
   const { shortcuts } = useKeyboardShortcuts({
@@ -134,25 +151,36 @@ export function DashboardLayout() {
 
         {/* Nav */}
         <nav className="flex-1 space-y-1 p-3" aria-label="Main navigation">
-          {navItems.map(({ to, icon: Icon, label, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              onClick={() => setSidebarOpen(false)}
-              className={({ isActive }) =>
-                cn(
-                  'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                  isActive
-                    ? 'bg-secondary text-foreground'
-                    : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
-                )
-              }
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-              {label}
-            </NavLink>
-          ))}
+          {navItems.map(({ to, icon: Icon, label, end, badgeKey }) => {
+            const badgeCount = badgeKey ? counts[badgeKey] : 0
+            return (
+              <NavLink
+                key={to}
+                to={to}
+                end={end}
+                onClick={() => setSidebarOpen(false)}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-secondary text-foreground'
+                      : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
+                  )
+                }
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span className="flex-1">{label}</span>
+                {badgeCount > 0 && (
+                  <span
+                    className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500/15 px-1.5 text-[10px] font-semibold tabular-nums text-amber-400"
+                    aria-label={`${badgeCount} ${label.toLowerCase()} notification${badgeCount !== 1 ? 's' : ''}`}
+                  >
+                    {badgeCount > 99 ? '99+' : badgeCount}
+                  </span>
+                )}
+              </NavLink>
+            )
+          })}
         </nav>
 
         {/* Footer */}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -479,3 +479,21 @@ export function fetchIssueLabels(companyId: string, issueId: string) {
 export function fetchLabels(companyId: string) {
   return fetchJson<Label[]>(`${BASE_URL}/companies/${companyId}/labels`)
 }
+
+// --- Inbox counts ---
+
+export interface InboxCounts {
+  unread_issues: number
+  pending_approvals: number
+  new_comments: number
+  total: number
+}
+
+export function fetchInboxCounts(
+  companyId: string,
+  userOrAgentId: string,
+) {
+  return fetchJson<InboxCounts>(
+    `${BASE_URL}/companies/${companyId}/inbox/count?user_or_agent_id=${encodeURIComponent(userOrAgentId)}`,
+  )
+}


### PR DESCRIPTION
## Summary
- **Sidebar badge counts**: Calls `GET /api/companies/:id/inbox/count` every 10 seconds and displays amber badge pills on Tasks (unread issues) and Activity (new comments) nav items. Badges cap at "99+" and include ARIA labels for accessibility.
- **Company page memory**: New `useCompanyPageMemory` hook persists last visited page per company in localStorage. When switching companies via the CompanySelector, the dashboard automatically navigates to the last page the user viewed for that company.
- **Polling integration**: Uses existing `usePollingInterval` pattern with a new `POLLING_INTERVALS.inbox` (10s) entry. Polling pauses when the tab is hidden or manually paused.

## Files Changed
- `apps/dashboard/src/hooks/useInboxCounts.ts` — new hook, polls inbox count API
- `apps/dashboard/src/hooks/useCompanyPageMemory.ts` — new hook, localStorage page memory
- `apps/dashboard/src/hooks/usePolling.ts` — added `inbox: 10_000` interval
- `apps/dashboard/src/layouts/DashboardLayout.tsx` — integrated badges + page memory
- `apps/dashboard/src/lib/api.ts` — added `InboxCounts` type and `fetchInboxCounts`

## Test plan
- [ ] Verify badge counts appear on Tasks and Activity when unread issues / new comments exist
- [ ] Verify badges disappear when counts are 0
- [ ] Verify badge shows "99+" when count exceeds 99
- [ ] Switch companies and verify dashboard navigates to last visited page
- [ ] Verify polling pauses when tab is hidden (check Network tab)
- [ ] Verify badges are accessible via screen reader (ARIA labels)
- [ ] Test on mobile (375px) — badges should not overflow sidebar

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)