### PR TITLE
feat: add company memberships, invites, and join requests

### DIFF
--- a/apps/cli/src/server/routes/memberships.ts
+++ b/apps/cli/src/server/routes/memberships.ts
@@ -1,0 +1,569 @@
+/**
+ * Company membership, invite & join-request routes
+ *
+ * Mounted at /api/companies — routes include /:id/ prefix.
+ * All mutating endpoints require human JWT auth via humanAuth middleware.
+ * Public endpoints: GET /api/invites/:token (invite details)
+ */
+
+import { randomBytes } from 'node:crypto'
+import { Hono } from 'hono'
+import type { DatabaseProvider } from '@shackleai/db'
+import type {
+  CompanyMembership,
+  CompanyInvite,
+  JoinRequest,
+  User,
+} from '@shackleai/shared'
+import {
+  CreateInviteInput,
+  CreateJoinRequestInput,
+  UpdateMemberRoleInput,
+} from '@shackleai/shared'
+import {
+  MembershipRole,
+  MembershipRoleWeight,
+  JoinRequestStatus,
+  INVITE_TTL_MS,
+} from '@shackleai/shared'
+import type { CompanyScopeVariables } from '../middleware/company-scope.js'
+import { companyScope } from '../middleware/company-scope.js'
+import { humanAuth, type HumanAuthVariables } from '../middleware/human-auth.js'
+
+type Variables = CompanyScopeVariables & HumanAuthVariables
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if `actor` role outranks `target` role. */
+function outranks(actorRole: string, targetRole: string): boolean {
+  const a = MembershipRoleWeight[actorRole as MembershipRole] ?? 0
+  const t = MembershipRoleWeight[targetRole as MembershipRole] ?? 0
+  return a > t
+}
+
+/** Returns true if `role` is admin or owner. */
+function isAdminOrAbove(role: string): boolean {
+  const w = MembershipRoleWeight[role as MembershipRole] ?? 0
+  return w >= MembershipRoleWeight[MembershipRole.Admin]
+}
+
+/** Look up calling user's membership in a company. */
+async function getCallerMembership(
+  db: DatabaseProvider,
+  companyId: string,
+  userId: string,
+): Promise<CompanyMembership | null> {
+  const result = await db.query<CompanyMembership>(
+    'SELECT * FROM company_memberships WHERE company_id = $1 AND user_id = $2',
+    [companyId, userId],
+  )
+  return result.rows[0] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Router — company-scoped membership routes
+// ---------------------------------------------------------------------------
+
+export function membershipsRouter(db: DatabaseProvider): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>()
+
+  // Inject db into context
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    return next()
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /:id/members — list company members
+  // -------------------------------------------------------------------------
+  app.get('/:id/members', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+
+    const result = await db.query<CompanyMembership & { user_name: string; user_email: string }>(
+      `SELECT cm.*, u.name as user_name, u.email as user_email
+       FROM company_memberships cm
+       JOIN users u ON u.id = cm.user_id
+       WHERE cm.company_id = $1
+       ORDER BY cm.joined_at ASC`,
+      [company.id],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /:id/invites — create an invite (admin+ only)
+  // -------------------------------------------------------------------------
+  app.post('/:id/invites', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const userId = c.get('userId')
+
+    // Verify caller is admin+
+    const callerMembership = await getCallerMembership(db, company.id, userId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    const body = await c.req.json()
+    const parsed = CreateInviteInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, 400)
+    }
+
+    const { email, role } = parsed.data
+
+    // Cannot invite someone with a higher role than your own
+    if (!outranks(callerMembership.role, role) && callerMembership.role !== role) {
+      // Allow same-level (admin inviting admin) but not higher
+      if (MembershipRoleWeight[role as MembershipRole] > MembershipRoleWeight[callerMembership.role as MembershipRole]) {
+        return c.json({ error: 'Cannot invite a user with a role above your own' }, 403)
+      }
+    }
+
+    // Owners cannot be invited — they are set at company creation
+    if (role === MembershipRole.Owner) {
+      return c.json({ error: 'Cannot invite with owner role' }, 400)
+    }
+
+    // Check if user is already a member
+    const existingMember = await db.query(
+      `SELECT id FROM company_memberships cm
+       JOIN users u ON u.id = cm.user_id
+       WHERE cm.company_id = $1 AND u.email = $2`,
+      [company.id, email.toLowerCase()],
+    )
+    if (existingMember.rows.length > 0) {
+      return c.json({ error: 'User is already a member of this company' }, 409)
+    }
+
+    // Check for existing pending invite
+    const existingInvite = await db.query(
+      `SELECT id FROM company_invites
+       WHERE company_id = $1 AND email = $2 AND accepted_at IS NULL AND expires_at > NOW()`,
+      [company.id, email.toLowerCase()],
+    )
+    if (existingInvite.rows.length > 0) {
+      return c.json({ error: 'A pending invite already exists for this email' }, 409)
+    }
+
+    const token = randomBytes(32).toString('hex')
+    const expiresAt = new Date(Date.now() + INVITE_TTL_MS).toISOString()
+
+    const result = await db.query<CompanyInvite>(
+      `INSERT INTO company_invites (company_id, email, role, token, invited_by, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [company.id, email.toLowerCase(), role, token, userId, expiresAt],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /:id/invites — list invites for a company (admin+ only)
+  // -------------------------------------------------------------------------
+  app.get('/:id/invites', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const userId = c.get('userId')
+
+    const callerMembership = await getCallerMembership(db, company.id, userId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    const result = await db.query<CompanyInvite>(
+      `SELECT * FROM company_invites WHERE company_id = $1 ORDER BY created_at DESC`,
+      [company.id],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /:id/join-requests — request to join a company (any authenticated user)
+  // -------------------------------------------------------------------------
+  app.post('/:id/join-requests', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const userId = c.get('userId')
+
+    const body = await c.req.json()
+    const parsed = CreateJoinRequestInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, 400)
+    }
+
+    // Already a member?
+    const existing = await getCallerMembership(db, company.id, userId)
+    if (existing) {
+      return c.json({ error: 'Already a member of this company' }, 409)
+    }
+
+    // Already have a pending request?
+    const pendingReq = await db.query(
+      `SELECT id FROM join_requests
+       WHERE company_id = $1 AND user_id = $2 AND status = $3`,
+      [company.id, userId, JoinRequestStatus.Pending],
+    )
+    if (pendingReq.rows.length > 0) {
+      return c.json({ error: 'A pending join request already exists' }, 409)
+    }
+
+    const result = await db.query<JoinRequest>(
+      `INSERT INTO join_requests (company_id, user_id, message)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [company.id, userId, parsed.data.message ?? null],
+    )
+
+    return c.json({ data: result.rows[0] }, 201)
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /:id/join-requests — list join requests (admin+ only)
+  // -------------------------------------------------------------------------
+  app.get('/:id/join-requests', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const userId = c.get('userId')
+
+    const callerMembership = await getCallerMembership(db, company.id, userId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    const result = await db.query<JoinRequest & { user_name: string; user_email: string }>(
+      `SELECT jr.*, u.name as user_name, u.email as user_email
+       FROM join_requests jr
+       JOIN users u ON u.id = jr.user_id
+       WHERE jr.company_id = $1
+       ORDER BY jr.created_at DESC`,
+      [company.id],
+    )
+
+    return c.json({ data: result.rows })
+  })
+
+  // -------------------------------------------------------------------------
+  // PUT /:id/join-requests/:requestId/:action — approve or deny (admin+ only)
+  // -------------------------------------------------------------------------
+  app.put('/:id/join-requests/:requestId/:action', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const userId = c.get('userId')
+    const requestId = c.req.param('requestId')!
+    const action = c.req.param('action')!
+
+    if (action !== 'approve' && action !== 'deny') {
+      return c.json({ error: 'Action must be "approve" or "deny"' }, 400)
+    }
+
+    const callerMembership = await getCallerMembership(db, company.id, userId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    const reqResult = await db.query<JoinRequest>(
+      'SELECT * FROM join_requests WHERE id = $1 AND company_id = $2',
+      [requestId, company.id],
+    )
+
+    if (reqResult.rows.length === 0) {
+      return c.json({ error: 'Join request not found' }, 404)
+    }
+
+    const joinReq = reqResult.rows[0]
+    if (joinReq.status !== JoinRequestStatus.Pending) {
+      return c.json({ error: `Join request already ${joinReq.status}` }, 409)
+    }
+
+    const newStatus = action === 'approve' ? JoinRequestStatus.Approved : JoinRequestStatus.Denied
+
+    await db.query(
+      `UPDATE join_requests SET status = $1, decided_by = $2 WHERE id = $3`,
+      [newStatus, userId, requestId],
+    )
+
+    // If approved, create the membership
+    if (action === 'approve') {
+      await db.query(
+        `INSERT INTO company_memberships (company_id, user_id, role)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (company_id, user_id) DO NOTHING`,
+        [company.id, joinReq.user_id, MembershipRole.Member],
+      )
+
+      // Also set the user's company_id if not already set
+      await db.query(
+        `UPDATE users SET company_id = $1, updated_at = NOW() WHERE id = $2 AND company_id IS NULL`,
+        [company.id, joinReq.user_id],
+      )
+    }
+
+    return c.json({ data: { message: `Join request ${newStatus}`, request_id: requestId } })
+  })
+
+  // -------------------------------------------------------------------------
+  // PUT /:id/members/:userId/role — change a member's role (admin+ only)
+  // -------------------------------------------------------------------------
+  app.put('/:id/members/:userId/role', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const callerId = c.get('userId')
+    const targetUserId = c.req.param('userId')!
+
+    const body = await c.req.json()
+    const parsed = UpdateMemberRoleInput.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, 400)
+    }
+
+    const { role: newRole } = parsed.data
+
+    // Cannot set owner role via this endpoint
+    if (newRole === MembershipRole.Owner) {
+      return c.json({ error: 'Cannot assign owner role via this endpoint' }, 400)
+    }
+
+    const callerMembership = await getCallerMembership(db, company.id, callerId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    const targetMembership = await getCallerMembership(db, company.id, targetUserId)
+    if (!targetMembership) {
+      return c.json({ error: 'Member not found' }, 404)
+    }
+
+    // Cannot change the role of someone with equal or higher rank (unless you're owner)
+    if (callerMembership.role !== MembershipRole.Owner && !outranks(callerMembership.role, targetMembership.role)) {
+      return c.json({ error: 'Cannot change the role of a member with equal or higher rank' }, 403)
+    }
+
+    // Cannot demote yourself
+    if (callerId === targetUserId) {
+      return c.json({ error: 'Cannot change your own role' }, 400)
+    }
+
+    await db.query(
+      `UPDATE company_memberships SET role = $1 WHERE company_id = $2 AND user_id = $3`,
+      [newRole, company.id, targetUserId],
+    )
+
+    return c.json({ data: { message: 'Role updated', user_id: targetUserId, role: newRole } })
+  })
+
+  // -------------------------------------------------------------------------
+  // DELETE /:id/members/:userId — remove a member (admin+ only, or self)
+  // -------------------------------------------------------------------------
+  app.delete('/:id/members/:userId', companyScope, humanAuth, async (c) => {
+    const company = c.get('company')
+    const callerId = c.get('userId')
+    const targetUserId = c.req.param('userId')!
+
+    const targetMembership = await getCallerMembership(db, company.id, targetUserId)
+    if (!targetMembership) {
+      return c.json({ error: 'Member not found' }, 404)
+    }
+
+    // Cannot remove the owner
+    if (targetMembership.role === MembershipRole.Owner) {
+      return c.json({ error: 'Cannot remove the company owner' }, 403)
+    }
+
+    // Self-removal is always allowed (leaving the company)
+    if (callerId === targetUserId) {
+      await db.query(
+        'DELETE FROM company_memberships WHERE company_id = $1 AND user_id = $2',
+        [company.id, targetUserId],
+      )
+      // Clear the user's company_id if it matches
+      await db.query(
+        'UPDATE users SET company_id = NULL, updated_at = NOW() WHERE id = $1 AND company_id = $2',
+        [targetUserId, company.id],
+      )
+      return c.json({ data: { message: 'You have left the company' } })
+    }
+
+    // Otherwise require admin+
+    const callerMembership = await getCallerMembership(db, company.id, callerId)
+    if (!callerMembership || !isAdminOrAbove(callerMembership.role)) {
+      return c.json({ error: 'Forbidden — admin or owner role required' }, 403)
+    }
+
+    // Cannot remove someone with equal or higher rank (unless owner)
+    if (callerMembership.role !== MembershipRole.Owner && !outranks(callerMembership.role, targetMembership.role)) {
+      return c.json({ error: 'Cannot remove a member with equal or higher rank' }, 403)
+    }
+
+    await db.query(
+      'DELETE FROM company_memberships WHERE company_id = $1 AND user_id = $2',
+      [company.id, targetUserId],
+    )
+
+    // Clear the user's company_id if it matches
+    await db.query(
+      'UPDATE users SET company_id = NULL, updated_at = NOW() WHERE id = $1 AND company_id = $2',
+      [targetUserId, company.id],
+    )
+
+    return c.json({ data: { message: 'Member removed', user_id: targetUserId } })
+  })
+
+  return app
+}
+
+// ---------------------------------------------------------------------------
+// Public invite routes — mounted at /api/invites (no API key required)
+// ---------------------------------------------------------------------------
+
+export function invitesPublicRouter(db: DatabaseProvider): Hono {
+  const app = new Hono()
+
+  // GET /api/invites/:token — get invite details (public, no auth)
+  app.get('/:token', async (c) => {
+    const token = c.req.param('token')!
+
+    const result = await db.query<CompanyInvite & { company_name: string }>(
+      `SELECT ci.*, co.name as company_name
+       FROM company_invites ci
+       JOIN companies co ON co.id = ci.company_id
+       WHERE ci.token = $1`,
+      [token],
+    )
+
+    if (result.rows.length === 0) {
+      return c.json({ error: 'Invite not found' }, 404)
+    }
+
+    const invite = result.rows[0]
+
+    // Check expiry
+    if (new Date(invite.expires_at) < new Date()) {
+      return c.json({ error: 'Invite has expired' }, 410)
+    }
+
+    // Check if already accepted
+    if (invite.accepted_at) {
+      return c.json({ error: 'Invite has already been accepted' }, 410)
+    }
+
+    // Return safe subset (no internal IDs exposed unnecessarily)
+    return c.json({
+      data: {
+        company_name: invite.company_name,
+        email: invite.email,
+        role: invite.role,
+        expires_at: invite.expires_at,
+      },
+    })
+  })
+
+  // POST /api/invites/:token/accept — accept invite (requires JWT auth)
+  app.post('/:token/accept', async (c) => {
+    // This endpoint needs human auth but is mounted outside the global API key middleware.
+    // We manually verify JWT here since humanAuth middleware requires db on context.
+    const { createHash } = await import('node:crypto')
+    const { verifyJwt } = await import('./auth.js')
+
+    const authHeader = c.req.header('Authorization')
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return c.json({ error: 'Unauthorized — login required to accept an invite' }, 401)
+    }
+
+    const jwtToken = authHeader.slice('Bearer '.length).trim()
+    const payload = verifyJwt(jwtToken)
+    if (!payload) {
+      return c.json({ error: 'Invalid or expired token' }, 401)
+    }
+
+    // Verify session
+    const tokenHash = createHash('sha256').update(jwtToken).digest('hex')
+    const session = await db.query(
+      'SELECT id FROM user_sessions WHERE token_hash = $1 AND expires_at > NOW()',
+      [tokenHash],
+    )
+    if (session.rows.length === 0) {
+      return c.json({ error: 'Session expired or invalidated' }, 401)
+    }
+
+    const userId = payload.sub
+    const inviteToken = c.req.param('token')!
+
+    const inviteResult = await db.query<CompanyInvite>(
+      'SELECT * FROM company_invites WHERE token = $1',
+      [inviteToken],
+    )
+
+    if (inviteResult.rows.length === 0) {
+      return c.json({ error: 'Invite not found' }, 404)
+    }
+
+    const invite = inviteResult.rows[0]
+
+    // Check expiry
+    if (new Date(invite.expires_at) < new Date()) {
+      return c.json({ error: 'Invite has expired' }, 410)
+    }
+
+    // Check if already accepted
+    if (invite.accepted_at) {
+      return c.json({ error: 'Invite has already been accepted' }, 410)
+    }
+
+    // Verify the accepting user's email matches the invite
+    const userResult = await db.query<User>(
+      'SELECT * FROM users WHERE id = $1',
+      [userId],
+    )
+    if (userResult.rows.length === 0) {
+      return c.json({ error: 'User not found' }, 404)
+    }
+
+    const user = userResult.rows[0]
+    if (user.email.toLowerCase() !== invite.email.toLowerCase()) {
+      return c.json({ error: 'This invite was sent to a different email address' }, 403)
+    }
+
+    // Check if already a member
+    const existingMembership = await db.query(
+      'SELECT id FROM company_memberships WHERE company_id = $1 AND user_id = $2',
+      [invite.company_id, userId],
+    )
+    if (existingMembership.rows.length > 0) {
+      // Mark invite as accepted anyway
+      await db.query(
+        'UPDATE company_invites SET accepted_at = NOW() WHERE id = $1',
+        [invite.id],
+      )
+      return c.json({ data: { message: 'Already a member of this company' } })
+    }
+
+    // Create membership
+    await db.query(
+      `INSERT INTO company_memberships (company_id, user_id, role)
+       VALUES ($1, $2, $3)`,
+      [invite.company_id, userId, invite.role],
+    )
+
+    // Mark invite as accepted
+    await db.query(
+      'UPDATE company_invites SET accepted_at = NOW() WHERE id = $1',
+      [invite.id],
+    )
+
+    // Set the user's company_id if not already set
+    await db.query(
+      'UPDATE users SET company_id = $1, updated_at = NOW() WHERE id = $2 AND company_id IS NULL',
+      [invite.company_id, userId],
+    )
+
+    return c.json({
+      data: {
+        message: 'Invite accepted',
+        company_id: invite.company_id,
+        role: invite.role,
+      },
+    })
+  })
+
+  return app
+}

--- a/packages/db/src/migrations/036_memberships.ts
+++ b/packages/db/src/migrations/036_memberships.ts
@@ -1,0 +1,48 @@
+export const name = '036_memberships'
+
+export const sql = `
+-- Company memberships — links users to companies with a role
+CREATE TABLE IF NOT EXISTS company_memberships (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member',
+  joined_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (company_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_company_memberships_company ON company_memberships(company_id);
+CREATE INDEX IF NOT EXISTS idx_company_memberships_user ON company_memberships(user_id);
+
+-- Invites — email-based invitations with a unique token
+CREATE TABLE IF NOT EXISTS company_invites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'member',
+  token TEXT NOT NULL UNIQUE,
+  invited_by UUID NOT NULL REFERENCES users(id),
+  expires_at TIMESTAMPTZ NOT NULL,
+  accepted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_company_invites_token ON company_invites(token);
+CREATE INDEX IF NOT EXISTS idx_company_invites_company ON company_invites(company_id);
+CREATE INDEX IF NOT EXISTS idx_company_invites_email ON company_invites(email);
+
+-- Join requests — user-initiated requests to join a company
+CREATE TABLE IF NOT EXISTS join_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  message TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  decided_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (company_id, user_id, status)
+);
+
+CREATE INDEX IF NOT EXISTS idx_join_requests_company ON join_requests(company_id);
+CREATE INDEX IF NOT EXISTS idx_join_requests_user ON join_requests(user_id);
+`

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -34,6 +34,7 @@ import * as m032 from './032_workspace_policy_rules.js'
 import * as m033 from './033_users.js'
 import * as m034 from './034_plugins.js'
 import * as m035 from './035_board_claim.js'
+import * as m036 from './036_memberships.js'
 
 export interface Migration {
   name: string
@@ -76,6 +77,7 @@ const migrations: Migration[] = [
   m033,
   m034,
   m035,
+  m036,
 ]
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -265,3 +265,45 @@ export const LlmProvider = {
   OpenRouter: 'openrouter',
 } as const
 export type LlmProvider = (typeof LlmProvider)[keyof typeof LlmProvider]
+
+// ---------------------------------------------------------------------------
+// Company Membership Roles — hierarchical: owner > admin > member > viewer
+// ---------------------------------------------------------------------------
+
+export const MembershipRole = {
+  Owner: 'owner',
+  Admin: 'admin',
+  Member: 'member',
+  Viewer: 'viewer',
+} as const
+export type MembershipRole = (typeof MembershipRole)[keyof typeof MembershipRole]
+
+/** Numeric weight for role hierarchy comparison — higher = more powerful. */
+export const MembershipRoleWeight: Record<MembershipRole, number> = {
+  [MembershipRole.Owner]: 40,
+  [MembershipRole.Admin]: 30,
+  [MembershipRole.Member]: 20,
+  [MembershipRole.Viewer]: 10,
+} as const
+
+// ---------------------------------------------------------------------------
+// Invite & Join Request Statuses
+// ---------------------------------------------------------------------------
+
+export const InviteStatus = {
+  Pending: 'pending',
+  Accepted: 'accepted',
+  Expired: 'expired',
+  Revoked: 'revoked',
+} as const
+export type InviteStatus = (typeof InviteStatus)[keyof typeof InviteStatus]
+
+export const JoinRequestStatus = {
+  Pending: 'pending',
+  Approved: 'approved',
+  Denied: 'denied',
+} as const
+export type JoinRequestStatus = (typeof JoinRequestStatus)[keyof typeof JoinRequestStatus]
+
+/** Invite token expiry — 72 hours in milliseconds. */
+export const INVITE_TTL_MS = 72 * 60 * 60 * 1000

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -791,3 +791,37 @@ export interface JoinRequest {
   decided_by: string | null
   created_at: Date
 }
+
+// ---------------------------------------------------------------------------
+// Company Memberships, Invites & Join Requests
+// ---------------------------------------------------------------------------
+
+export interface CompanyMembership {
+  id: string
+  company_id: string
+  user_id: string
+  role: string
+  joined_at: Date
+}
+
+export interface CompanyInvite {
+  id: string
+  company_id: string
+  email: string
+  role: string
+  token: string
+  invited_by: string
+  expires_at: Date
+  accepted_at: Date | null
+  created_at: Date
+}
+
+export interface JoinRequest {
+  id: string
+  company_id: string
+  user_id: string
+  message: string | null
+  status: string
+  decided_by: string | null
+  created_at: Date
+}

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -23,6 +23,7 @@ import {
   LlmProvider,
   WorkspacePolicyAction,
   UserRole,
+  MembershipRole,
 } from './constants.js'
 
 // ---------------------------------------------------------------------------
@@ -662,3 +663,31 @@ export const LoginUserInput = z.object({
   password: nonEmpty,
 })
 export type LoginUserInput = z.infer<typeof LoginUserInput>
+
+// ---------------------------------------------------------------------------
+// Company Memberships, Invites & Join Requests
+// ---------------------------------------------------------------------------
+
+
+const membershipRoleValues = Object.values(MembershipRole) as [string, ...string[]]
+
+export const CreateInviteInput = z.object({
+  email: z.string().email(),
+  role: z.enum(membershipRoleValues).optional().default(MembershipRole.Member),
+})
+export type CreateInviteInput = z.infer<typeof CreateInviteInput>
+
+export const CreateJoinRequestInput = z.object({
+  message: z.string().max(500).nullable().optional(),
+})
+export type CreateJoinRequestInput = z.infer<typeof CreateJoinRequestInput>
+
+export const DecideJoinRequestInput = z.object({
+  action: z.enum(['approve', 'deny'] as const),
+})
+export type DecideJoinRequestInput = z.infer<typeof DecideJoinRequestInput>
+
+export const UpdateMemberRoleInput = z.object({
+  role: z.enum(membershipRoleValues),
+})
+export type UpdateMemberRoleInput = z.infer<typeof UpdateMemberRoleInput>


### PR DESCRIPTION
## Summary
- Adds migration 036 with `company_memberships`, `company_invites`, and `join_requests` tables
- Implements 8 API endpoints for the multi-user company model: list members, create/accept invites, create/approve/deny join requests, change roles, remove members
- Adds role hierarchy (owner > admin > member > viewer) with numeric weights for authorization checks
- Public invite endpoints (`/api/invites/:token`) bypass API key auth but validate JWT internally for accept

## API Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/api/companies/:id/members` | JWT | List company members |
| `POST` | `/api/companies/:id/invites` | JWT (admin+) | Create invite (72h expiry) |
| `GET` | `/api/companies/:id/invites` | JWT (admin+) | List invites |
| `GET` | `/api/invites/:token` | Public | Get invite details |
| `POST` | `/api/invites/:token/accept` | JWT | Accept invite |
| `POST` | `/api/companies/:id/join-requests` | JWT | Request to join |
| `GET` | `/api/companies/:id/join-requests` | JWT (admin+) | List join requests |
| `PUT` | `/api/companies/:id/join-requests/:id/approve\|deny` | JWT (admin+) | Decide request |
| `PUT` | `/api/companies/:id/members/:userId/role` | JWT (admin+) | Change member role |
| `DELETE` | `/api/companies/:id/members/:userId` | JWT (admin+/self) | Remove member |

## Test plan
- [ ] Create invite as admin, verify 72h expiry and unique token
- [ ] Accept invite with matching email, verify membership created
- [ ] Reject invite acceptance with mismatched email
- [ ] Submit join request, approve as admin, verify membership
- [ ] Deny join request, verify no membership created
- [ ] Change member role, verify hierarchy enforcement
- [ ] Remove member, verify cannot remove owner
- [ ] Verify self-removal (leave company) works

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)