### PR TITLE
feat: LLM model configuration and provider management

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -35,6 +35,7 @@ import { assetsRouter, assetServeRouter } from './routes/assets.js'
 import { workProductsRouter } from './routes/work-products.js'
 import { workspaceOperationsRouter } from './routes/workspace-operations.js'
 import { financeRouter } from './routes/finance.js'
+import { llmConfigsRouter } from './routes/llm-configs.js'
 import { createApiAuth } from './middleware/auth.js'
 
 import { VERSION } from '../index.js'
@@ -116,6 +117,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   app.route('/api/companies', documentsRouter(db))
   app.route('/api/companies', workspaceOperationsRouter(db))
   app.route('/api/companies', financeRouter(db))
+  app.route('/api/companies', llmConfigsRouter(db))
 
   // --- Serve dashboard static files ---
   // Resolve dashboard dist relative to this file (works in monorepo and npm install)

--- a/apps/cli/src/server/routes/llm-configs.ts
+++ b/apps/cli/src/server/routes/llm-configs.ts
@@ -1,0 +1,184 @@
+/**
+ * LLM Config CRUD routes — /api/companies/:id/llm-configs
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { LlmConfig } from '@shackleai/shared'
+import { CreateLlmConfigInput, UpdateLlmConfigInput } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { parsePagination } from '../pagination.js'
+
+type Variables = CompanyScopeVariables
+
+export function llmConfigsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // GET /api/companies/:id/llm-configs — list configured models
+  app.get('/:id/llm-configs', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const { limit, offset } = parsePagination(c)
+    const result = await db.query<LlmConfig>(
+      `SELECT * FROM llm_configs WHERE company_id = $1 ORDER BY is_default DESC, created_at DESC LIMIT $2 OFFSET $3`,
+      [companyId, limit, offset],
+    )
+    return c.json({ data: result.rows })
+  })
+
+  // POST /api/companies/:id/llm-configs — add model config
+  app.post('/:id/llm-configs', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = CreateLlmConfigInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const { provider, model, is_default, max_tokens, temperature } = parsed.data
+
+    // If this config is being set as default, unset any existing default for this company
+    if (is_default) {
+      await db.query(
+        `UPDATE llm_configs SET is_default = false, updated_at = NOW() WHERE company_id = $1 AND is_default = true`,
+        [companyId],
+      )
+    }
+
+    try {
+      const result = await db.query<LlmConfig>(
+        `INSERT INTO llm_configs
+           (company_id, provider, model, is_default, max_tokens, temperature)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING *`,
+        [
+          companyId,
+          provider,
+          model,
+          is_default,
+          max_tokens ?? null,
+          temperature ?? null,
+        ],
+      )
+
+      return c.json({ data: result.rows[0] }, 201)
+    } catch (err: unknown) {
+      // Handle unique constraint violation (company_id, provider, model)
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('unique') || message.includes('duplicate')) {
+        return c.json({ error: 'A config for this provider/model combination already exists' }, 409)
+      }
+      throw err
+    }
+  })
+
+  // PUT /api/companies/:id/llm-configs/:configId — update model config
+  app.put('/:id/llm-configs/:configId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const configId = c.req.param('configId')
+
+    // Verify config exists and belongs to company
+    const existing = await db.query<LlmConfig>(
+      `SELECT id FROM llm_configs WHERE id = $1 AND company_id = $2`,
+      [configId, companyId],
+    )
+    if (existing.rows.length === 0) {
+      return c.json({ error: 'LLM config not found' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const parsed = UpdateLlmConfigInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
+    }
+
+    const updates = parsed.data
+    const fields = Object.keys(updates) as (keyof typeof updates)[]
+
+    if (fields.length === 0) {
+      const result = await db.query<LlmConfig>(
+        `SELECT * FROM llm_configs WHERE id = $1 AND company_id = $2`,
+        [configId, companyId],
+      )
+      return c.json({ data: result.rows[0] })
+    }
+
+    // If setting as default, unset other defaults first
+    if (updates.is_default === true) {
+      await db.query(
+        `UPDATE llm_configs SET is_default = false, updated_at = NOW() WHERE company_id = $1 AND is_default = true AND id != $2`,
+        [companyId, configId],
+      )
+    }
+
+    const setClauses = [...fields.map((f, i) => `${f} = $${i + 3}`), `updated_at = NOW()`].join(', ')
+    const values = fields.map((f) => updates[f])
+
+    try {
+      const result = await db.query<LlmConfig>(
+        `UPDATE llm_configs SET ${setClauses}
+         WHERE id = $1 AND company_id = $2
+         RETURNING *`,
+        [configId, companyId, ...values],
+      )
+
+      return c.json({ data: result.rows[0] })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('unique') || message.includes('duplicate')) {
+        return c.json({ error: 'A config for this provider/model combination already exists' }, 409)
+      }
+      throw err
+    }
+  })
+
+  // DELETE /api/companies/:id/llm-configs/:configId — remove model config
+  app.delete('/:id/llm-configs/:configId', companyScope, async (c) => {
+    const companyId = c.req.param('id')
+    const configId = c.req.param('configId')
+
+    // Check if any agents are using this config
+    const agentsUsing = await db.query<{ id: string }>(
+      `SELECT id FROM agents WHERE llm_config_id = $1 AND company_id = $2 LIMIT 1`,
+      [configId, companyId],
+    )
+    if (agentsUsing.rows.length > 0) {
+      return c.json(
+        { error: 'Cannot delete LLM config that is assigned to agents. Remove agent assignments first.' },
+        409,
+      )
+    }
+
+    const result = await db.query<LlmConfig>(
+      `DELETE FROM llm_configs WHERE id = $1 AND company_id = $2 RETURNING id`,
+      [configId, companyId],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'LLM config not found' }, 404)
+    }
+
+    return c.json({ data: { deleted: true, id: result.rows[0].id } })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/030_llm_configs.ts
+++ b/packages/db/src/migrations/030_llm_configs.ts
@@ -1,0 +1,22 @@
+export const name = '030_llm_configs'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS llm_configs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id),
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  is_default BOOLEAN NOT NULL DEFAULT false,
+  max_tokens INT,
+  temperature NUMERIC(3,2),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (company_id, provider, model)
+);
+
+-- Optional FK from agents to llm_configs for per-agent model override
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS llm_config_id UUID REFERENCES llm_configs(id);
+
+-- Index for company-scoped lookups
+CREATE INDEX IF NOT EXISTS idx_llm_configs_company_id ON llm_configs(company_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -28,6 +28,7 @@ import * as m026 from './026_issue_read_states.js'
 import * as m027 from './027_assets.js'
 import * as m028 from './028_finance_events.js'
 import * as m029 from './029_workspace_operations.js'
+import * as m030 from './030_llm_configs.js'
 
 export interface Migration {
   name: string
@@ -64,6 +65,7 @@ const migrations: Migration[] = [
   m027,
   m028,
   m029,
+  m030,
 ]
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -219,3 +219,18 @@ export const WebSocketEventType = {
 } as const
 export type WebSocketEventType =
   (typeof WebSocketEventType)[keyof typeof WebSocketEventType]
+
+// ---------------------------------------------------------------------------
+// LLM Provider
+// ---------------------------------------------------------------------------
+
+export const LlmProvider = {
+  OpenAI: 'openai',
+  Anthropic: 'anthropic',
+  Google: 'google',
+  Mistral: 'mistral',
+  Groq: 'groq',
+  Ollama: 'ollama',
+  OpenRouter: 'openrouter',
+} as const
+export type LlmProvider = (typeof LlmProvider)[keyof typeof LlmProvider]

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -30,6 +30,7 @@ export interface Agent {
   adapter_config: Record<string, unknown>
   budget_monthly_cents: number
   spent_monthly_cents: number
+  llm_config_id: string | null
   last_heartbeat_at: Date | null
   created_at: Date
   updated_at: Date
@@ -577,6 +578,22 @@ export interface WakeupRequest {
   status: 'pending' | 'processed' | 'expired'
   created_at: string
   processed_at: string | null
+}
+
+// ---------------------------------------------------------------------------
+// LLM Configs -- per-company model configuration and provider management
+// ---------------------------------------------------------------------------
+
+export interface LlmConfig {
+  id: string
+  company_id: string
+  provider: string
+  model: string
+  is_default: boolean
+  max_tokens: number | null
+  temperature: number | null
+  created_at: Date
+  updated_at: Date
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -20,6 +20,7 @@ import {
   WorkProductType,
   FinanceEventType,
   WorkspaceOperationType,
+  LlmProvider,
 } from './constants.js'
 
 // ---------------------------------------------------------------------------
@@ -80,6 +81,7 @@ export const CreateAgentInput = z.object({
   adapter_type: z.enum(adapterTypeValues).default(AdapterType.Process),
   adapter_config: z.record(z.string(), z.unknown()).optional().default({}),
   budget_monthly_cents: z.number().int().min(0).optional().default(0),
+  llm_config_id: uuid.nullable().optional(),
 })
 export type CreateAgentInput = z.infer<typeof CreateAgentInput>
 
@@ -93,6 +95,7 @@ export const UpdateAgentInput = z.object({
   adapter_type: z.enum(adapterTypeValues).optional(),
   adapter_config: z.record(z.string(), z.unknown()).optional(),
   budget_monthly_cents: z.number().int().min(0).optional(),
+  llm_config_id: uuid.nullable().optional(),
 })
 export type UpdateAgentInput = z.infer<typeof UpdateAgentInput>
 
@@ -589,3 +592,27 @@ export const CreateWorkspaceOperationInput = z.object({
   details: z.record(z.string(), z.unknown()).optional().default({}),
 })
 export type CreateWorkspaceOperationInput = z.infer<typeof CreateWorkspaceOperationInput>
+
+// ---------------------------------------------------------------------------
+// LLM Config
+// ---------------------------------------------------------------------------
+
+const llmProviderValues = Object.values(LlmProvider) as [string, ...string[]]
+
+export const CreateLlmConfigInput = z.object({
+  provider: z.enum(llmProviderValues),
+  model: nonEmpty,
+  is_default: z.boolean().optional().default(false),
+  max_tokens: z.number().int().min(1).nullable().optional(),
+  temperature: z.number().min(0).max(2).nullable().optional(),
+})
+export type CreateLlmConfigInput = z.infer<typeof CreateLlmConfigInput>
+
+export const UpdateLlmConfigInput = z.object({
+  provider: z.enum(llmProviderValues).optional(),
+  model: nonEmpty.optional(),
+  is_default: z.boolean().optional(),
+  max_tokens: z.number().int().min(1).nullable().optional(),
+  temperature: z.number().min(0).max(2).nullable().optional(),
+})
+export type UpdateLlmConfigInput = z.infer<typeof UpdateLlmConfigInput>


### PR DESCRIPTION
## Summary

- Adds `llm_configs` table (migration 030) for per-company LLM provider/model configuration
- CRUD API routes at `/api/companies/:id/llm-configs` (GET, POST, PUT, DELETE)
- Per-agent model override via optional `llm_config_id` FK on agents table
- Shared types (`LlmConfig`, `LlmProvider`) and Zod validators (`CreateLlmConfigInput`, `UpdateLlmConfigInput`)

## Details

**Database**: New `llm_configs` table with unique constraint on `(company_id, provider, model)`. Supports `is_default` flag (only one default per company), `max_tokens`, and `temperature` settings. Agents table gains optional `llm_config_id` column.

**API Routes**:
- `GET /api/companies/:id/llm-configs` — list with pagination
- `POST /api/companies/:id/llm-configs` — create (auto-unsets previous default)
- `PUT /api/companies/:id/llm-configs/:configId` — update
- `DELETE /api/companies/:id/llm-configs/:configId` — delete (blocks if agents assigned)

**Providers**: openai, anthropic, google, mistral, groq, ollama, openrouter

## Test plan

- [ ] POST creates config, returns 201
- [ ] POST with duplicate provider/model returns 409
- [ ] Setting is_default=true unsets previous default
- [ ] PUT updates fields, handles unique constraint
- [ ] DELETE blocked when agents reference config (409)
- [ ] DELETE succeeds when no agents reference config
- [ ] GET returns paginated list sorted by default status
- [ ] Agent create/update accepts llm_config_id

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)