### PR TITLE
feat: add execution workspace policy enforcement

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export { LicenseManager } from './license.js'
 export type { LicenseStatus, ActivationResult } from './license.js'
 
 export { WorktreeManager } from './worktree/index.js'
+export { WorkspacePolicyEngine } from './worktree/index.js'
 export { WorkspaceOperationLogger } from './worktree/index.js'
 export type { LogOperationInput, OperationFilters } from './worktree/index.js'
 

--- a/packages/core/src/worktree/index.ts
+++ b/packages/core/src/worktree/index.ts
@@ -3,5 +3,6 @@
  */
 
 export { WorktreeManager } from './manager.js'
+export { WorkspacePolicyEngine } from './policy.js'
 export { WorkspaceOperationLogger } from './operation-logger.js'
 export type { LogOperationInput, OperationFilters } from './operation-logger.js'

--- a/packages/core/src/worktree/manager.ts
+++ b/packages/core/src/worktree/manager.ts
@@ -16,6 +16,8 @@ import type {
   AgentWorktree,
   WorktreeInfo,
   CleanupResult,
+  WorkspacePolicyCheckResult,
+  WorkspaceOperationType,
 } from '@shackleai/shared'
 import {
   WorktreeStatus,
@@ -23,6 +25,7 @@ import {
   WORKTREE_MAX_AGE_MS,
   GIT_MIN_VERSION,
 } from '@shackleai/shared'
+import { WorkspacePolicyEngine } from './policy.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -105,9 +108,44 @@ interface CleanupOptions {
 
 export class WorktreeManager {
   private db: DatabaseProvider
+  private policyEngine: WorkspacePolicyEngine
 
   constructor(db: DatabaseProvider) {
     this.db = db
+    this.policyEngine = new WorkspacePolicyEngine(db)
+  }
+  /**
+   * Check whether an agent is allowed to perform an operation in a workspace.
+   * Call this before executing any workspace operation to enforce policies.
+   *
+   * @throws Error if the operation is denied by policy
+   */
+  async enforcePolicy(
+    agentId: string,
+    workspaceId: string,
+    operation: WorkspaceOperationType,
+    filePath?: string,
+  ): Promise<WorkspacePolicyCheckResult> {
+    const result = await this.policyEngine.checkPolicy({
+      agentId,
+      workspaceId,
+      operation,
+      filePath,
+    })
+
+    if (!result.allowed) {
+      throw new Error(
+        `Workspace policy violation: ${result.reason} ` +
+          `(agent=${agentId}, workspace=${workspaceId}, op=${operation})`,
+      )
+    }
+
+    return result
+  }
+
+  /** Access the underlying policy engine for rule management. */
+  get policy(): WorkspacePolicyEngine {
+    return this.policyEngine
   }
 
   // ── Create ──────────────────────────────────────────────────────────────

--- a/packages/core/src/worktree/policy.ts
+++ b/packages/core/src/worktree/policy.ts
@@ -1,0 +1,210 @@
+/**
+ * WorkspacePolicyEngine -- Enforces per-agent, per-workspace operation policies.
+ *
+ * Security model: **default-deny for cross-workspace access**.
+ * An agent can only operate in workspaces it owns unless an explicit
+ * allow rule grants cross-workspace access.
+ *
+ * Policy resolution:
+ * 1. Check workspace ownership (agent_id match)
+ * 2. Load workspace-specific rules ordered by priority DESC
+ * 3. Match operation type and file path (glob via micromatch)
+ * 4. First matching rule wins
+ * 5. If no rule matches: ALLOW for own workspace, DENY for foreign workspace
+ */
+
+import type { DatabaseProvider } from '@shackleai/db'
+import type {
+  WorkspacePolicyRule,
+  WorkspacePolicyCheckResult,
+  WorkspaceOperationType,
+} from '@shackleai/shared'
+import { WorkspacePolicyAction } from '@shackleai/shared'
+import micromatch from 'micromatch'
+
+// ---------------------------------------------------------------------------
+// WorkspacePolicyEngine
+// ---------------------------------------------------------------------------
+
+interface PolicyCheckInput {
+  /** The agent requesting the operation. */
+  agentId: string
+  /** The workspace (worktree) the operation targets. */
+  workspaceId: string
+  /** The type of operation being performed. */
+  operation: WorkspaceOperationType
+  /** Optional file path for file-scoped operations. */
+  filePath?: string
+}
+
+export class WorkspacePolicyEngine {
+  private readonly db: DatabaseProvider
+
+  constructor(db: DatabaseProvider) {
+    this.db = db
+  }
+
+  /**
+   * Check whether an agent is allowed to perform an operation in a workspace.
+   *
+   * @returns PolicyCheckResult with allowed flag, matched rule, and reason
+   */
+  async checkPolicy(input: PolicyCheckInput): Promise<WorkspacePolicyCheckResult> {
+    const { agentId, workspaceId, operation, filePath } = input
+
+    // Step 1: Determine workspace ownership
+    const isOwner = await this.isWorkspaceOwner(agentId, workspaceId)
+
+    // Step 2: Load policy rules for this workspace + agent
+    const rules = await this.loadRules(workspaceId, agentId)
+
+    // Step 3: Evaluate rules in priority order (already sorted DESC)
+    for (const rule of rules) {
+      if (!this.matchesOperation(rule, operation)) continue
+      if (!this.matchesFilePath(rule, filePath)) continue
+
+      // Rule matched
+      const allowed = rule.action === WorkspacePolicyAction.Allow
+      return {
+        allowed,
+        matchedRule: rule,
+        reason: allowed
+          ? `Allowed by rule: operations=[${rule.operations.join(',')}], files=[${rule.filePatterns.join(',')}]`
+          : `Denied by rule: operations=[${rule.operations.join(',')}], files=[${rule.filePatterns.join(',')}]`,
+      }
+    }
+
+    // Step 4: No rule matched -- apply default policy
+    if (isOwner) {
+      return {
+        allowed: true,
+        reason: 'Default allow: agent owns this workspace',
+      }
+    }
+
+    return {
+      allowed: false,
+      reason: 'Default deny: agent does not own this workspace and no allow rule matches',
+    }
+  }
+
+  /**
+   * Set policy rules for a workspace + agent combination.
+   * Replaces all existing rules for this (workspaceId, agentId) pair.
+   */
+  async setRules(
+    workspaceId: string,
+    agentId: string,
+    rules: WorkspacePolicyRule[],
+  ): Promise<void> {
+    // Delete existing rules
+    await this.db.query(
+      `DELETE FROM workspace_policy_rules
+       WHERE workspace_id = $1 AND agent_id = $2`,
+      [workspaceId, agentId],
+    )
+
+    // Insert new rules
+    for (const rule of rules) {
+      await this.db.query(
+        `INSERT INTO workspace_policy_rules
+           (workspace_id, agent_id, operations, file_patterns, action, priority)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          workspaceId,
+          agentId,
+          JSON.stringify(rule.operations),
+          JSON.stringify(rule.filePatterns),
+          rule.action,
+          rule.priority,
+        ],
+      )
+    }
+  }
+
+  /**
+   * Get all policy rules for a workspace + agent combination.
+   */
+  async getRules(
+    workspaceId: string,
+    agentId: string,
+  ): Promise<WorkspacePolicyRule[]> {
+    return this.loadRules(workspaceId, agentId)
+  }
+
+  /**
+   * Remove all policy rules for a workspace + agent combination.
+   */
+  async clearRules(workspaceId: string, agentId: string): Promise<void> {
+    await this.db.query(
+      `DELETE FROM workspace_policy_rules
+       WHERE workspace_id = $1 AND agent_id = $2`,
+      [workspaceId, agentId],
+    )
+  }
+
+  // -- Private ------------------------------------------------------------
+
+  private async isWorkspaceOwner(
+    agentId: string,
+    workspaceId: string,
+  ): Promise<boolean> {
+    const result = await this.db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM agent_worktrees
+       WHERE id = $1 AND agent_id = $2`,
+      [workspaceId, agentId],
+    )
+    return parseInt(result.rows[0]?.count ?? '0', 10) > 0
+  }
+
+  private async loadRules(
+    workspaceId: string,
+    agentId: string,
+  ): Promise<WorkspacePolicyRule[]> {
+    interface RuleRow {
+      operations: string
+      file_patterns: string
+      action: string
+      priority: number
+    }
+
+    const result = await this.db.query<RuleRow>(
+      `SELECT operations, file_patterns, action, priority
+       FROM workspace_policy_rules
+       WHERE workspace_id = $1 AND agent_id = $2
+       ORDER BY priority DESC`,
+      [workspaceId, agentId],
+    )
+
+    return result.rows.map((row) => ({
+      operations: typeof row.operations === 'string'
+        ? JSON.parse(row.operations) as string[]
+        : row.operations as unknown as string[],
+      filePatterns: typeof row.file_patterns === 'string'
+        ? JSON.parse(row.file_patterns) as string[]
+        : row.file_patterns as unknown as string[],
+      action: row.action,
+      priority: row.priority,
+    }))
+  }
+
+  private matchesOperation(
+    rule: WorkspacePolicyRule,
+    operation: WorkspaceOperationType,
+  ): boolean {
+    // Empty operations array = matches all operations
+    if (rule.operations.length === 0) return true
+    return rule.operations.includes(operation)
+  }
+
+  private matchesFilePath(
+    rule: WorkspacePolicyRule,
+    filePath?: string,
+  ): boolean {
+    // Empty file patterns = matches all files
+    if (rule.filePatterns.length === 0) return true
+    // If rule has file patterns but no file path was provided, no match
+    if (!filePath) return false
+    return micromatch.isMatch(filePath, rule.filePatterns)
+  }
+}

--- a/packages/db/src/migrations/032_workspace_policy_rules.ts
+++ b/packages/db/src/migrations/032_workspace_policy_rules.ts
@@ -1,0 +1,16 @@
+export const name = '032_workspace_policy_rules'
+
+export const sql = `
+CREATE TABLE IF NOT EXISTS workspace_policy_rules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES agent_worktrees(id) ON DELETE CASCADE,
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  operations JSONB NOT NULL DEFAULT '[]',
+  file_patterns JSONB NOT NULL DEFAULT '[]',
+  action TEXT NOT NULL DEFAULT 'allow',
+  priority INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_wpr_workspace_agent ON workspace_policy_rules(workspace_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_wpr_priority ON workspace_policy_rules(priority DESC);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -30,6 +30,7 @@ import * as m028 from './028_finance_events.js'
 import * as m029 from './029_workspace_operations.js'
 import * as m030 from './030_llm_configs.js'
 import * as m031 from './031_company_logo.js'
+import * as m032 from './032_workspace_policy_rules.js'
 
 export interface Migration {
   name: string
@@ -68,6 +69,7 @@ const migrations: Migration[] = [
   m029,
   m030,
   m031,
+  m032,
 ]
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -197,6 +197,13 @@ export const WorkspaceOperationType = {
 export type WorkspaceOperationType =
   (typeof WorkspaceOperationType)[keyof typeof WorkspaceOperationType]
 
+export const WorkspacePolicyAction = {
+  Allow: 'allow',
+  Deny: 'deny',
+} as const
+export type WorkspacePolicyAction =
+  (typeof WorkspacePolicyAction)[keyof typeof WorkspacePolicyAction]
+
 /** Free tier limit for concurrent active worktrees per company. */
 export const FREE_TIER_MAX_WORKTREES = 5
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -611,6 +611,47 @@ export interface WorkspaceOperation {
   created_at: Date
 }
 
+
+// ---------------------------------------------------------------------------
+// Workspace Policies -- per-agent, per-workspace operation rules
+// ---------------------------------------------------------------------------
+
+/**
+ * A single workspace policy rule.
+ * Rules are evaluated in priority order (highest first).
+ * First match wins; if no rule matches, the default policy applies.
+ */
+export interface WorkspacePolicyRule {
+  /** Operation types this rule applies to. Empty = all operations. */
+  operations: string[]
+  /** Glob patterns for file paths this rule applies to. Empty = all files. */
+  filePatterns: string[]
+  /** Allow or deny the matched operations. */
+  action: string
+  /** Higher priority rules are evaluated first. */
+  priority: number
+}
+
+/**
+ * A complete workspace policy -- attached to a workspace for a specific agent.
+ * Default behavior: agents can only operate in their own worktrees.
+ */
+export interface WorkspacePolicy {
+  /** The workspace (worktree) ID this policy applies to. */
+  workspaceId: string
+  /** The agent this policy applies to. */
+  agentId: string
+  /** Ordered rules -- evaluated highest-priority first. */
+  rules: WorkspacePolicyRule[]
+}
+
+/** Result of a workspace policy check. */
+export interface WorkspacePolicyCheckResult {
+  allowed: boolean
+  /** The rule that matched, if any. */
+  matchedRule?: WorkspacePolicyRule
+  reason: string
+}
 // ---------------------------------------------------------------------------
 // WebSocket Events — real-time dashboard updates
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -21,6 +21,7 @@ import {
   FinanceEventType,
   WorkspaceOperationType,
   LlmProvider,
+  WorkspacePolicyAction,
 } from './constants.js'
 
 // ---------------------------------------------------------------------------
@@ -616,3 +617,27 @@ export const UpdateLlmConfigInput = z.object({
   temperature: z.number().min(0).max(2).nullable().optional(),
 })
 export type UpdateLlmConfigInput = z.infer<typeof UpdateLlmConfigInput>
+
+// ---------------------------------------------------------------------------
+// Workspace Policy Rules
+// ---------------------------------------------------------------------------
+
+const workspacePolicyActionValues = Object.values(WorkspacePolicyAction) as [
+  string,
+  ...string[],
+]
+
+export const WorkspacePolicyRuleInput = z.object({
+  operations: z.array(z.enum(workspaceOperationTypeValues)).default([]),
+  file_patterns: z.array(z.string()).default([]),
+  action: z.enum(workspacePolicyActionValues).default(WorkspacePolicyAction.Allow),
+  priority: z.number().int().min(0).default(0),
+})
+export type WorkspacePolicyRuleInput = z.infer<typeof WorkspacePolicyRuleInput>
+
+export const SetWorkspacePolicyInput = z.object({
+  workspace_id: uuid,
+  agent_id: uuid,
+  rules: z.array(WorkspacePolicyRuleInput).min(1),
+})
+export type SetWorkspacePolicyInput = z.infer<typeof SetWorkspacePolicyInput>


### PR DESCRIPTION
## Summary
- Add `WorkspacePolicyEngine` that enforces per-agent, per-workspace operation policies with default-deny for cross-workspace access
- Policy rules support operation type matching (`file_read`, `file_write`, `git_push`, etc.) and file path glob patterns via micromatch
- Wire policy enforcement into `WorktreeManager` with `enforcePolicy()` method and `.policy` accessor
- Add `WorkspacePolicyAction` constant, `WorkspacePolicyRule`/`WorkspacePolicy`/`WorkspacePolicyCheckResult` types, and Zod validators (`WorkspacePolicyRuleInput`, `SetWorkspacePolicyInput`)
- Add migration 030 for `workspace_policy_rules` table with cascade deletes and priority index

## Test plan
- [ ] Unit test `WorkspacePolicyEngine.checkPolicy()` with owned vs foreign workspace
- [ ] Unit test rule matching: operation type filtering, file glob patterns, priority ordering
- [ ] Unit test `WorktreeManager.enforcePolicy()` throws on denied operations
- [ ] Verify migration creates `workspace_policy_rules` table with correct schema
- [ ] Integration test: set rules, check policy, clear rules lifecycle

Closes #172

Generated with [Claude Code](https://claude.com/claude-code)