### PR TITLE
feat: add company logo upload and branding

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -32,6 +32,7 @@ import { inboxRouter } from './routes/inbox.js'
 import { templatesRouter, companyTemplatesRouter } from './routes/templates.js'
 import { attachmentsRouter } from './routes/attachments.js'
 import { assetsRouter, assetServeRouter } from './routes/assets.js'
+import { companyLogoRouter } from './routes/company-logo.js'
 import { workProductsRouter } from './routes/work-products.js'
 import { workspaceOperationsRouter } from './routes/workspace-operations.js'
 import { financeRouter } from './routes/finance.js'
@@ -111,6 +112,7 @@ export function createApp(db: DatabaseProvider, options?: CreateAppOptions): Hon
   if (options?.storage) {
     app.route('/api/companies', attachmentsRouter(db, options.storage))
     app.route('/api/companies', assetsRouter(db, options.storage))
+    app.route('/api/companies', companyLogoRouter(db, options.storage))
     app.route('/api/assets', assetServeRouter(db, options.storage))
   }
   app.route('/api/companies', workProductsRouter(db))

--- a/apps/cli/src/server/routes/companies.ts
+++ b/apps/cli/src/server/routes/companies.ts
@@ -13,6 +13,14 @@ import { readConfig, writeConfig } from '../../config.js'
 
 type Variables = CompanyScopeVariables
 
+/** Append a computed logo_url field to a company row. */
+function withLogoUrl(company: Company): Company & { logo_url: string | null } {
+  return {
+    ...company,
+    logo_url: company.logo_asset_id ? `/api/assets/${company.logo_asset_id}` : null,
+  }
+}
+
 export function companiesRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
   const app = new Hono<{ Variables: Variables }>()
 
@@ -29,7 +37,7 @@ export function companiesRouter(db: DatabaseProvider): Hono<{ Variables: Variabl
       'SELECT * FROM companies ORDER BY created_at DESC LIMIT $1 OFFSET $2',
       [limit, offset],
     )
-    return c.json({ data: result.rows })
+    return c.json({ data: result.rows.map(withLogoUrl) })
   })
 
   // POST /api/companies — create company
@@ -55,13 +63,13 @@ export function companiesRouter(db: DatabaseProvider): Hono<{ Variables: Variabl
       [name, description ?? null, status, issue_prefix, budget_monthly_cents],
     )
 
-    return c.json({ data: result.rows[0] }, 201)
+    return c.json({ data: withLogoUrl(result.rows[0]) }, 201)
   })
 
   // GET /api/companies/:id — get by id
   app.get('/:id', companyScope, async (c) => {
     const company = c.get('company')
-    return c.json({ data: company })
+    return c.json({ data: withLogoUrl(company) })
   })
 
   // PATCH /api/companies/:id — update company
@@ -95,7 +103,7 @@ export function companiesRouter(db: DatabaseProvider): Hono<{ Variables: Variabl
       [id, ...values],
     )
 
-    return c.json({ data: result.rows[0] })
+    return c.json({ data: withLogoUrl(result.rows[0]) })
   })
 
   // GET /api/companies/:id/llm-keys — returns redacted LLM API keys

--- a/apps/cli/src/server/routes/company-logo.ts
+++ b/apps/cli/src/server/routes/company-logo.ts
@@ -1,0 +1,146 @@
+/**
+ * Company logo routes — /api/companies/:id/logo
+ *
+ * Upload and remove a company logo. Reuses the asset upload pipeline
+ * (storage + assets table) and links the resulting asset to the company
+ * via companies.logo_asset_id.
+ */
+
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type { StorageProvider } from '@shackleai/core'
+import type { Asset, Company } from '@shackleai/shared'
+import { MAX_ASSET_SIZE_BYTES } from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+
+/** Image MIME types allowed for logos. */
+const LOGO_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+] as const
+
+type Variables = CompanyScopeVariables
+
+export function companyLogoRouter(
+  db: DatabaseProvider,
+  storage: StorageProvider,
+): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context for all routes
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // PUT /api/companies/:id/logo — upload or replace company logo
+  app.put('/:id/logo', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+
+    const body = await c.req.parseBody()
+    const file = body['file']
+    if (!file || typeof file === 'string') {
+      return c.json({ error: 'Missing file in multipart form data' }, 400)
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const filename = file.name || 'logo'
+    const mime = file.type || 'application/octet-stream'
+
+    // Validate file size
+    if (buffer.length > MAX_ASSET_SIZE_BYTES) {
+      return c.json(
+        { error: `File too large. Maximum size is ${MAX_ASSET_SIZE_BYTES / (1024 * 1024)} MB` },
+        413,
+      )
+    }
+
+    // Validate MIME type — logos must be images
+    if (!(LOGO_MIME_TYPES as readonly string[]).includes(mime)) {
+      return c.json(
+        { error: `Unsupported file type: ${mime}. Logos must be images: ${LOGO_MIME_TYPES.join(', ')}` },
+        415,
+      )
+    }
+
+    // Upload to storage
+    const uniquePrefix = crypto.randomUUID()
+    const storageKey = `assets/${companyId}/${uniquePrefix}-${filename}`
+    const uploadResult = await storage.upload(storageKey, buffer, mime)
+
+    // Create asset record
+    const assetResult = await db.query<Asset>(
+      `INSERT INTO assets (company_id, filename, mime_type, size_bytes, storage_key, uploaded_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [companyId, filename, mime, uploadResult.size, storageKey, null],
+    )
+    const asset = assetResult.rows[0]
+
+    // Get the old logo asset id so we can clean it up
+    const company = c.get('company')
+    const oldLogoAssetId = company.logo_asset_id
+
+    // Link new logo to company
+    const companyResult = await db.query<Company>(
+      `UPDATE companies SET logo_asset_id = $1, updated_at = NOW() WHERE id = $2 RETURNING *`,
+      [asset.id, companyId],
+    )
+
+    // Clean up old logo asset if one existed
+    if (oldLogoAssetId) {
+      const oldAssetResult = await db.query<Asset>(
+        `DELETE FROM assets WHERE id = $1 AND company_id = $2 RETURNING *`,
+        [oldLogoAssetId, companyId],
+      )
+      if (oldAssetResult.rows.length > 0) {
+        void storage.delete(oldAssetResult.rows[0].storage_key).catch(() => {
+          // Orphan file cleanup can be handled by a background job
+        })
+      }
+    }
+
+    const updatedCompany = companyResult.rows[0]
+    return c.json({
+      data: {
+        ...updatedCompany,
+        logo_url: `/api/assets/${asset.id}`,
+      },
+    })
+  })
+
+  // DELETE /api/companies/:id/logo — remove company logo
+  app.delete('/:id/logo', companyScope, async (c) => {
+    const companyId = c.req.param('id')!
+    const company = c.get('company')
+
+    if (!company.logo_asset_id) {
+      return c.json({ error: 'Company has no logo' }, 404)
+    }
+
+    // Unlink logo from company
+    const companyResult = await db.query<Company>(
+      `UPDATE companies SET logo_asset_id = NULL, updated_at = NOW() WHERE id = $1 RETURNING *`,
+      [companyId],
+    )
+
+    // Delete the asset record and storage file
+    const assetResult = await db.query<Asset>(
+      `DELETE FROM assets WHERE id = $1 AND company_id = $2 RETURNING *`,
+      [company.logo_asset_id, companyId],
+    )
+    if (assetResult.rows.length > 0) {
+      void storage.delete(assetResult.rows[0].storage_key).catch(() => {
+        // Orphan file cleanup can be handled by a background job
+      })
+    }
+
+    return c.json({ data: companyResult.rows[0] })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/031_company_logo.ts
+++ b/packages/db/src/migrations/031_company_logo.ts
@@ -1,0 +1,5 @@
+export const name = '031_company_logo'
+
+export const sql = `
+  ALTER TABLE companies ADD COLUMN IF NOT EXISTS logo_asset_id UUID REFERENCES assets(id) ON DELETE SET NULL;
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -29,6 +29,7 @@ import * as m027 from './027_assets.js'
 import * as m028 from './028_finance_events.js'
 import * as m029 from './029_workspace_operations.js'
 import * as m030 from './030_llm_configs.js'
+import * as m031 from './031_company_logo.js'
 
 export interface Migration {
   name: string
@@ -66,6 +67,7 @@ const migrations: Migration[] = [
   m028,
   m029,
   m030,
+  m031,
 ]
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -13,6 +13,7 @@ export interface Company {
   spent_monthly_cents: number
   default_honesty_checklist: string[] | null
   require_approval: boolean
+  logo_asset_id: string | null
   created_at: Date
   updated_at: Date
 }


### PR DESCRIPTION
## Summary

- Adds logo_asset_id column to the companies table (migration 030) with FK to assets and ON DELETE SET NULL
- Adds PUT /api/companies/:id/logo -- multipart image upload that creates an asset, links it to the company, and cleans up the previous logo if one existed
- Adds DELETE /api/companies/:id/logo -- unlinks and deletes the logo asset
- All company GET responses now include a computed logo_url field (/api/assets/<id> or null)
- Updates Company type in @shackleai/shared with logo_asset_id: string | null
- Logo uploads are restricted to image MIME types only (png, jpeg, gif, webp, svg+xml)

## Test plan

- [ ] Upload a logo via PUT /api/companies/:id/logo with a valid image file
- [ ] Verify logo_url appears in GET /api/companies and GET /api/companies/:id
- [ ] Upload a new logo and verify the old asset is cleaned up
- [ ] Delete logo via DELETE /api/companies/:id/logo and verify it returns 404 on second delete
- [ ] Verify non-image MIME types are rejected with 415
- [ ] Verify oversized files are rejected with 413
- [ ] Run migration 030 on fresh and existing databases

Closes #179