### PR TITLE
feat: agent runs tab + run transcript page

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { CostsPage } from './pages/costs'
 import { OrgChartPage } from './pages/org-chart'
 import { SettingsPage } from './pages/settings'
 import { TaskDetailPage } from './pages/task-detail'
+import { RunTranscriptPage } from './pages/run-transcript'
 import { DesignGuidePage } from './pages/design-guide'
 
 export function App() {
@@ -19,6 +20,7 @@ export function App() {
         <Route index element={<OverviewPage />} />
         <Route path="agents" element={<AgentsPage />} />
         <Route path="agents/:id" element={<AgentDetailPage />} />
+        <Route path="agents/:id/runs/:runId" element={<RunTranscriptPage />} />
         <Route path="tasks" element={<TasksPage />} />
         <Route path="tasks/:id" element={<TaskDetailPage />} />
         <Route path="board" element={<KanbanPage />} />

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -67,6 +67,14 @@ export interface HeartbeatRun {
   created_at: string
 }
 
+export interface HeartbeatRunEvent {
+  id: string
+  heartbeat_run_id: string
+  event_type: string
+  payload: Record<string, unknown> | null
+  created_at: string
+}
+
 export interface ActivityLogEntry {
   id: string
   company_id: string
@@ -136,6 +144,18 @@ export function fetchHeartbeats(
   const qs = params.toString()
   return fetchJson<HeartbeatRun[]>(
     `${BASE_URL}/companies/${companyId}/agents/${agentId}/heartbeats${qs ? `?${qs}` : ''}`,
+  )
+}
+
+export function fetchHeartbeatRun(companyId: string, runId: string) {
+  return fetchJson<HeartbeatRun>(
+    `${BASE_URL}/companies/${companyId}/heartbeats/${runId}`,
+  )
+}
+
+export function fetchHeartbeatRunEvents(companyId: string, runId: string) {
+  return fetchJson<HeartbeatRunEvent[]>(
+    `${BASE_URL}/companies/${companyId}/heartbeats/${runId}/events`,
   )
 }
 

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -33,3 +33,43 @@ export function formatRelativeTime(date: string | Date | null): string {
   const diffDays = Math.floor(diffHours / 24)
   return `${diffDays}d ago`
 }
+
+export function formatDuration(
+  startedAt: string | null,
+  finishedAt: string | null,
+): string {
+  if (!startedAt) return '\u2014'
+  const start = new Date(startedAt)
+  const end = finishedAt ? new Date(finishedAt) : new Date()
+  const diffMs = end.getTime() - start.getTime()
+  if (diffMs < 1000) return `${diffMs}ms`
+  const secs = Math.floor(diffMs / 1000)
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const remainingSecs = secs % 60
+  if (mins < 60) return `${mins}m ${remainingSecs}s`
+  const hours = Math.floor(mins / 60)
+  const remainingMins = mins % 60
+  return `${hours}h ${remainingMins}m`
+}
+
+export function humanizeEventType(eventType: string): string {
+  return eventType
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+export function redactPaths(text: string): string {
+  // Replace absolute Windows paths (D:\..., C:\...)
+  let result = text.replace(
+    /[A-Z]:\\(?:[^\s\\]+\\)*([^\s\\]+)/g,
+    (_match, filename: string) => `./${filename}`,
+  )
+  // Replace absolute Unix paths (/home/..., /Users/...)
+  result = result.replace(
+    /\/(?:home|Users|tmp|var|opt)\/(?:[^\s/]+\/)*([^\s/]+)/g,
+    (_match, filename: string) => `./${filename}`,
+  )
+  return result
+}

--- a/apps/dashboard/src/pages/agent-detail.tsx
+++ b/apps/dashboard/src/pages/agent-detail.tsx
@@ -3,7 +3,20 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useCompanyId } from '@/hooks/useCompanyId'
 import { usePollingInterval, POLLING_INTERVALS } from '@/hooks/usePolling'
 import { useState } from 'react'
-import { ArrowLeft, Bot, Activity, Play, Pause, XCircle, Loader2, ChevronDown, ChevronRight } from 'lucide-react'
+import {
+  ArrowLeft,
+  Bot,
+  Activity,
+  Play,
+  Pause,
+  XCircle,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+  RotateCcw,
+  FileText,
+  Info,
+} from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -16,9 +29,25 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Select } from '@/components/ui/select'
-import { fetchAgent, fetchHeartbeats, wakeupAgent, updateAgent, pauseAgent, resumeAgent, terminateAgent, type Agent, type HeartbeatRun } from '@/lib/api'
+import {
+  fetchAgent,
+  fetchHeartbeats,
+  wakeupAgent,
+  updateAgent,
+  pauseAgent,
+  resumeAgent,
+  terminateAgent,
+  type Agent,
+  type HeartbeatRun,
+} from '@/lib/api'
 import { Pagination } from '@/components/ui/pagination'
-import { cn, formatCents, formatDate, formatRelativeTime } from '@/lib/utils'
+import {
+  cn,
+  formatCents,
+  formatDate,
+  formatDuration,
+  formatRelativeTime,
+} from '@/lib/utils'
 import { useToast } from '@/components/ui/toast'
 
 const HEARTBEATS_PAGE_SIZE = 10
@@ -41,7 +70,10 @@ const SCHEDULE_OPTIONS = [
   { value: '0 * * * *', label: 'Every hour' },
 ] as const
 
-const statusVariant: Record<string, 'success' | 'warning' | 'destructive' | 'secondary'> = {
+const statusVariant: Record<
+  string,
+  'success' | 'warning' | 'destructive' | 'secondary'
+> = {
   active: 'success',
   idle: 'secondary',
   paused: 'warning',
@@ -49,7 +81,10 @@ const statusVariant: Record<string, 'success' | 'warning' | 'destructive' | 'sec
   terminated: 'destructive',
 }
 
-const heartbeatStatusVariant: Record<string, 'success' | 'warning' | 'destructive' | 'secondary' | 'info'> = {
+const heartbeatStatusVariant: Record<
+  string,
+  'success' | 'warning' | 'destructive' | 'secondary' | 'info'
+> = {
   success: 'success',
   running: 'info',
   failed: 'destructive',
@@ -84,7 +119,13 @@ function DetailSkeleton() {
   )
 }
 
-function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
+function InfoRow({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
   return (
     <div className="flex items-start justify-between gap-4 py-2">
       <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
@@ -93,10 +134,22 @@ function InfoRow({ label, children }: { label: string; children: React.ReactNode
   )
 }
 
-function HeartbeatTable({ heartbeats }: { heartbeats: HeartbeatRun[] }) {
+function HeartbeatTable({
+  heartbeats,
+  agentId,
+  onRetry,
+  retryPending,
+}: {
+  heartbeats: HeartbeatRun[]
+  agentId: string
+  onRetry: () => void
+  retryPending: boolean
+}) {
+  const navigate = useNavigate()
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
-  const toggle = (id: string) => {
+  const toggle = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation()
     setExpanded((prev) => {
       const next = new Set(prev)
       if (next.has(id)) next.delete(id)
@@ -113,32 +166,51 @@ function HeartbeatTable({ heartbeats }: { heartbeats: HeartbeatRun[] }) {
           <TableHead>Trigger</TableHead>
           <TableHead>Status</TableHead>
           <TableHead className="hidden sm:table-cell">Started</TableHead>
+          <TableHead className="hidden md:table-cell">Duration</TableHead>
           <TableHead className="hidden md:table-cell">Exit</TableHead>
           <TableHead>Error</TableHead>
+          <TableHead className="w-20"></TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {heartbeats.map((hb) => {
           const isOpen = expanded.has(hb.id)
           const hasOutput = hb.stdout_excerpt || hb.error || hb.usage_json
+          const isFailed = hb.status === 'failed'
           return (
             <>
               <TableRow
                 key={hb.id}
-                className={hasOutput ? 'cursor-pointer hover:bg-muted/50' : ''}
-                onClick={() => hasOutput && toggle(hb.id)}
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() =>
+                  navigate(`/agents/${agentId}/runs/${hb.id}`)
+                }
               >
                 <TableCell className="w-8 px-2">
                   {hasOutput && (
-                    isOpen
-                      ? <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      : <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    <button
+                      onClick={(e) => toggle(hb.id, e)}
+                      className="p-0.5 rounded hover:bg-muted"
+                      aria-label={
+                        isOpen ? 'Collapse details' : 'Expand details'
+                      }
+                    >
+                      {isOpen ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </button>
                   )}
                 </TableCell>
-                <TableCell className="capitalize">{hb.trigger_type}</TableCell>
+                <TableCell className="capitalize">
+                  {hb.trigger_type}
+                </TableCell>
                 <TableCell>
                   <Badge
-                    variant={heartbeatStatusVariant[hb.status] ?? 'secondary'}
+                    variant={
+                      heartbeatStatusVariant[hb.status] ?? 'secondary'
+                    }
                     className="capitalize"
                   >
                     {hb.status}
@@ -147,20 +219,61 @@ function HeartbeatTable({ heartbeats }: { heartbeats: HeartbeatRun[] }) {
                 <TableCell className="hidden sm:table-cell text-xs text-muted-foreground">
                   {formatRelativeTime(hb.started_at)}
                 </TableCell>
+                <TableCell className="hidden md:table-cell text-xs text-muted-foreground font-mono">
+                  {formatDuration(hb.started_at, hb.finished_at)}
+                </TableCell>
                 <TableCell className="hidden md:table-cell font-mono text-xs">
-                  {hb.exit_code ?? '—'}
+                  {hb.exit_code ?? '\u2014'}
                 </TableCell>
                 <TableCell className="max-w-[200px] truncate text-xs text-destructive-foreground">
-                  {hb.error ? hb.error.split('\n')[0] : '—'}
+                  {hb.error ? hb.error.split('\n')[0] : '\u2014'}
+                </TableCell>
+                <TableCell className="w-20">
+                  <div className="flex items-center gap-1">
+                    {isFailed && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-2 text-xs"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onRetry()
+                        }}
+                        disabled={retryPending}
+                        aria-label="Retry this run"
+                      >
+                        {retryPending ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <RotateCcw className="h-3 w-3" />
+                        )}
+                        Retry
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs text-muted-foreground"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        navigate(`/agents/${agentId}/runs/${hb.id}`)
+                      }}
+                      aria-label="View run transcript"
+                    >
+                      <FileText className="h-3 w-3" />
+                    </Button>
+                  </div>
                 </TableCell>
               </TableRow>
               {isOpen && (
                 <TableRow key={`${hb.id}-detail`}>
-                  <TableCell colSpan={6} className="bg-muted/30 p-4">
+                  <TableCell colSpan={8} className="bg-muted/30 p-4">
                     <div className="space-y-3">
                       {hb.stdout_excerpt && (
                         <div>
-                          <p className="mb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Agent Output</p>
+                          <p className="mb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                            Agent Output
+                          </p>
                           <pre className="max-h-[400px] overflow-auto rounded-md bg-background p-3 text-xs font-mono whitespace-pre-wrap border">
                             {hb.stdout_excerpt}
                           </pre>
@@ -168,26 +281,46 @@ function HeartbeatTable({ heartbeats }: { heartbeats: HeartbeatRun[] }) {
                       )}
                       {hb.error && (
                         <div>
-                          <p className="mb-1 text-xs font-semibold text-destructive uppercase tracking-wide">Error</p>
+                          <p className="mb-1 text-xs font-semibold text-destructive uppercase tracking-wide">
+                            Error
+                          </p>
                           <pre className="overflow-auto rounded-md bg-background p-3 text-xs font-mono whitespace-pre-wrap border border-destructive/20">
                             {hb.error}
                           </pre>
                         </div>
                       )}
-                      {hb.usage_json && (() => {
-                        try {
-                          const u = JSON.parse(hb.usage_json)
-                          return (
-                            <div className="flex gap-4 text-xs text-muted-foreground">
-                              <span>Provider: <strong>{u.provider}</strong></span>
-                              <span>Model: <strong>{u.model}</strong></span>
-                              <span>Input: <strong>{u.inputTokens}</strong> tokens</span>
-                              <span>Output: <strong>{u.outputTokens}</strong> tokens</span>
-                              <span>Cost: <strong>${(u.costCents / 100).toFixed(2)}</strong></span>
-                            </div>
-                          )
-                        } catch { return null }
-                      })()}
+                      {hb.usage_json &&
+                        (() => {
+                          try {
+                            const u = JSON.parse(hb.usage_json)
+                            return (
+                              <div className="flex gap-4 text-xs text-muted-foreground">
+                                <span>
+                                  Provider: <strong>{u.provider}</strong>
+                                </span>
+                                <span>
+                                  Model: <strong>{u.model}</strong>
+                                </span>
+                                <span>
+                                  Input: <strong>{u.inputTokens}</strong>{' '}
+                                  tokens
+                                </span>
+                                <span>
+                                  Output: <strong>{u.outputTokens}</strong>{' '}
+                                  tokens
+                                </span>
+                                <span>
+                                  Cost:{' '}
+                                  <strong>
+                                    ${(u.costCents / 100).toFixed(2)}
+                                  </strong>
+                                </span>
+                              </div>
+                            )
+                          } catch {
+                            return null
+                          }
+                        })()}
                     </div>
                   </TableCell>
                 </TableRow>
@@ -208,6 +341,7 @@ export function AgentDetailPage() {
   const navigate = useNavigate()
   const { toast } = useToast()
 
+  const [activeTab, setActiveTab] = useState<'overview' | 'runs'>('overview')
   const [editingSchedule, setEditingSchedule] = useState(false)
   const [scheduleChanged, setScheduleChanged] = useState(false)
   const [pendingSchedule, setPendingSchedule] = useState<string | null>(null)
@@ -216,7 +350,9 @@ export function AgentDetailPage() {
   const pause = useMutation({
     mutationFn: () => pauseAgent(companyId!, agentId!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['agent', companyId, agentId] })
+      queryClient.invalidateQueries({
+        queryKey: ['agent', companyId, agentId],
+      })
       queryClient.invalidateQueries({ queryKey: ['agents', companyId] })
       toast('Agent paused', 'info')
     },
@@ -228,7 +364,9 @@ export function AgentDetailPage() {
   const resume = useMutation({
     mutationFn: () => resumeAgent(companyId!, agentId!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['agent', companyId, agentId] })
+      queryClient.invalidateQueries({
+        queryKey: ['agent', companyId, agentId],
+      })
       queryClient.invalidateQueries({ queryKey: ['agents', companyId] })
       toast('Agent resumed', 'success')
     },
@@ -252,9 +390,16 @@ export function AgentDetailPage() {
   const wakeup = useMutation({
     mutationFn: () => wakeupAgent(companyId!, agentId!),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['heartbeats', companyId, agentId] })
-      queryClient.invalidateQueries({ queryKey: ['agent', companyId, agentId] })
-      toast(`Heartbeat completed (exit: ${data?.exit_code ?? 'n/a'})`, 'success')
+      queryClient.invalidateQueries({
+        queryKey: ['heartbeats', companyId, agentId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['agent', companyId, agentId],
+      })
+      toast(
+        `Heartbeat completed (exit: ${data?.exit_code ?? 'n/a'})`,
+        'success',
+      )
     },
     onError: (err: Error) => {
       toast(`Heartbeat failed: ${err.message}`, 'error')
@@ -270,10 +415,14 @@ export function AgentDetailPage() {
       } else {
         delete updatedConfig.cron
       }
-      return updateAgent(companyId!, agentId!, { adapter_config: updatedConfig })
+      return updateAgent(companyId!, agentId!, {
+        adapter_config: updatedConfig,
+      })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['agent', companyId, agentId] })
+      queryClient.invalidateQueries({
+        queryKey: ['agent', companyId, agentId],
+      })
       setEditingSchedule(false)
       setPendingSchedule(null)
       setScheduleChanged(true)
@@ -297,7 +446,9 @@ export function AgentDetailPage() {
 
   const [heartbeatPage, setHeartbeatPage] = useState(0)
 
-  const { data: rawHeartbeats, isLoading: heartbeatsLoading } = useQuery<HeartbeatRun[]>({
+  const { data: rawHeartbeats, isLoading: heartbeatsLoading } = useQuery<
+    HeartbeatRun[]
+  >({
     queryKey: ['heartbeats', companyId, agentId, heartbeatPage],
     queryFn: () =>
       fetchHeartbeats(companyId!, agentId!, {
@@ -308,8 +459,11 @@ export function AgentDetailPage() {
     refetchInterval: agentDetailInterval,
   })
 
-  const heartbeatsHasMore = (rawHeartbeats?.length ?? 0) > HEARTBEATS_PAGE_SIZE
-  const heartbeats = rawHeartbeats ? rawHeartbeats.slice(0, HEARTBEATS_PAGE_SIZE) : undefined
+  const heartbeatsHasMore =
+    (rawHeartbeats?.length ?? 0) > HEARTBEATS_PAGE_SIZE
+  const heartbeats = rawHeartbeats
+    ? rawHeartbeats.slice(0, HEARTBEATS_PAGE_SIZE)
+    : undefined
 
   if (agentLoading) return <DetailSkeleton />
   if (agentError) {
@@ -356,7 +510,11 @@ export function AgentDetailPage() {
             size="sm"
             variant="outline"
             onClick={() => wakeup.mutate()}
-            disabled={wakeup.isPending || !companyId || agent.status === 'terminated'}
+            disabled={
+              wakeup.isPending ||
+              !companyId ||
+              agent.status === 'terminated'
+            }
           >
             {wakeup.isPending ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -398,7 +556,9 @@ export function AgentDetailPage() {
               )}
               {confirmingTerminate ? (
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-destructive">Are you sure?</span>
+                  <span className="text-sm text-destructive">
+                    Are you sure?
+                  </span>
                   <Button
                     size="sm"
                     variant="destructive"
@@ -440,7 +600,11 @@ export function AgentDetailPage() {
         <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-4 py-2 text-sm">
           Heartbeat triggered successfully.
           {wakeup.data.exit_code !== null && (
-            <> Exit code: <code className="font-mono">{wakeup.data.exit_code}</code></>
+            <>
+              {' '}
+              Exit code:{' '}
+              <code className="font-mono">{wakeup.data.exit_code}</code>
+            </>
           )}
         </div>
       )}
@@ -450,179 +614,251 @@ export function AgentDetailPage() {
         </div>
       )}
 
-      {/* Info cards */}
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Details</CardTitle>
-          </CardHeader>
-          <CardContent className="divide-y divide-border">
-            <InfoRow label="Status">
-              <Badge
-                variant={statusVariant[agent.status] ?? 'secondary'}
-                className="capitalize"
-              >
-                {agent.status}
-              </Badge>
-            </InfoRow>
-            <InfoRow label="Role">{agent.role}</InfoRow>
-            <InfoRow label="Adapter">
-              <Badge variant="outline" className="capitalize font-mono text-xs">
-                {agent.adapter_type}
-              </Badge>
-            </InfoRow>
-            <InfoRow label="Last Heartbeat">
-              {formatRelativeTime(agent.last_heartbeat_at)}
-            </InfoRow>
-            <InfoRow label="Schedule">
-              {editingSchedule ? (
-                <div className="flex items-center gap-2">
-                  <Select
-                    value={pendingSchedule ?? (agent.adapter_config?.cron as string) ?? ''}
-                    onChange={(e) => setPendingSchedule(e.target.value)}
-                    disabled={updateSchedule.isPending}
-                    className="h-7 text-xs"
-                    aria-label="Change schedule"
-                  >
-                    {SCHEDULE_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </Select>
-                  <Button
-                    size="sm"
-                    className="h-7 px-2 text-xs"
-                    disabled={updateSchedule.isPending || pendingSchedule === null}
-                    onClick={() => {
-                      if (pendingSchedule !== null) {
-                        updateSchedule.mutate(pendingSchedule)
-                      }
-                    }}
-                  >
-                    {updateSchedule.isPending ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      'Save'
-                    )}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 text-xs"
-                    onClick={() => {
-                      setEditingSchedule(false)
-                      setPendingSchedule(null)
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <Badge
-                    variant={agent.adapter_config?.cron ? 'info' : 'secondary'}
-                    className="text-xs"
-                  >
-                    {cronToLabel(agent.adapter_config?.cron as string | undefined)}
-                  </Badge>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-xs text-muted-foreground"
-                    onClick={() => setEditingSchedule(true)}
-                  >
-                    Change
-                  </Button>
-                </div>
-              )}
-            </InfoRow>
-            {scheduleChanged && (
-              <p className="px-0 py-2 text-xs text-amber-600">
-                Restart the server for schedule changes to take effect.
-              </p>
-            )}
-            {updateSchedule.isError && (
-              <p className="px-0 py-2 text-xs text-destructive">
-                Failed to update schedule: {(updateSchedule.error as Error).message}
-              </p>
-            )}
-            <InfoRow label="Created">{formatDate(agent.created_at)}</InfoRow>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Budget</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-baseline justify-between">
-              <span className="text-2xl font-bold">
-                {formatCents(agent.spent_monthly_cents)}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                of {formatCents(agent.budget_monthly_cents)}
-              </span>
-            </div>
-            <div className="h-3 overflow-hidden rounded-full bg-muted">
-              <div
-                className={cn(
-                  'h-full rounded-full transition-all',
-                  budgetPct > 90
-                    ? 'bg-red-500'
-                    : budgetPct > 70
-                      ? 'bg-amber-500'
-                      : 'bg-emerald-500',
-                )}
-                style={{ width: `${budgetPct}%` }}
-              />
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {budgetPct.toFixed(0)}% of monthly budget used
-            </p>
-          </CardContent>
-        </Card>
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border">
+        <button
+          className={cn(
+            'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+            activeTab === 'overview'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
+          onClick={() => setActiveTab('overview')}
+        >
+          <Info className="mr-1.5 inline h-4 w-4" />
+          Overview
+        </button>
+        <button
+          className={cn(
+            'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+            activeTab === 'runs'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
+          onClick={() => setActiveTab('runs')}
+        >
+          <Activity className="mr-1.5 inline h-4 w-4" />
+          Runs
+          {heartbeats && heartbeats.length > 0 && (
+            <Badge
+              variant="secondary"
+              className="ml-2 text-[10px] px-1.5 py-0"
+            >
+              {heartbeats.length}
+              {heartbeatsHasMore ? '+' : ''}
+            </Badge>
+          )}
+        </button>
       </div>
 
-      {/* Heartbeat history */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Activity className="h-4 w-4" />
-            Heartbeat History
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          {heartbeatsLoading ? (
-            <div className="space-y-2 p-6">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="h-10 animate-pulse rounded bg-muted" />
-              ))}
-            </div>
-          ) : !heartbeats || heartbeats.length === 0 ? (
-            heartbeatPage === 0 ? (
-              <p className="p-6 text-center text-sm text-muted-foreground">
-                No heartbeat data yet
-              </p>
+      {/* Overview tab */}
+      {activeTab === 'overview' && (
+        <>
+          {/* Info cards */}
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Details</CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y divide-border">
+                <InfoRow label="Status">
+                  <Badge
+                    variant={statusVariant[agent.status] ?? 'secondary'}
+                    className="capitalize"
+                  >
+                    {agent.status}
+                  </Badge>
+                </InfoRow>
+                <InfoRow label="Role">{agent.role}</InfoRow>
+                <InfoRow label="Adapter">
+                  <Badge
+                    variant="outline"
+                    className="capitalize font-mono text-xs"
+                  >
+                    {agent.adapter_type}
+                  </Badge>
+                </InfoRow>
+                <InfoRow label="Last Heartbeat">
+                  {formatRelativeTime(agent.last_heartbeat_at)}
+                </InfoRow>
+                <InfoRow label="Schedule">
+                  {editingSchedule ? (
+                    <div className="flex items-center gap-2">
+                      <Select
+                        value={
+                          pendingSchedule ??
+                          (agent.adapter_config?.cron as string) ??
+                          ''
+                        }
+                        onChange={(e) => setPendingSchedule(e.target.value)}
+                        disabled={updateSchedule.isPending}
+                        className="h-7 text-xs"
+                        aria-label="Change schedule"
+                      >
+                        {SCHEDULE_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </Select>
+                      <Button
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        disabled={
+                          updateSchedule.isPending ||
+                          pendingSchedule === null
+                        }
+                        onClick={() => {
+                          if (pendingSchedule !== null) {
+                            updateSchedule.mutate(pendingSchedule)
+                          }
+                        }}
+                      >
+                        {updateSchedule.isPending ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          'Save'
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => {
+                          setEditingSchedule(false)
+                          setPendingSchedule(null)
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant={
+                          agent.adapter_config?.cron ? 'info' : 'secondary'
+                        }
+                        className="text-xs"
+                      >
+                        {cronToLabel(
+                          agent.adapter_config?.cron as
+                            | string
+                            | undefined,
+                        )}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-xs text-muted-foreground"
+                        onClick={() => setEditingSchedule(true)}
+                      >
+                        Change
+                      </Button>
+                    </div>
+                  )}
+                </InfoRow>
+                {scheduleChanged && (
+                  <p className="px-0 py-2 text-xs text-amber-600">
+                    Restart the server for schedule changes to take effect.
+                  </p>
+                )}
+                {updateSchedule.isError && (
+                  <p className="px-0 py-2 text-xs text-destructive">
+                    Failed to update schedule:{' '}
+                    {(updateSchedule.error as Error).message}
+                  </p>
+                )}
+                <InfoRow label="Created">
+                  {formatDate(agent.created_at)}
+                </InfoRow>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Budget</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-baseline justify-between">
+                  <span className="text-2xl font-bold">
+                    {formatCents(agent.spent_monthly_cents)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    of {formatCents(agent.budget_monthly_cents)}
+                  </span>
+                </div>
+                <div className="h-3 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={cn(
+                      'h-full rounded-full transition-all',
+                      budgetPct > 90
+                        ? 'bg-red-500'
+                        : budgetPct > 70
+                          ? 'bg-amber-500'
+                          : 'bg-emerald-500',
+                    )}
+                    style={{ width: `${budgetPct}%` }}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {budgetPct.toFixed(0)}% of monthly budget used
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      )}
+
+      {/* Runs tab */}
+      {activeTab === 'runs' && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Activity className="h-4 w-4" />
+              Run History
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            {heartbeatsLoading ? (
+              <div className="space-y-2 p-6">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-10 animate-pulse rounded bg-muted"
+                  />
+                ))}
+              </div>
+            ) : !heartbeats || heartbeats.length === 0 ? (
+              heartbeatPage === 0 ? (
+                <p className="p-6 text-center text-sm text-muted-foreground">
+                  No runs yet. Click &quot;Run Heartbeat&quot; to trigger
+                  the first one.
+                </p>
+              ) : (
+                <p className="p-6 text-center text-sm text-muted-foreground">
+                  No more runs to display.
+                </p>
+              )
             ) : (
-              <p className="p-6 text-center text-sm text-muted-foreground">
-                No more heartbeats to display.
-              </p>
-            )
-          ) : (
-            <>
-              <HeartbeatTable heartbeats={heartbeats} />
-              <Pagination
-                page={heartbeatPage}
-                pageSize={HEARTBEATS_PAGE_SIZE}
-                total={-1}
-                hasMore={heartbeatsHasMore}
-                onPageChange={setHeartbeatPage}
-              />
-            </>
-          )}
-        </CardContent>
-      </Card>
+              <>
+                <HeartbeatTable
+                  heartbeats={heartbeats}
+                  agentId={agentId!}
+                  onRetry={() => wakeup.mutate()}
+                  retryPending={wakeup.isPending}
+                />
+                <Pagination
+                  page={heartbeatPage}
+                  pageSize={HEARTBEATS_PAGE_SIZE}
+                  total={-1}
+                  hasMore={heartbeatsHasMore}
+                  onPageChange={setHeartbeatPage}
+                />
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/pages/run-transcript.tsx
+++ b/apps/dashboard/src/pages/run-transcript.tsx
@@ -1,0 +1,494 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useParams, Link } from 'react-router-dom'
+import { useCompanyId } from '@/hooks/useCompanyId'
+import { usePollingInterval, POLLING_INTERVALS } from '@/hooks/usePolling'
+import { useState } from 'react'
+import {
+  ArrowLeft,
+  Bot,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  Play,
+  RotateCcw,
+  Terminal,
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  DollarSign,
+  Shield,
+  Cpu,
+  Database,
+  Zap,
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  fetchHeartbeatRun,
+  fetchHeartbeatRunEvents,
+  fetchAgent,
+  wakeupAgent,
+  type HeartbeatRun,
+  type HeartbeatRunEvent,
+  type Agent,
+} from '@/lib/api'
+import {
+  cn,
+  formatDate,
+  formatDuration,
+  formatRelativeTime,
+  humanizeEventType,
+  redactPaths,
+} from '@/lib/utils'
+import { useToast } from '@/components/ui/toast'
+
+const statusVariant: Record<string, 'success' | 'warning' | 'destructive' | 'secondary' | 'info'> = {
+  success: 'success',
+  running: 'info',
+  failed: 'destructive',
+  skipped: 'secondary',
+}
+
+const eventIcons: Record<string, typeof Circle> = {
+  adapter_loaded: Cpu,
+  governance_checked: Shield,
+  budget_checked: DollarSign,
+  context_built: Database,
+  adapter_started: Play,
+  adapter_finished: CheckCircle2,
+  cost_recorded: DollarSign,
+  session_saved: Database,
+  error: AlertTriangle,
+}
+
+function TranscriptSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="h-6 w-48 animate-pulse rounded bg-muted" />
+      <div className="grid gap-4 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-16 animate-pulse rounded bg-muted" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MetadataCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <p className="mb-1 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        {label}
+      </p>
+      <div className="text-sm">{children}</div>
+    </div>
+  )
+}
+
+function EventTimeline({
+  events,
+  runStartedAt,
+}: {
+  events: HeartbeatRunEvent[]
+  runStartedAt: string | null
+}) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const runStart = runStartedAt ? new Date(runStartedAt).getTime() : null
+
+  return (
+    <div className="space-y-0">
+      {events.map((event, index) => {
+        const isCollapsed = collapsed.has(event.id)
+        const Icon = eventIcons[event.event_type] ?? Zap
+        const isError = event.event_type === 'error'
+        const payload = event.payload
+        const hasContent = payload && Object.keys(payload).length > 0
+
+        // Calculate relative time from run start
+        const eventTime = new Date(event.created_at).getTime()
+        const relativeMs = runStart ? eventTime - runStart : null
+        const relativeLabel = relativeMs !== null && relativeMs >= 0
+          ? relativeMs < 1000 ? `+${relativeMs}ms` : `+${(relativeMs / 1000).toFixed(1)}s`
+          : null
+
+        return (
+          <div key={event.id} className="relative flex gap-3">
+            {/* Timeline line */}
+            <div className="flex flex-col items-center">
+              <div
+                className={cn(
+                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border',
+                  isError
+                    ? 'border-destructive/50 bg-destructive/10 text-destructive'
+                    : 'border-border bg-muted text-muted-foreground',
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </div>
+              {index < events.length - 1 && (
+                <div className="w-px flex-1 bg-border" />
+              )}
+            </div>
+
+            {/* Event content */}
+            <div className={cn('flex-1 pb-6', index === events.length - 1 && 'pb-0')}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    {humanizeEventType(event.event_type)}
+                  </span>
+                  {relativeLabel && (
+                    <span className="text-xs text-muted-foreground font-mono">
+                      {relativeLabel}
+                    </span>
+                  )}
+                </div>
+                {hasContent && (
+                  <button
+                    onClick={() => toggle(event.id)}
+                    className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted"
+                    aria-label={isCollapsed ? 'Expand event details' : 'Collapse event details'}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRight className="h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="h-3 w-3" />
+                    )}
+                    {isCollapsed ? 'Show' : 'Hide'}
+                  </button>
+                )}
+              </div>
+
+              {hasContent && !isCollapsed && (
+                <div className="mt-2">
+                  <EventPayload payload={payload} isError={isError} />
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function EventPayload({
+  payload,
+  isError,
+}: {
+  payload: Record<string, unknown>
+  isError: boolean
+}) {
+  // Check for stdout/stderr text content
+  const stdout = payload.stdout as string | undefined
+  const stderr = payload.stderr as string | undefined
+  const message = payload.message as string | undefined
+  const errorMsg = payload.error as string | undefined
+
+  // Check for structured data we can render nicely
+  const cost = payload.cost_cents as number | undefined
+  const provider = payload.provider as string | undefined
+  const model = payload.model as string | undefined
+  const inputTokens = payload.input_tokens as number | undefined
+  const outputTokens = payload.output_tokens as number | undefined
+
+  return (
+    <div className="space-y-2">
+      {/* Structured cost data */}
+      {(cost !== undefined || provider || model) && (
+        <div className="flex flex-wrap gap-3 text-xs text-muted-foreground rounded-md border bg-muted/30 p-3">
+          {provider && <span>Provider: <strong>{provider}</strong></span>}
+          {model && <span>Model: <strong>{model}</strong></span>}
+          {inputTokens !== undefined && <span>Input: <strong>{inputTokens}</strong> tokens</span>}
+          {outputTokens !== undefined && <span>Output: <strong>{outputTokens}</strong> tokens</span>}
+          {cost !== undefined && <span>Cost: <strong>${(cost / 100).toFixed(4)}</strong></span>}
+        </div>
+      )}
+
+      {/* Error message */}
+      {(errorMsg || (isError && message)) && (
+        <pre className={cn(
+          'overflow-auto rounded-md p-3 text-xs font-mono whitespace-pre-wrap border',
+          'border-destructive/20 bg-destructive/5 text-destructive',
+        )}>
+          {redactPaths(errorMsg || message || '')}
+        </pre>
+      )}
+
+      {/* Stdout */}
+      {stdout && (
+        <div>
+          <p className="mb-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+            stdout
+          </p>
+          <pre className="max-h-[300px] overflow-auto rounded-md border bg-background p-3 text-xs font-mono whitespace-pre-wrap">
+            {redactPaths(stdout)}
+          </pre>
+        </div>
+      )}
+
+      {/* Stderr */}
+      {stderr && (
+        <div>
+          <p className="mb-1 text-[10px] font-semibold text-amber-500 uppercase tracking-wider">
+            stderr
+          </p>
+          <pre className="max-h-[200px] overflow-auto rounded-md border border-amber-500/20 bg-amber-500/5 p-3 text-xs font-mono whitespace-pre-wrap">
+            {redactPaths(stderr)}
+          </pre>
+        </div>
+      )}
+
+      {/* Non-special message */}
+      {message && !isError && !errorMsg && (
+        <p className="text-xs text-muted-foreground">{redactPaths(message)}</p>
+      )}
+
+      {/* Generic payload (fallback) — render keys we haven't already handled */}
+      {(() => {
+        const handled = new Set(['stdout', 'stderr', 'message', 'error', 'cost_cents', 'provider', 'model', 'input_tokens', 'output_tokens'])
+        const remaining = Object.entries(payload).filter(([k]) => !handled.has(k))
+        if (remaining.length === 0) return null
+        return (
+          <pre className="max-h-[200px] overflow-auto rounded-md border bg-muted/30 p-3 text-xs font-mono whitespace-pre-wrap">
+            {redactPaths(JSON.stringify(Object.fromEntries(remaining), null, 2))}
+          </pre>
+        )
+      })()}
+    </div>
+  )
+}
+
+export function RunTranscriptPage() {
+  const { id: agentId, runId } = useParams<{ id: string; runId: string }>()
+  const companyId = useCompanyId()
+  const pollingInterval = usePollingInterval(POLLING_INTERVALS.agents)
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const {
+    data: run,
+    isLoading: runLoading,
+    error: runError,
+  } = useQuery<HeartbeatRun>({
+    queryKey: ['heartbeat-run', companyId, runId],
+    queryFn: () => fetchHeartbeatRun(companyId!, runId!),
+    enabled: !!companyId && !!runId,
+    refetchInterval: pollingInterval,
+  })
+
+  const { data: events, isLoading: eventsLoading } = useQuery<HeartbeatRunEvent[]>({
+    queryKey: ['heartbeat-run-events', companyId, runId],
+    queryFn: () => fetchHeartbeatRunEvents(companyId!, runId!),
+    enabled: !!companyId && !!runId,
+    refetchInterval: pollingInterval,
+  })
+
+  const { data: agent } = useQuery<Agent>({
+    queryKey: ['agent', companyId, agentId],
+    queryFn: () => fetchAgent(companyId!, agentId!),
+    enabled: !!companyId && !!agentId,
+    staleTime: 30_000,
+  })
+
+  const wakeup = useMutation({
+    mutationFn: () => wakeupAgent(companyId!, agentId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['heartbeats', companyId, agentId] })
+      queryClient.invalidateQueries({ queryKey: ['agent', companyId, agentId] })
+      toast('Retry triggered — new heartbeat started', 'success')
+    },
+    onError: (err: Error) => {
+      toast(`Retry failed: ${err.message}`, 'error')
+    },
+  })
+
+  if (runLoading) return <TranscriptSkeleton />
+  if (runError) {
+    return (
+      <div className="py-20 text-center text-sm text-muted-foreground">
+        Failed to load run: {(runError as Error).message}
+      </div>
+    )
+  }
+  if (!run) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-20">
+        <Terminal className="h-10 w-10 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Run not found</p>
+      </div>
+    )
+  }
+
+  const isFailed = run.status === 'failed'
+  const isRunning = run.status === 'running'
+
+  // Parse usage_json if available
+  let usage: { provider?: string; model?: string; inputTokens?: number; outputTokens?: number; costCents?: number } | null = null
+  if (run.usage_json) {
+    try {
+      usage = JSON.parse(run.usage_json)
+    } catch { /* ignore */ }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" asChild>
+          <Link to={`/agents/${agentId}`} aria-label="Back to agent">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Run Transcript</h2>
+            <Badge
+              variant={statusVariant[run.status] ?? 'secondary'}
+              className="capitalize"
+            >
+              {run.status}
+            </Badge>
+            {isRunning && <Loader2 className="h-4 w-4 animate-spin text-blue-400" />}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {agent?.name ?? 'Agent'} &middot; {run.trigger_type} trigger &middot; {formatRelativeTime(run.started_at)}
+          </p>
+        </div>
+        {isFailed && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => wakeup.mutate()}
+            disabled={wakeup.isPending}
+          >
+            {wakeup.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RotateCcw className="h-4 w-4" />
+            )}
+            {wakeup.isPending ? 'Retrying...' : 'Retry'}
+          </Button>
+        )}
+      </div>
+
+      {/* Metadata cards */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <MetadataCard label="Trigger">
+          <span className="capitalize">{run.trigger_type}</span>
+        </MetadataCard>
+        <MetadataCard label="Duration">
+          <div className="flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+            {formatDuration(run.started_at, run.finished_at)}
+          </div>
+        </MetadataCard>
+        <MetadataCard label="Exit Code">
+          <span className={cn(
+            'font-mono',
+            run.exit_code !== null && run.exit_code !== 0 && 'text-destructive',
+          )}>
+            {run.exit_code ?? (isRunning ? 'running...' : '—')}
+          </span>
+        </MetadataCard>
+        <MetadataCard label="Started">
+          {run.started_at ? formatDate(run.started_at) : '—'}
+        </MetadataCard>
+      </div>
+
+      {/* Cost summary */}
+      {usage && (
+        <div className="flex flex-wrap gap-4 rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+          {usage.provider && <span className="text-muted-foreground">Provider: <strong className="text-foreground">{usage.provider}</strong></span>}
+          {usage.model && <span className="text-muted-foreground">Model: <strong className="text-foreground">{usage.model}</strong></span>}
+          {usage.inputTokens !== undefined && <span className="text-muted-foreground">Input: <strong className="text-foreground">{usage.inputTokens.toLocaleString()}</strong> tokens</span>}
+          {usage.outputTokens !== undefined && <span className="text-muted-foreground">Output: <strong className="text-foreground">{usage.outputTokens.toLocaleString()}</strong> tokens</span>}
+          {usage.costCents !== undefined && <span className="text-muted-foreground">Cost: <strong className="text-foreground">${(usage.costCents / 100).toFixed(4)}</strong></span>}
+        </div>
+      )}
+
+      {/* Error banner */}
+      {run.error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-destructive" />
+            <span className="text-sm font-semibold text-destructive">Error</span>
+          </div>
+          <pre className="overflow-auto text-xs font-mono whitespace-pre-wrap text-destructive/90">
+            {redactPaths(run.error)}
+          </pre>
+        </div>
+      )}
+
+      {/* Stdout excerpt */}
+      {run.stdout_excerpt && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Terminal className="h-4 w-4" />
+              Agent Output
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <pre className="max-h-[400px] overflow-auto rounded-md border bg-muted/30 p-4 text-xs font-mono whitespace-pre-wrap">
+              {redactPaths(run.stdout_excerpt)}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Event timeline */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Zap className="h-4 w-4" />
+            Event Timeline
+            {events && (
+              <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+                {events.length}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {eventsLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex gap-3">
+                  <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                    <div className="h-12 animate-pulse rounded bg-muted" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : !events || events.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No events recorded for this run.
+            </p>
+          ) : (
+            <EventTimeline events={events} runStartedAt={run.started_at} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **#259**: Added a "Runs" tab to the agent detail page showing heartbeat run history with status badges, duration, trigger type, and a retry button on failed runs. Each row is clickable and navigates to the transcript page.
- **#258**: New run transcript page at `/agents/:id/runs/:runId` showing full run details: metadata cards (trigger, duration, exit code, timing), cost summary, error banners, stdout excerpt, and a collapsible event timeline with humanized labels and relative timestamps. File paths in output are redacted to relative paths.

### Files changed
- `apps/dashboard/src/App.tsx` — new route for run transcript
- `apps/dashboard/src/lib/api.ts` — `fetchHeartbeatRun`, `fetchHeartbeatRunEvents`, `HeartbeatRunEvent` type
- `apps/dashboard/src/lib/utils.ts` — `formatDuration`, `humanizeEventType`, `redactPaths`
- `apps/dashboard/src/pages/agent-detail.tsx` — Overview/Runs tabs, updated HeartbeatTable with retry + navigation
- `apps/dashboard/src/pages/run-transcript.tsx` — new transcript page

## Test plan
- [ ] Navigate to agent detail page, verify Overview and Runs tabs render
- [ ] Switch to Runs tab, verify heartbeat history loads with duration column
- [ ] Click Retry on a failed run, verify wakeup is triggered
- [ ] Click a run row, verify navigation to `/agents/:id/runs/:runId`
- [ ] On transcript page, verify metadata cards, event timeline, error banner
- [ ] Verify collapsible event sections work
- [ ] Verify path redaction in stdout/stderr output
- [ ] Verify responsive layout at 375px, 768px, 1440px
- [ ] Verify `pnpm build` passes

Closes #259, Closes #258

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>