### PR TITLE
feat: add mobile-responsive layout and PWA support

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -2,9 +2,24 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>ShackleAI Dashboard</title>
+
+    <!-- PWA meta tags -->
+    <meta name="theme-color" content="#f59e0b" />
+    <meta name="description" content="ShackleAI — The Operating System for AI Agents" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="ShackleAI" />
+    <meta name="mobile-web-app-capable" content="yes" />
+
+    <!-- Icons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
+
+    <!-- PWA manifest -->
+    <link rel="manifest" href="/manifest.json" />
+
     <script>
       // Apply saved theme before first paint to prevent flash
       (function() {
@@ -22,5 +37,16 @@
   <body class="min-h-screen bg-background text-foreground antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Service worker registration -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register('/sw.js').catch(function(err) {
+            console.warn('SW registration failed:', err);
+          });
+        });
+      }
+    </script>
   </body>
 </html>

--- a/apps/dashboard/public/icons/icon-192.svg
+++ b/apps/dashboard/public/icons/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#1a1a1a"/>
+  <rect x="48" y="48" width="96" height="96" rx="16" fill="#f59e0b"/>
+  <text x="96" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="64" font-weight="700" fill="#1a1a1a">S</text>
+</svg>

--- a/apps/dashboard/public/icons/icon-512.svg
+++ b/apps/dashboard/public/icons/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#1a1a1a"/>
+  <rect x="128" y="128" width="256" height="256" rx="40" fill="#f59e0b"/>
+  <text x="256" y="296" text-anchor="middle" font-family="system-ui, sans-serif" font-size="172" font-weight="700" fill="#1a1a1a">S</text>
+</svg>

--- a/apps/dashboard/public/manifest.json
+++ b/apps/dashboard/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "ShackleAI Dashboard",
+  "short_name": "ShackleAI",
+  "description": "The Operating System for AI Agents — manage your agent infrastructure from one dashboard.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1a1a",
+  "theme_color": "#f59e0b",
+  "orientation": "any",
+  "categories": ["developer", "productivity"],
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/apps/dashboard/public/sw.js
+++ b/apps/dashboard/public/sw.js
@@ -1,0 +1,70 @@
+/// <reference lib="webworker" />
+
+const CACHE_NAME = 'shackleai-shell-v1'
+
+/** App shell files to cache for offline support. */
+const SHELL_FILES = [
+  '/',
+  '/index.html',
+]
+
+// Install: cache the app shell
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_FILES)),
+  )
+  // Activate immediately without waiting for existing tabs to close
+  self.skipWaiting()
+})
+
+// Activate: clean up old caches
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key)),
+      ),
+    ),
+  )
+  // Take control of all open tabs immediately
+  self.clients.claim()
+})
+
+// Fetch: network-first strategy for API calls, cache-first for shell
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  const url = new URL(request.url)
+
+  // Skip non-GET requests
+  if (request.method !== 'GET') return
+
+  // API calls: always go to network (don't cache dynamic data)
+  if (url.pathname.startsWith('/api/')) return
+
+  // Navigation requests: serve from cache, fall back to network
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches.match('/index.html').then((r) => r || fetch(request)),
+      ),
+    )
+    return
+  }
+
+  // Static assets: cache-first, fall back to network
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached
+      return fetch(request).then((response) => {
+        // Cache successful responses for static assets
+        if (response.ok && (url.pathname.match(/\.(js|css|woff2?|png|svg|ico)$/))) {
+          const clone = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone))
+        }
+        return response
+      })
+    }),
+  )
+})

--- a/apps/dashboard/src/app.css
+++ b/apps/dashboard/src/app.css
@@ -61,6 +61,36 @@ body {
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
+/* Safe area insets for PWA standalone mode (notch/home indicator) */
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Responsive table: hide scrollbar but keep scroll behavior */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
+/* Touch-friendly tap targets for mobile */
+@media (max-width: 767px) {
+  /* Ensure minimum 44px tap targets on mobile */
+  button,
+  a[role="button"],
+  [role="tab"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Prevent text selection flash on tap */
+  nav a {
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
 @keyframes toast-slide-in {
   from {
     opacity: 0;

--- a/apps/dashboard/src/components/MobileBottomNav.tsx
+++ b/apps/dashboard/src/components/MobileBottomNav.tsx
@@ -1,0 +1,84 @@
+import { NavLink, useLocation } from 'react-router-dom'
+import {
+  LayoutDashboard,
+  Bot,
+  ListTodo,
+  Activity,
+  Settings,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useInboxCounts } from '@/hooks/useInboxCounts'
+
+interface BottomNavItem {
+  to: string
+  icon: typeof LayoutDashboard
+  label: string
+  end?: boolean
+  badgeKey?: 'unread_issues' | 'pending_approvals' | 'new_comments'
+}
+
+const bottomNavItems: BottomNavItem[] = [
+  { to: '/', icon: LayoutDashboard, label: 'Home', end: true },
+  { to: '/agents', icon: Bot, label: 'Agents' },
+  { to: '/tasks', icon: ListTodo, label: 'Tasks', badgeKey: 'unread_issues' },
+  { to: '/activity', icon: Activity, label: 'Activity', badgeKey: 'new_comments' },
+  { to: '/settings', icon: Settings, label: 'Settings' },
+]
+
+export function MobileBottomNav() {
+  const location = useLocation()
+  const { counts } = useInboxCounts()
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-50 flex h-16 items-center justify-around border-t border-border bg-background/95 backdrop-blur-sm pb-safe lg:hidden"
+      aria-label="Mobile navigation"
+    >
+      {bottomNavItems.map(({ to, icon: Icon, label, end, badgeKey }) => {
+        const isActive = end
+          ? location.pathname === to
+          : location.pathname.startsWith(to)
+        const badgeCount = badgeKey ? counts[badgeKey] : 0
+
+        return (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            className="relative flex flex-col items-center justify-center gap-0.5 px-3 py-1"
+            aria-label={label}
+          >
+            <div className="relative">
+              <Icon
+                className={cn(
+                  'h-5 w-5 transition-colors',
+                  isActive
+                    ? 'text-amber-500'
+                    : 'text-muted-foreground',
+                )}
+              />
+              {badgeCount > 0 && (
+                <span
+                  className="absolute -right-1.5 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-amber-500 px-1 text-[8px] font-bold text-white"
+                  aria-label={`${badgeCount} notification${badgeCount !== 1 ? 's' : ''}`}
+                >
+                  {badgeCount > 9 ? '9+' : badgeCount}
+                </span>
+              )}
+            </div>
+            <span
+              className={cn(
+                'text-[10px] font-medium transition-colors',
+                isActive
+                  ? 'text-amber-500'
+                  : 'text-muted-foreground',
+              )}
+            >
+              {label}
+            </span>
+          </NavLink>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/dashboard/src/components/ui/responsive-table.tsx
+++ b/apps/dashboard/src/components/ui/responsive-table.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Wraps table content to provide horizontal scrolling on small screens.
+ * Also adds a subtle left-fade indicator when content is scrollable.
+ */
+const ResponsiveTable = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'relative w-full',
+      // On mobile, enable horizontal scroll with momentum
+      'overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0',
+      // Hide scrollbar but keep scroll behavior
+      '[&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]',
+      className,
+    )}
+    {...props}
+  >
+    <div className="min-w-[600px] sm:min-w-0">
+      {children}
+    </div>
+  </div>
+))
+ResponsiveTable.displayName = 'ResponsiveTable'
+
+/**
+ * Alternative card-based layout for displaying table data on mobile.
+ * Use this when you want a completely different layout on small screens.
+ *
+ * Usage:
+ *   <MobileCardList className="sm:hidden">
+ *     {items.map(item => <MobileCard key={item.id}>...</MobileCard>)}
+ *   </MobileCardList>
+ */
+const MobileCardList = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('space-y-3', className)}
+    {...props}
+  />
+))
+MobileCardList.displayName = 'MobileCardList'
+
+const MobileCard = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-lg border border-border bg-card p-4 transition-colors hover:bg-muted/50',
+      className,
+    )}
+    {...props}
+  />
+))
+MobileCard.displayName = 'MobileCard'
+
+const MobileCardRow = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { label: string }
+>(({ className, label, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center justify-between gap-2 py-1', className)}
+    {...props}
+  >
+    <span className="text-xs font-medium text-muted-foreground shrink-0">
+      {label}
+    </span>
+    <span className="text-sm text-right truncate">{children}</span>
+  </div>
+))
+MobileCardRow.displayName = 'MobileCardRow'
+
+export { ResponsiveTable, MobileCardList, MobileCard, MobileCardRow }

--- a/apps/dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/dashboard/src/layouts/DashboardLayout.tsx
@@ -22,6 +22,7 @@ import { ThemeToggle } from '@/components/theme-toggle'
 import { LiveIndicator } from '@/components/LiveIndicator'
 import { CommandPalette } from '@/components/CommandPalette'
 import { KeyboardShortcutsHelp } from '@/components/KeyboardShortcutsHelp'
+import { MobileBottomNav } from '@/components/MobileBottomNav'
 import { useRecentPages } from '@/hooks/useRecentPages'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useInboxCounts } from '@/hooks/useInboxCounts'
@@ -224,12 +225,15 @@ export function DashboardLayout() {
           </div>
         </header>
 
-        {/* Page content */}
-        <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+        {/* Page content — extra bottom padding on mobile for bottom nav */}
+        <main className="flex-1 overflow-y-auto p-4 pb-20 lg:p-6 lg:pb-6">
           <UpgradeBanner />
           <Outlet />
         </main>
       </div>
+
+      {/* Mobile bottom navigation */}
+      <MobileBottomNav />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Mobile bottom navigation**: 5-item tab bar (Home, Agents, Tasks, Activity, Settings) with amber active state and badge counts, hidden on desktop (lg+)
- **PWA support**: manifest.json, service worker with offline shell caching, meta tags (theme-color, apple-mobile-web-app, viewport-fit=cover)
- **Responsive table primitives**: `ResponsiveTable` (horizontal scroll wrapper), `MobileCardList`/`MobileCard`/`MobileCardRow` (card layout alternative for small screens)
- **Mobile CSS**: safe-area-inset padding for PWA standalone mode, 44px minimum tap targets, tap-highlight suppression

## Files changed
| File | Change |
|------|--------|
| `apps/dashboard/index.html` | PWA meta tags, manifest link, service worker registration |
| `apps/dashboard/src/app.css` | Safe area insets, scrollbar-hide, touch-friendly tap targets |
| `apps/dashboard/src/layouts/DashboardLayout.tsx` | Import + render MobileBottomNav, bottom padding for mobile |
| `apps/dashboard/src/components/MobileBottomNav.tsx` | **New** — bottom tab bar for mobile |
| `apps/dashboard/src/components/ui/responsive-table.tsx` | **New** — responsive table primitives |
| `apps/dashboard/public/manifest.json` | **New** — PWA web app manifest |
| `apps/dashboard/public/sw.js` | **New** — service worker (offline shell) |
| `apps/dashboard/public/icons/icon-{192,512}.svg` | **New** — PWA app icons |

## Test plan
- [ ] Open dashboard at 375px width — bottom nav visible, sidebar hidden
- [ ] Open dashboard at 1440px width — sidebar visible, bottom nav hidden
- [ ] Tap hamburger menu on mobile — sidebar slides in with overlay
- [ ] Bottom nav badges reflect inbox counts
- [ ] Install as PWA on Chrome (desktop + mobile) — standalone mode works
- [ ] Kill network after load — offline shell serves cached index.html
- [ ] Verify typecheck (`npx tsc --noEmit`) and build (`npx vite build`) pass

Closes #105

Generated with [Claude Code](https://claude.com/claude-code)